### PR TITLE
Rename lattice_name/lat_name to root_lattice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Introduction
 Pals-cpp is the parser library for PALS accelerator lattice files. It uses rapidyaml https://github.com/biojppm/rapidyaml to read lattices into memory and provides additional capabilities like printing to console, writing to files, and searching for elements. One major component is performing lattice expansion following the PALS specifications:
-1. The lattice to be expanded can be specified by the user. If none is specified, the one in the last `use: lattice_name` statement will be expanded. If none exists, the last lattice in the file is expanded. 
+1. The lattice to be expanded can be specified by the user. If none is specified, the one in the last `use: root_lattice` statement will be expanded. If none exists, the last lattice in the file is expanded. 
 2. Content from other files can be brought into scope using `include: filename`
 3. Elements that inherit parameters from other elements will have those properties brought into scope.
 4. Beamlines in a lattice with a `repeat: count` will have their contents repeated `count` times in the lattice.
@@ -26,7 +26,7 @@ This builds `libyaml_c_wrapper.dylib`, a shared object library that can interfac
 ```
 
 ### Example 2
-The program `examples/print_lattices` performs lattice expansion on a user-specified lattice. The first argument is the file name where the lattice is defined. It also takes an option argument using `-lat lattice_name` to specify a specific lattice to expand, otherwise it will choose a default (the lattice in the last `use` statement, or the last lattice in the file if none is present). The program will create and print a struct containing three lattices:
+The program `examples/print_lattices` performs lattice expansion on a user-specified lattice. The first argument is the file name where the lattice is defined. It also takes an option argument using `-lat root_lattice` to specify a specific lattice to expand, otherwise it will choose a default (the lattice in the last `use` statement, or the last lattice in the file if none is present). The program will create and print a struct containing three lattices:
 - `original` is a map containing the base lattice as well as any lattices included
 in the base lattice.
 - `included` is the base lattice but with all included files substituted in.

--- a/examples/print_lattices.cpp
+++ b/examples/print_lattices.cpp
@@ -7,12 +7,12 @@
 
 int main(int argc, char* argv[]) {
     const char* file_name = nullptr;
-    const char* lattice_name = "";
+    const char* root_lattice = "";
 
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "-lat") == 0) {
             if (i + 1 < argc) {
-                lattice_name = argv[++i];
+                root_lattice = argv[++i];
             } else {
                 std::cerr << "Error: -lat requires an argument" << std::endl;
                 return 1;
@@ -23,13 +23,13 @@ int main(int argc, char* argv[]) {
     }
 
     if (!file_name) {
-        std::cerr << "Usage: " << argv[0] << " <file> [-lat <lattice_name>]" << std::endl;
+        std::cerr << "Usage: " << argv[0] << " <file> [-lat <root_lattice>]" << std::endl;
         return 1;
     }
 
     std::string file_path = std::string("../lattice_files/") + file_name;
 
-    struct lattices lat = parse_and_expand_PALS(file_path.c_str(), lattice_name);
+    struct lattices lat = parse_and_expand_PALS(file_path.c_str(), root_lattice);
 
     std::cout << "========== Printing original lattice ==========" << std::endl;
     std::cout << tree_to_string(lat.original) << std::endl << "\n\n";

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -465,8 +465,8 @@ static size_t find_lattice(ryml::Tree& t, const std::string& name) {
 /**
  * Create the expanded lattice. Starts with the included lattice, and expands
  * the lattice with the following priorities:
- *  1. If `lat_name` != null, then expand the lattice called `lat_name`
- *  2. If `lat_name` == null, expand the lattice specified in the last `use`
+ *  1. If `root_lattice` != null, then expand the lattice called `root_lattice`
+ *  2. If `root_lattice` == null, expand the lattice specified in the last `use`
  * statement.
  *  3. If no use statement is present, expand the lattice that occurs last in
  * the file. Last expansion performs the following:
@@ -477,7 +477,7 @@ static size_t find_lattice(ryml::Tree& t, const std::string& name) {
  * copied into element.
  */
 static YAMLTreeHandle make_expanded(const char* filename,
-                                    const char* lat_name) {
+                                    const char* root_lattice) {
     YAMLTreeHandle data = make_included(filename);
     if (!data) return nullptr;
     ryml::Tree& t = GET_TREE(data);
@@ -487,7 +487,7 @@ static YAMLTreeHandle make_expanded(const char* filename,
     std::map<std::string, size_t> emap;
     make_ele_map(emap, t, t.root_id());
 
-    std::string name_str = lat_name ? lat_name : "";
+    std::string name_str = root_lattice ? root_lattice : "";
     size_t lat_node = find_lattice(t, name_str);
     if (lat_node == ryml::NONE) return data;
     size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
@@ -558,11 +558,11 @@ static YAMLTreeHandle make_original(const char* filename) {
 extern "C" {
 
 YAML_API struct lattices parse_and_expand_PALS(const char* filename,
-                                      const char* lattice_name) {
+                                      const char* root_lattice) {
     struct lattices lat = {};
     lat.original = make_original(filename);
     lat.included = make_included(filename);
-    lat.expanded = make_expanded(filename, lattice_name);
+    lat.expanded = make_expanded(filename, root_lattice);
     return lat;
 }
 

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -42,7 +42,7 @@ extern "C" {
  * Builds and returns all three representations of a lattice file.
  *
  * @param filename     Path to the top-level YAML lattice file.
- * @param lattice_name Name of the lattice to expand. If NULL or empty:
+ * @param root_lattice Name of the lattice to expand. If NULL or empty:
  *                       - expands the lattice named by the last "use"
  * statement, or
  *                       - expands the last lattice defined in the file if no
@@ -57,7 +57,7 @@ extern "C" {
  *         All three handles must be freed individually with delete_tree().
  */
 YAML_API struct lattices parse_and_expand_PALS(const char* filename,
-                                      const char* lattice_name);
+                                      const char* root_lattice);
 
 // --- PARSING & MEMORY ---
 


### PR DESCRIPTION
## Summary
- Renames the `lattice_name` and `lat_name` identifiers to `root_lattice` throughout the codebase for consistency.
- Covers `src/yaml_c_wrapper.h`, `src/yaml_c_wrapper.cpp`, `examples/print_lattices.cpp`, and `README.md` (including doc comments and usage strings).

## Testing
- `cmake --build build` — compiles cleanly.
- `ctest` — all 54 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)