### PR TITLE
Rename included to combined

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This builds `libyaml_c_wrapper.dylib`, a shared object library that can interfac
 The program `examples/print_lattices` performs lattice expansion on a user-specified lattice. The first argument is the file name where the lattice is defined. It also takes an option argument using `-lat root_lattice` to specify a specific lattice to expand, otherwise it will choose a default (the lattice in the last `use` statement, or the last lattice in the file if none is present). The program will create and print a struct containing three lattices:
 - `original` is a map containing the base lattice as well as any lattices included
 in the base lattice.
-- `included` is the base lattice but with all included files substituted in.
+- `combined` is the base lattice but with all included files substituted in.
 - `expanded` is the base lattice after lattice expansion has been performed.
 To see the console output, in the build directory, run
 

--- a/examples/print_lattices.cpp
+++ b/examples/print_lattices.cpp
@@ -34,8 +34,8 @@ int main(int argc, char* argv[]) {
     std::cout << "========== Printing original lattice ==========" << std::endl;
     std::cout << tree_to_string(lat.original) << std::endl << "\n\n";
 
-    std::cout << "========== Printing included lattice ==========" << std::endl;
-    std::cout << tree_to_string(lat.included) << std::endl << "\n\n";
+    std::cout << "========== Printing combined lattice ==========" << std::endl;
+    std::cout << tree_to_string(lat.combined) << std::endl << "\n\n";
 
     std::cout << "========== Printing expanded lattice ==========" << std::endl;
     std::cout << tree_to_string(lat.expanded) << std::endl;

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -307,11 +307,11 @@ static void expand(ryml::Tree& t, size_t node,
 }
 
 /**
- * Recursive helper for make_included. Starting from `node`, replace all
+ * Recursive helper for make_combined. Starting from `node`, replace all
  * instances of "include: filename" with the contents of `filename`. Also
  * recurses into `filename` to handle nested include statements.
  */
-static void make_included_recursive(ryml::Tree& t, size_t node) {
+static void make_combined_recursive(ryml::Tree& t, size_t node) {
     if (node == ryml::NONE) return;
 
     if (t.is_seq(node)) {
@@ -363,35 +363,35 @@ static void make_included_recursive(ryml::Tree& t, size_t node) {
                     }
                     delete inc;
                     // Recurse into inserted nodes to handle nested includes
-                    for (size_t n : inserted) make_included_recursive(t, n);
+                    for (size_t n : inserted) make_combined_recursive(t, n);
                 }
                 t.remove(child);
                 child = next;
                 continue;
             }
 
-            make_included_recursive(t, child);
+            make_combined_recursive(t, child);
             child = next;
         }
         return;
     }
 
     for (size_t c = t.first_child(node); c != ryml::NONE; c = t.next_sibling(c))
-        make_included_recursive(t, c);
+        make_combined_recursive(t, c);
 }
 
 /**
- * Makes the included lattice file. Takes all instances of include statements in
+ * Makes the combined lattice file. Takes all instances of include statements in
  * filename, as well as nested include statements within included files, and
  * adds them all to the master tree.
  */
-static YAMLTreeHandle make_included(const char* filename) {
+static YAMLTreeHandle make_combined(const char* filename) {
     ParsedData* data = static_cast<ParsedData*>(parse_file(filename));
     if (!data) return nullptr;
     ryml::Tree& t = data->tree;
     t.reserve(t.capacity() + 64);
     t.reserve_arena(t.arena_capacity() + 65536);
-    make_included_recursive(t, t.root_id());
+    make_combined_recursive(t, t.root_id());
     return data;
 }
 
@@ -463,7 +463,7 @@ static size_t find_lattice(ryml::Tree& t, const std::string& name) {
 }
 
 /**
- * Create the expanded lattice. Starts with the included lattice, and expands
+ * Create the expanded lattice. Starts with the combined lattice, and expands
  * the lattice with the following priorities:
  *  1. If `root_lattice` != null, then expand the lattice called `root_lattice`
  *  2. If `root_lattice` == null, expand the lattice specified in the last `use`
@@ -478,7 +478,7 @@ static size_t find_lattice(ryml::Tree& t, const std::string& name) {
  */
 static YAMLTreeHandle make_expanded(const char* filename,
                                     const char* root_lattice) {
-    YAMLTreeHandle data = make_included(filename);
+    YAMLTreeHandle data = make_combined(filename);
     if (!data) return nullptr;
     ryml::Tree& t = GET_TREE(data);
     t.reserve_arena(t.arena_capacity() + 100000);
@@ -561,7 +561,7 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
                                       const char* root_lattice) {
     struct lattices lat = {};
     lat.original = make_original(filename);
-    lat.included = make_included(filename);
+    lat.combined = make_combined(filename);
     lat.expanded = make_expanded(filename, root_lattice);
     return lat;
 }

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -31,7 +31,7 @@ typedef size_t YAMLNodeId;
 struct lattices {
     YAMLTreeHandle original;  // Raw tree mapping each file (including includes)
                               // to its unparsed contents
-    YAMLTreeHandle included;  // Tree with all "include" directives resolved and
+    YAMLTreeHandle combined;  // Tree with all "include" directives resolved and
                               // spliced inline
     YAMLTreeHandle expanded;  // Tree with the selected lattice fully expanded
 };
@@ -50,7 +50,7 @@ extern "C" {
  * @return A `lattices` struct containing three handles:
  *           - `original`: raw tree mapping each file (including includes) to
  * its unparsed contents.
- *           - `included`: tree with all "include" directives resolved and
+ *           - `combined`: tree with all "include" directives resolved and
  * spliced inline.
  *           - `expanded`: tree with the selected lattice fully expanded —
  * scalars substituted, repeats unrolled, inherits merged, and forks resolved.

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -618,9 +618,9 @@ TEST_CASE("Cloning via deep_copy_node produces an independent copy", "[copy]") {
 TEST_CASE("parse_and_expand_PALS returns three non-null handles", "[lattices]") {
     struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", nullptr);
     REQUIRE(lat.original != nullptr);
-    REQUIRE(lat.included != nullptr);
+    REQUIRE(lat.combined != nullptr);
     REQUIRE(lat.expanded != nullptr);
     delete_tree(lat.original);
-    delete_tree(lat.included);
+    delete_tree(lat.combined);
     delete_tree(lat.expanded);
 }


### PR DESCRIPTION
## Summary
- Renames the `included` identifier to `combined` for clarity:
  - `lattices::included` struct field → `combined`
  - `make_included` → `make_combined`, `make_included_recursive` → `make_combined_recursive`
  - all `lat.included` field accesses (source, example, tests)
  - related doc comments, the `print_lattices` output label, and the README bullet
- Left the include-*mechanism* references untouched (`#include`, the `include:` YAML directive, "included files", etc.).

## Testing
- `cmake --build build` — compiles cleanly.
- `ctest` — all 54 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)