### PR TITLE
Use PALS/facility root node in lattice files

### DIFF
--- a/examples/example_rw.cpp
+++ b/examples/example_rw.cpp
@@ -4,7 +4,7 @@
 
 int main(int argc, char* argv[]) {
     std::cout << "============ Printing Developer Information ============" << std::endl;
-    std::string text = "Use the function 'parse_file(filename)' to read a lattice file. For example,\n\n" 
+    std::string text = "Use the function 'parse_file(filename)' to read a lattice file. For example,\n\n"
                        "YAMLTreeHandle tree = parse_file(\"../lattice_files/ex.pals.yaml\")\n"
                        "reads the file 'ex.pals.yaml' into a tree named 'tree'.\n\n";
     // reading a lattice from a yaml file
@@ -16,13 +16,19 @@ int main(int argc, char* argv[]) {
     std::cout << tree_to_string(tree) << std::endl << std::endl;
 
     // type checking
-    std::cout << "The root node of 'ex.pals.yaml' is a sequence, so is_sequence(tree, get_root(tree)) = "
-              << is_sequence(tree, get_root(tree)) << "\n";
+    std::cout << "The root node of 'ex.pals.yaml' is the 'PALS' map, so is_map(tree, get_root(tree)) = "
+              << is_map(tree, get_root(tree)) << "\n";
+
+    // The lattice contents live under the 'facility' node of the 'PALS' root.
+    YAMLNodeId pals = get_child_by_key(tree, get_root(tree), "PALS");
+    YAMLNodeId facility = get_child_by_key(tree, pals, "facility");
+    std::cout << "The 'facility' node is a sequence, so is_sequence(tree, facility) = "
+              << is_sequence(tree, facility) << "\n";
 
     // accessing sequence
     std::cout << "Elements in a sequence may be accessed by their index.\n";
-    YAMLNodeId seq1 = get_child_by_index(tree, get_root(tree), 0);
-    std::cout << "The first element of 'tree' is: \n"
+    YAMLNodeId seq1 = get_child_by_index(tree, facility, 0);
+    std::cout << "The first element of 'facility' is: \n"
               << node_to_string(tree, seq1) << "\n";
 
     // accessing map
@@ -31,23 +37,23 @@ int main(int argc, char* argv[]) {
     std::cout << "The element 'thingB' has:\n    "
               << node_to_string(tree, map1) << "\n";
 
-    // add a new sequence element to the root containing new_map: {apples: 5}
-    std::cout << "Adding a new element '-apples: 5' to root.\n";
-    YAMLNodeId new_map_entry = add_map(tree, get_root(tree), NULL, END);
+    // add a new sequence element to the facility containing new_map: {apples: 5}
+    std::cout << "Adding a new element '-apples: 5' to facility.\n";
+    YAMLNodeId new_map_entry = add_map(tree, facility, NULL, END);
     YAMLNodeId map = add_map(tree, new_map_entry, "new_map", END);
     add_scalar(tree, map, "apples", "5", END);
 
-    // add a new sequence element to the root containing magnets
+    // add a new sequence element to the facility containing magnets
     std::cout << "Adding a new element\n"
               << "    - magnet_list:\n"
               << "        - magnet1\n"
               << "        - magnet2\n"
-              << "to root.\n\n";
-    YAMLNodeId magnets_entry = add_map(tree, get_root(tree), NULL, END);
+              << "to facility.\n\n";
+    YAMLNodeId magnets_entry = add_map(tree, facility, NULL, END);
     YAMLNodeId sequence = add_sequence(tree, magnets_entry, "magnet_list", END);
     add_scalar(tree, sequence, NULL, "magnet1", END);
     add_scalar(tree, sequence, NULL, "magnet2", 1);
-    
+
     // writing trees to files
     std::cout << "Use 'write_file(tree, filename)' to write the edited tree to a file.\n";
     write_file(tree, "../lattice_files/expand.pals.yaml");

--- a/lattice_files/ex.pals.yaml
+++ b/lattice_files/ex.pals.yaml
@@ -1,48 +1,49 @@
-- thingB:
-    kind: Sextupole
-    length: 2
-- lat1:
-    kind: Lattice
-    branches:
-        - inj_line
-- lat2:
-    kind: Lattice
-    branches:
-        - inj_line
-- inj_line:
-    kind: BeamLine
-    multipass: true
-    length: 37.8
-    zero_point: thingC
-    line:                # This item refers to the name of an element or BeamLine defined elsewhere.
-      - thingZ:               # thingZ inherits parameters from thingB
-          inherit: thingB
-      - Q1a:                  # Define an element in place called Q1a
-          kind: Quadrupole
-          length: 1.03
-          direction: -1
-      - a_subline:            # Item a_subline is repeated three times
-          repeat: 3
-      - to_dump:
-            kind: Fork
-            ForkP:
-                to_line: generic_dump
-                destination_element: dump_begin
-                new_branch: this_dump
-                propagate_reference: true
-- include: "../lattice_files/include.pals.yaml"
-- a_subline:
-    kind: BeamLine
-    line:
-        - a
-        - b
-        - c
-- use: "lat2"
-- use: "lat1"
+PALS:
+  facility:
+    - thingB:
+        kind: Sextupole
+        length: 2
+    - lat1:
+        kind: Lattice
+        branches:
+            - inj_line
+    - lat2:
+        kind: Lattice
+        branches:
+            - inj_line
+    - inj_line:
+        kind: BeamLine
+        multipass: true
+        length: 37.8
+        zero_point: thingC
+        line:                # This item refers to the name of an element or BeamLine defined elsewhere.
+          - thingZ:               # thingZ inherits parameters from thingB
+              inherit: thingB
+          - Q1a:                  # Define an element in place called Q1a
+              kind: Quadrupole
+              length: 1.03
+              direction: -1
+          - a_subline:            # Item a_subline is repeated three times
+              repeat: 3
+          - to_dump:
+                kind: Fork
+                ForkP:
+                    to_line: generic_dump
+                    destination_element: dump_begin
+                    new_branch: this_dump
+                    propagate_reference: true
+    - include: "../lattice_files/include.pals.yaml"
+    - a_subline:
+        kind: BeamLine
+        line:
+            - a
+            - b
+            - c
+    - use: "lat2"
+    - use: "lat1"
 
-- generic_dump:
-    kind: BeamLine
-    line:
-        - dump_begin
-        - amarker
-
+    - generic_dump:
+        kind: BeamLine
+        line:
+            - dump_begin
+            - amarker


### PR DESCRIPTION
## Summary

The lattice files were on an outdated PALS layout (a bare top-level list). Per the [PALS spec](https://pals-project.readthedocs.io) (*Fundamental Structure -> PALS Root Object*), a top-level PALS file's document root is a `PALS` node with a `facility` child that holds the lattice elements, beamlines, and lattices.

- `lattice_files/ex.pals.yaml` — wrapped its contents under `PALS:` -> `facility:`.
- `examples/example_rw.cpp` — now reads the root as the `PALS` map, navigates to the `facility` sequence to index elements, and appends its demo entries (`new_map`, `magnet_list`) there. The git-ignored generated `expand.pals.yaml` follows the same structure.

The `include*.pals.yaml` fragments are intentionally left as bare lists: included sub-files are spliced verbatim into `facility` and must not carry their own `PALS` root (wrapping them would break include resolution).

## Testing

- `ctest` -> **54/54 passing**.
- `example_rw` and `print_lattices` run cleanly; lattice expansion (inherit / repeat / fork resolution) still works through the new `PALS`/`facility` tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
