### PR TITLE
Fix: Insertion Order During Lattice Expansion

### DIFF
--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -274,12 +274,10 @@ YAML::Node expand_internal(YAML::Node node,
             }
         }
 
-        YAML::Node final_map = YAML::Node(YAML::NodeType::Map);
         for (auto ele : new_map) {
-            final_map[ele.first.as<std::string>()] =
-                expand_internal(ele.second, elements_map);
+            ele.second = expand_internal(ele.second, elements_map);
         }
-        return final_map;
+        return new_map;
     }
 
     return YAML::Clone(node);


### PR DESCRIPTION
In `src/yaml_c_wrapper.cpp` the `expand_internal()` function was creating a brand new empty `YAML::Node(Map)` and re-inserting all entries from a cloned map. This unnecessary reconstruction could lose insertion order because re-inserting keys by string into a fresh node goes through `yaml-cpp`'s map lookup path, which doesn't guarantee the same ordering as the source.

The fix modifies map values in-place on the already-cloned `new_map` node instead of rebuilding a new map, preserving `yaml-cpp`'s internal insertion order throughout lattice expansion.

Fix #18