### PR TITLE
Evaluate PALS expressions in the expanded tree via libapc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,17 +41,31 @@ set(PCRE2_BUILD_PCRE2GREP OFF CACHE BOOL "" FORCE)
 set(PCRE2_SUPPORT_JIT OFF CACHE BOOL "" FORCE)
 set(PCRE2_STATIC_PIC ON CACHE BOOL "" FORCE)
 
+# AtomicAndPhysicalConstantsCLib (apc) provides the particle-data functions
+# (mass_of / charge_of / anomalous_moment_of) and the named physical constants
+# used by the PALS expression evaluator. Its values mirror
+# AtomicAndPhysicalConstants.jl so the whole ecosystem shares one set of numbers.
+FetchContent_Declare(
+  apc
+  GIT_REPOSITORY https://github.com/pals-project/AtomicAndPhysicalConstantsCLib.git
+  GIT_TAG main
+)
+set(APC_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+
 FetchContent_MakeAvailable(rapidyaml)
 FetchContent_MakeAvailable(Catch2)
 FetchContent_MakeAvailable(pcre2)
+FetchContent_MakeAvailable(apc)
 
 add_subdirectory(tests)
 
 file(COPY ${CMAKE_SOURCE_DIR}/lattice_files/
      DESTINATION ${CMAKE_BINARY_DIR}/lattice_files/)
 
-add_library(yaml_c_wrapper SHARED src/yaml_c_wrapper.cpp)
-target_link_libraries(yaml_c_wrapper PUBLIC ryml PRIVATE pcre2-8-static)
+add_library(yaml_c_wrapper SHARED
+  src/yaml_c_wrapper.cpp
+  src/pals_expression.cpp)
+target_link_libraries(yaml_c_wrapper PUBLIC ryml PRIVATE pcre2-8-static apc)
 
 add_executable(example_rw examples/example_rw.cpp)
 target_link_libraries(example_rw yaml_c_wrapper ryml)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,29 @@ Pals-cpp is the parser library for PALS accelerator lattice files. It uses rapid
 4. Beamlines in a lattice with a `repeat: count` will have their contents repeated `count` times in the lattice.
 5. Elements in a lattice defined outside of it will have their definitions brought it.
 6. Fork elements will create new branches in the lattice to their destination branch. 
+7. Mathematical expressions are evaluated to numbers (see below).
 
+## Expression Evaluation
+As a final step of expansion, every scalar value in the `expanded` tree that is a
+PALS mathematical expression is replaced with its numeric value. This covers the
+full PALS expression grammar — arithmetic (`+ - * / ^`), parentheses, the
+[built-in constants](https://github.com/pals-project/pals) (`pi`, `c_light`,
+`r_electron`, …), the math functions (`sqrt`, `log`, `sin`, `floor`, `modulo`, …),
+and user-defined constants and variables (both the `kind: constant`/`value:` and
+the compact `constants:`/`variables:` forms, resolved in dependency order). Both
+immediate expressions and `expr(...)`-delayed expressions are evaluated to a
+number in the expanded tree. Values that are not expressions — element/line name
+references, `kind:` names, booleans — are left untouched, and expressions
+containing `random()`/`random_gauss()` are left as text so the expanded tree stays
+reproducible. The `combined` and `original` trees always retain the original
+expression text.
+
+The particle-data functions `mass_of`, `charge_of`, and `anomalous_moment_of`, and
+the physical values behind the named constants, are provided by
+[AtomicAndPhysicalConstantsCLib](https://github.com/pals-project/AtomicAndPhysicalConstantsCLib)
+(a C++ mirror of [AtomicAndPhysicalConstants.jl](https://github.com/bmad-sim/AtomicAndPhysicalConstants.jl)),
+fetched automatically by CMake. A single expression can also be evaluated on its
+own via `evaluate_pals_expression()`.
 
 ## Usage
 First, to build, run the following in the root directory:  

--- a/src/pals_expression.cpp
+++ b/src/pals_expression.cpp
@@ -1,0 +1,330 @@
+/**
+ * @file pals_expression.cpp
+ * @brief Recursive-descent evaluator for PALS mathematical expressions.
+ *
+ * Grammar (standard precedence; `^` is right-associative):
+ *   expr    := term (('+' | '-') term)*
+ *   term    := power (('*' | '/') power)*
+ *   power   := unary ('^' power)?
+ *   unary   := ('+' | '-') unary | primary
+ *   primary := number | name | name '(' args ')' | '(' expr ')'
+ *
+ * The particle functions mass_of / charge_of / anomalous_moment_of take a bare
+ * species name (e.g. `mass_of(He3)`), not a numeric sub-expression, so their
+ * argument is read as raw text and passed to AtomicAndPhysicalConstantsCLib.
+ */
+
+#include "pals_expression.h"
+
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <stdexcept>
+#include <vector>
+
+#include "apc/apc.h"
+
+namespace pals {
+namespace {
+
+// std::numbers::pi is C++20; keep this a plain constant for C++17.
+constexpr double kPi = 3.14159265358979323846;
+
+// Thrown to abort a non-evaluable expression; caught at the top level.
+struct ParseError {};
+
+class Parser {
+ public:
+  Parser(const std::string& s, const SymbolLookup& lookup)
+      : s_(s), lookup_(lookup) {}
+
+  double parse() {
+    double v = expr();
+    if (peek() != '\0') throw ParseError{};  // trailing junk
+    return v;
+  }
+
+  bool deferred() const { return deferred_; }
+
+ private:
+  const std::string& s_;
+  const SymbolLookup& lookup_;
+  size_t pos_ = 0;
+  bool deferred_ = false;
+
+  void skip_ws() {
+    while (pos_ < s_.size() &&
+           std::isspace(static_cast<unsigned char>(s_[pos_])))
+      ++pos_;
+  }
+
+  // Returns the next significant char (whitespace skipped) without consuming.
+  char peek() {
+    skip_ws();
+    return pos_ < s_.size() ? s_[pos_] : '\0';
+  }
+
+  bool consume(char c) {
+    if (peek() == c) {
+      ++pos_;
+      return true;
+    }
+    return false;
+  }
+
+  double expr() {
+    double v = term();
+    for (;;) {
+      char c = peek();
+      if (c == '+') {
+        ++pos_;
+        v += term();
+      } else if (c == '-') {
+        ++pos_;
+        v -= term();
+      } else {
+        return v;
+      }
+    }
+  }
+
+  double term() {
+    double v = unary();
+    for (;;) {
+      char c = peek();
+      if (c == '*') {
+        ++pos_;
+        v *= unary();
+      } else if (c == '/') {
+        ++pos_;
+        v /= unary();
+      } else {
+        return v;
+      }
+    }
+  }
+
+  // Unary signs bind looser than `^`, so -2^2 == -(2^2) and 2^-2 == 2^(-2),
+  // matching the Fortran/Bmad convention used across the ecosystem.
+  double unary() {
+    char c = peek();
+    if (c == '+') {
+      ++pos_;
+      return unary();
+    }
+    if (c == '-') {
+      ++pos_;
+      return -unary();
+    }
+    return power();
+  }
+
+  double power() {
+    double base = primary();
+    if (peek() == '^') {
+      ++pos_;
+      return std::pow(base, unary());  // right-associative; exponent may be signed
+    }
+    return base;
+  }
+
+  double primary() {
+    char c = peek();
+    if (c == '(') {
+      ++pos_;
+      double v = expr();
+      if (!consume(')')) throw ParseError{};
+      return v;
+    }
+    if (std::isdigit(static_cast<unsigned char>(c)) || c == '.') return number();
+    if (std::isalpha(static_cast<unsigned char>(c)) || c == '_') return name();
+    throw ParseError{};
+  }
+
+  double number() {
+    skip_ws();
+    const char* start = s_.c_str() + pos_;
+    char* end = nullptr;
+    double v = std::strtod(start, &end);
+    if (end == start) throw ParseError{};
+    pos_ += static_cast<size_t>(end - start);
+    return v;
+  }
+
+  std::string read_identifier() {
+    skip_ws();
+    size_t start = pos_;
+    while (pos_ < s_.size()) {
+      char c = s_[pos_];
+      if (std::isalnum(static_cast<unsigned char>(c)) || c == '_')
+        ++pos_;
+      else
+        break;
+    }
+    return s_.substr(start, pos_ - start);
+  }
+
+  // Reads a raw species-name argument up to the matching ')'. The opening '('
+  // must already be consumed.
+  std::string read_raw_arg() {
+    int depth = 1;
+    std::string out;
+    while (pos_ < s_.size()) {
+      char c = s_[pos_];
+      if (c == '(') {
+        ++depth;
+      } else if (c == ')') {
+        if (--depth == 0) {
+          ++pos_;
+          break;
+        }
+      }
+      out.push_back(c);
+      ++pos_;
+    }
+    if (depth != 0) throw ParseError{};
+    size_t a = out.find_first_not_of(" \t");
+    size_t b = out.find_last_not_of(" \t");
+    if (a == std::string::npos) return "";
+    return out.substr(a, b - a + 1);
+  }
+
+  double name() {
+    std::string id = read_identifier();
+    if (peek() == '(') {
+      ++pos_;  // consume '('
+      return call(id);
+    }
+    double v;
+    if (builtin_constant(id, v)) return v;
+    if (lookup_ && lookup_(id, v)) return v;
+    throw ParseError{};  // unknown identifier
+  }
+
+  std::vector<double> arg_list() {
+    std::vector<double> args;
+    if (peek() == ')') {
+      ++pos_;
+      return args;
+    }
+    args.push_back(expr());
+    while (peek() == ',') {
+      ++pos_;
+      args.push_back(expr());
+    }
+    if (!consume(')')) throw ParseError{};
+    return args;
+  }
+
+  double call(const std::string& fn) {
+    // Particle-data functions take a bare species name, not an expression.
+    if (fn == "mass_of" || fn == "charge_of" || fn == "anomalous_moment_of") {
+      std::string sp = read_raw_arg();
+      try {
+        if (fn == "mass_of") return apc::mass_of(sp);
+        if (fn == "charge_of") return apc::charge_of(sp);
+        return apc::anomalous_moment_of(sp);
+      } catch (const std::exception&) {
+        throw ParseError{};  // unknown species
+      }
+    }
+    // random()/random_gauss() cannot be evaluated reproducibly: mark deferred
+    // but still consume the argument list so parsing completes.
+    if (fn == "random" || fn == "random_gauss") {
+      arg_list();
+      deferred_ = true;
+      return 0.0;  // unused when deferred
+    }
+    return apply(fn, arg_list());
+  }
+
+  static double apply(const std::string& fn, const std::vector<double>& a) {
+    auto unary = [&]() -> double {
+      if (a.size() != 1) throw ParseError{};
+      return a[0];
+    };
+    auto binary = [&](int i) -> double {
+      if (a.size() != 2) throw ParseError{};
+      return a[i];
+    };
+
+    if (fn == "sqrt") return std::sqrt(unary());
+    if (fn == "log") return std::log(unary());
+    if (fn == "exp") return std::exp(unary());
+    if (fn == "sin") return std::sin(unary());
+    if (fn == "cos") return std::cos(unary());
+    if (fn == "tan") return std::tan(unary());
+    if (fn == "cot") { double x = unary(); return std::cos(x) / std::sin(x); }
+    if (fn == "sinc") { double x = unary(); return x == 0.0 ? 1.0 : std::sin(x) / x; }
+    if (fn == "asin") return std::asin(unary());
+    if (fn == "acos") return std::acos(unary());
+    if (fn == "atan") return std::atan(unary());
+    if (fn == "atan2") return std::atan2(binary(0), binary(1));
+    if (fn == "sinh") return std::sinh(unary());
+    if (fn == "cosh") return std::cosh(unary());
+    if (fn == "tanh") return std::tanh(unary());
+    if (fn == "coth") { double x = unary(); return std::cosh(x) / std::sinh(x); }
+    if (fn == "asinh") return std::asinh(unary());
+    if (fn == "acosh") return std::acosh(unary());
+    if (fn == "atanh") return std::atanh(unary());
+    if (fn == "acoth") return std::atanh(1.0 / unary());
+    if (fn == "abs") return std::fabs(unary());
+    if (fn == "factorial") return std::tgamma(unary() + 1.0);
+    if (fn == "int") return std::trunc(unary());       // toward zero
+    if (fn == "nint") return std::round(unary());      // nearest, half away
+    if (fn == "sign") { double x = unary(); return (x > 0) - (x < 0); }
+    if (fn == "floor") return std::floor(unary());
+    if (fn == "ceiling") return std::ceil(unary());
+    if (fn == "modulo") {
+      double x = binary(0), p = binary(1);
+      return x - std::floor(x / p) * p;
+    }
+    throw ParseError{};  // unknown function
+  }
+};
+
+}  // namespace
+
+bool builtin_constant(const std::string& name, double& out) {
+  // Physical values come from AtomicAndPhysicalConstantsCLib (AAPC, CODATA
+  // 2022) so PALS shares the ecosystem's numbers. k_boltzmann and
+  // classical_radius_factor are derived from AAPC quantities (AAPC does not
+  // export them directly); pi is exact.
+  if (name == "pi") { out = kPi; return true; }
+  if (name == "c_light") { out = apc::C_LIGHT; return true; }
+  if (name == "h_planck") { out = apc::H_PLANCK; return true; }
+  if (name == "hbar") { out = apc::H_BAR; return true; }
+  if (name == "k_boltzmann") { out = 1.380649e-23 / apc::J_PER_EV; return true; }  // eV/K
+  if (name == "r_electron") { out = apc::R_ELECTRON; return true; }
+  if (name == "r_proton") { out = apc::R_PROTON; return true; }
+  if (name == "e_charge") { out = apc::E_CHARGE; return true; }
+  if (name == "mu_0") { out = apc::MU_0; return true; }
+  if (name == "epsilon_0") { out = apc::EPS_0; return true; }
+  if (name == "classical_radius_factor") {
+    out = apc::R_ELECTRON * apc::M_ELECTRON;
+    return true;
+  }
+  if (name == "fine_structure") { out = apc::FINE_STRUCTURE; return true; }
+  if (name == "n_avogadro") { out = apc::AVOGADRO; return true; }
+  return false;
+}
+
+EvalOutcome eval_expression(const std::string& text, const SymbolLookup& lookup) {
+  EvalOutcome r;
+  try {
+    Parser p(text, lookup);
+    double v = p.parse();
+    if (p.deferred()) {
+      r.deferred = true;
+      return r;
+    }
+    if (!std::isfinite(v)) return r;  // ok stays false
+    r.ok = true;
+    r.value = v;
+  } catch (...) {
+    // Not an evaluable expression; r.ok stays false.
+  }
+  return r;
+}
+
+}  // namespace pals

--- a/src/pals_expression.h
+++ b/src/pals_expression.h
@@ -1,0 +1,52 @@
+#ifndef PALS_EXPRESSION_H
+#define PALS_EXPRESSION_H
+
+/**
+ * @file pals_expression.h
+ * @brief Evaluator for PALS mathematical expressions (the "Mathematical
+ *        Expressions", "Functions", and "Constants and Variables" sections of
+ *        the PALS standard).
+ *
+ * Particle-data functions (mass_of, charge_of, anomalous_moment_of) and the
+ * named physical constants (c_light, r_electron, ...) are sourced from
+ * AtomicAndPhysicalConstantsCLib so the whole PALS/Bmad ecosystem shares one
+ * set of numbers.
+ */
+
+#include <functional>
+#include <string>
+
+namespace pals {
+
+// Outcome of evaluating a PALS expression.
+//   ok=true                  -> `value` holds the finite numeric result.
+//   deferred=true            -> the expression contains random()/random_gauss(),
+//                               which must stay unevaluated to keep the expanded
+//                               tree reproducible. `value` is unspecified.
+//   ok=false, deferred=false -> not a (valid) evaluable expression: parse error,
+//                               unknown identifier, unknown species, or a
+//                               non-finite result. The caller should leave the
+//                               original text untouched.
+struct EvalOutcome {
+  bool ok = false;
+  bool deferred = false;
+  double value = 0.0;
+};
+
+// Looks up a user-defined constant/variable by name. Returns true and sets
+// `out` if the name is known. Built-in PALS constants (pi, c_light, ...) are
+// resolved inside the evaluator and need not be provided here.
+using SymbolLookup = std::function<bool(const std::string& name, double& out)>;
+
+// Evaluates `text` as a PALS mathematical expression. A leading `expr(...)`
+// wrapper, if present, must be stripped by the caller. `lookup` resolves user
+// symbols; an empty std::function is fine when none are available.
+EvalOutcome eval_expression(const std::string& text, const SymbolLookup& lookup);
+
+// If `name` is a built-in PALS constant, sets `out` to its value and returns
+// true; otherwise returns false.
+bool builtin_constant(const std::string& name, double& out);
+
+}  // namespace pals
+
+#endif  // PALS_EXPRESSION_H

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -1,10 +1,14 @@
 #include "yaml_c_wrapper.h"
 
 #include <algorithm>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <map>
+#include <memory>
 #include <ryml.hpp>
 #include <ryml_std.hpp>
 #include <set>
@@ -14,6 +18,8 @@
 
 #define PCRE2_CODE_UNIT_WIDTH 8
 #include <pcre2.h>
+
+#include "pals_expression.h"
 
 // Underlying object for YAMLTreeHandle. Contains the parsed YAML tree and the
 // string buffer it was parsed from. Nodes are identied by their index (of type
@@ -608,6 +614,178 @@ static size_t find_lattice(ryml::Tree& t, const std::string& name) {
  * 3. Elements that contain "inherit: ancestor" have the contents of ancestor
  * copied into element.
  */
+// ============================================================
+// EXPRESSION EVALUATION
+// ============================================================
+//
+// After the tree is fully expanded, every scalar value that is a PALS
+// mathematical expression is replaced with its evaluated number (immediate and
+// `expr(...)`-delayed alike, per the standard's evaluation model as applied to
+// the expanded tree). Values that are not expressions -- element/line name
+// references, `kind:` names, booleans, etc. -- fail to evaluate and are left
+// untouched. Expressions containing random()/random_gauss() are deferred
+// (kept as text) so the expanded tree stays reproducible.
+//
+// The math, functions, built-in constants, and particle-data functions
+// (mass_of/charge_of/anomalous_moment_of, from AtomicAndPhysicalConstantsCLib)
+// live in pals_expression.cpp; this layer supplies user constants/variables and
+// walks the tree.
+
+// Keys whose scalar values are names/flags, never expressions. Skipping them
+// avoids a stray collision between such a name and a constant (e.g. an element
+// literally named `pi`).
+static const std::set<std::string>& non_expr_keys() {
+    static const std::set<std::string> keys = {
+        "kind",       "include",     "use",
+        "inherit",    "zero_point",  "to_line",
+        "destination_element", "new_branch", "multipass",
+        "propagate_reference", "name"};
+    return keys;
+}
+
+// Trims surrounding whitespace and, if the whole value is `expr(...)`, unwraps
+// it. `was_expr` reports whether an `expr(...)` wrapper was present.
+static std::string strip_expr_wrapper(const std::string& s, bool& was_expr) {
+    was_expr = false;
+    size_t a = s.find_first_not_of(" \t\r\n");
+    size_t b = s.find_last_not_of(" \t\r\n");
+    if (a == std::string::npos) return "";
+    std::string t = s.substr(a, b - a + 1);
+    const std::string pre = "expr(";
+    if (t.size() > pre.size() && t.compare(0, pre.size(), pre) == 0 &&
+        t.back() == ')') {
+        was_expr = true;
+        return t.substr(pre.size(), t.size() - pre.size() - 1);
+    }
+    return t;
+}
+
+// Shortest decimal string that round-trips back to `v` (so integers stay
+// integer-looking and no precision is lost).
+static std::string format_double(double v) {
+    char buf[64];
+    for (int prec = 1; prec <= 17; ++prec) {
+        std::snprintf(buf, sizeof(buf), "%.*g", prec, v);
+        if (std::strtod(buf, nullptr) == v) return std::string(buf);
+    }
+    std::snprintf(buf, sizeof(buf), "%.17g", v);
+    return std::string(buf);
+}
+
+// Collects user constant/variable definitions (name -> defining expression),
+// in both the full (`kind: constant`/`value:`) and compact
+// (`constants:`/`variables:` lists) forms. First definition of a name wins;
+// the standard requires duplicates to share the same value.
+static void collect_defs(const ryml::Tree& t, size_t node,
+                         std::map<std::string, std::string>& defs) {
+    if (node == ryml::NONE) return;
+
+    // Full form: a named map with `kind: constant|variable` and a `value:`.
+    if (t.is_map(node) && t.has_key(node)) {
+        size_t kind = t.find_child(node, ryml::to_csubstr("kind"));
+        if (kind != ryml::NONE && t.has_val(kind)) {
+            std::string k(t.val(kind).str, t.val(kind).len);
+            if (k == "constant" || k == "variable") {
+                size_t val = t.find_child(node, ryml::to_csubstr("value"));
+                if (val != ryml::NONE && t.has_val(val)) {
+                    defs.emplace(std::string(t.key(node).str, t.key(node).len),
+                                 std::string(t.val(val).str, t.val(val).len));
+                }
+            }
+        }
+    }
+
+    // Compact form: a `constants:`/`variables:` sequence of single-key maps.
+    if (t.has_key(node)) {
+        std::string k(t.key(node).str, t.key(node).len);
+        if ((k == "constants" || k == "variables") && t.is_seq(node)) {
+            for (size_t el = t.first_child(node); el != ryml::NONE;
+                 el = t.next_sibling(el)) {
+                if (!t.is_map(el)) continue;
+                for (size_t kv = t.first_child(el); kv != ryml::NONE;
+                     kv = t.next_sibling(kv)) {
+                    if (t.has_key(kv) && t.has_val(kv))
+                        defs.emplace(
+                            std::string(t.key(kv).str, t.key(kv).len),
+                            std::string(t.val(kv).str, t.val(kv).len));
+                }
+            }
+        }
+    }
+
+    for (size_t c = t.first_child(node); c != ryml::NONE;
+         c = t.next_sibling(c))
+        collect_defs(t, c, defs);
+}
+
+// Replaces every evaluable scalar value in the subtree with its numeric value.
+static void substitute_values(ryml::Tree& t, size_t node,
+                              const pals::SymbolLookup& resolve) {
+    if (node == ryml::NONE) return;
+
+    if (t.has_val(node)) {
+        bool skip = false;
+        if (t.has_key(node)) {
+            std::string k(t.key(node).str, t.key(node).len);
+            skip = non_expr_keys().count(k) != 0;
+        } else {
+            // Bare sequence element: skip beamline `line:` name references.
+            size_t p = t.parent(node);
+            if (p != ryml::NONE && t.has_key(p) &&
+                t.key(p) == ryml::to_csubstr("line"))
+                skip = true;
+        }
+        if (!skip) {
+            bool was_expr = false;
+            std::string body = strip_expr_wrapper(
+                std::string(t.val(node).str, t.val(node).len), was_expr);
+            pals::EvalOutcome r = pals::eval_expression(body, resolve);
+            if (r.ok)
+                t.set_val(node,
+                          t.to_arena(ryml::to_csubstr(format_double(r.value))));
+        }
+    }
+
+    for (size_t c = t.first_child(node); c != ryml::NONE;
+         c = t.next_sibling(c))
+        substitute_values(t, c, resolve);
+}
+
+// Evaluates all expressions in the (already expanded) tree in place.
+static void evaluate_expressions(ryml::Tree& t) {
+    std::map<std::string, std::string> defs;
+    collect_defs(t, t.root_id(), defs);
+
+    // Lazily evaluate user symbols on demand, memoizing results and guarding
+    // against reference cycles. A symbol whose defining expression is itself
+    // unresolvable is reported as unknown.
+    auto cache = std::make_shared<std::map<std::string, double>>();
+    auto active = std::make_shared<std::set<std::string>>();
+    std::shared_ptr<pals::SymbolLookup> resolve =
+        std::make_shared<pals::SymbolLookup>();
+    *resolve = [&defs, cache, active, resolve](const std::string& name,
+                                               double& out) -> bool {
+        auto ci = cache->find(name);
+        if (ci != cache->end()) {
+            out = ci->second;
+            return true;
+        }
+        auto di = defs.find(name);
+        if (di == defs.end()) return false;
+        if (!active->insert(name).second) return false;  // cycle
+        bool was_expr = false;
+        std::string body = strip_expr_wrapper(di->second, was_expr);
+        pals::EvalOutcome r = pals::eval_expression(body, *resolve);
+        active->erase(name);
+        if (!r.ok) return false;
+        (*cache)[name] = r.value;
+        out = r.value;
+        return true;
+    };
+
+    substitute_values(t, t.root_id(), *resolve);
+}
+
 static YAMLTreeHandle make_expanded_from_combined(ParsedData* comb,
                                                   const char* root_lattice) {
     if (!comb) return nullptr;
@@ -630,6 +808,11 @@ static YAMLTreeHandle make_expanded_from_combined(ParsedData* comb,
     size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
 
     expand(t, lat_node, emap, data->provenance, branches);
+
+    // Final pass: evaluate every mathematical expression in the expanded tree
+    // to a number (immediate and expr()-delayed alike). Node ids are unchanged
+    // -- only scalar text is rewritten -- so provenance stays valid.
+    evaluate_expressions(t);
     return data;
 }
 
@@ -971,6 +1154,17 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
     lat.expanded = make_expanded_from_combined(
         static_cast<ParsedData*>(lat.combined), root_lattice);
     return lat;
+}
+
+YAML_API double evaluate_pals_expression(const char* expr, bool* ok) {
+    if (ok) *ok = false;
+    if (!expr) return 0.0;
+    bool was_expr = false;
+    std::string body = strip_expr_wrapper(expr, was_expr);
+    pals::EvalOutcome r = pals::eval_expression(body, pals::SymbolLookup{});
+    if (!r.ok) return 0.0;
+    if (ok) *ok = true;
+    return r.value;
 }
 
 YAML_API struct correspondence_map build_correspondence_map(

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -99,6 +99,29 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
                                       const char* root_lattice);
 
 /**
+ * Evaluates a single PALS mathematical expression to a double.
+ *
+ * Supports the full PALS expression grammar: arithmetic (+ - * / ^), unary
+ * signs, parentheses, the built-in constants (pi, c_light, r_electron, ...),
+ * the math functions (sqrt, log, sin, floor, modulo, ...), and the
+ * particle-data functions mass_of / charge_of / anomalous_moment_of (backed by
+ * AtomicAndPhysicalConstantsCLib). A leading `expr(...)` wrapper is accepted
+ * and unwrapped.
+ *
+ * This entry point evaluates a standalone string: user-defined constants and
+ * variables are NOT in scope (use parse_and_expand_PALS() for whole-lattice
+ * evaluation, which resolves them). Expressions containing random() /
+ * random_gauss() are treated as non-evaluable here.
+ *
+ * @param expr Null-terminated expression string.
+ * @param ok   Optional out-param. Set to true on success, false on a parse
+ *             error, unknown identifier/species, deferred random(), or a
+ *             non-finite result. May be NULL.
+ * @return The evaluated value on success, or 0.0 on failure.
+ */
+YAML_API double evaluate_pals_expression(const char* expr, bool* ok);
+
+/**
  * Builds the node correspondence between the three trees of a `lattices` value.
  *
  * Returns a flat list containing one `node_link` per node of the `expanded`

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1,6 +1,8 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch_test_macros.hpp>
 #include <algorithm>
+#include <cmath>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <map>
@@ -713,7 +715,19 @@ TEST_CASE("build_correspondence_map connects a node across trees by value",
                          get_child_by_key(lat.expanded, e_const, "constants"),
                          "a_const");
     REQUIRE(e_a_const != YAML_NULL_ID);
-    REQUIRE(val_eq(lat.expanded, e_a_const, "0.3 * r_electron"));
+    // The expanded tree has its expressions evaluated, so this constant now
+    // holds a number; the combined/original copies (checked below) still carry
+    // the original expression text.
+    {
+        char* s = as_string(lat.expanded, e_a_const);
+        REQUIRE(s != nullptr);
+        double got = std::strtod(s, nullptr);
+        yaml_free_string(s);
+        bool okc = false;
+        double want = evaluate_pals_expression("0.3 * r_electron", &okc);
+        REQUIRE(okc);
+        REQUIRE(got == want);
+    }
 
     // Find its link and follow it to the combined and original copies.
     bool found = false;
@@ -1065,4 +1079,177 @@ TEST_CASE("a malformed pattern yields an empty result, not a crash",
     REQUIRE(m.count == 0);
     free_name_matches(m);
     delete_tree(t);
+}
+
+// ============================================================
+// EXPRESSION EVALUATION
+// ============================================================
+
+// Evaluate a standalone expression, requiring success, and return its value.
+static double eval_ok(const char* expr) {
+    bool ok = false;
+    double v = evaluate_pals_expression(expr, &ok);
+    REQUIRE(ok);
+    return v;
+}
+
+// True if two doubles agree to a relative/absolute tolerance.
+static bool close(double got, double want) {
+    return std::fabs(got - want) <= 1e-9 * std::max(1.0, std::fabs(want));
+}
+
+TEST_CASE("evaluate_pals_expression: arithmetic and precedence", "[expr]") {
+    REQUIRE(eval_ok("2 + 3 * 4") == 14.0);
+    REQUIRE(eval_ok("(2 + 3) * 4") == 20.0);
+    REQUIRE(eval_ok("2 ^ 3 ^ 2") == 512.0);   // right-associative
+    REQUIRE(eval_ok("-2 ^ 2") == -4.0);        // unary minus looser than ^
+    REQUIRE(eval_ok("2 ^ -2") == 0.25);
+    REQUIRE(close(eval_ok("3.75e7 / c_light^2"),
+                  3.75e7 / (2.99792458e8 * 2.99792458e8)));
+}
+
+TEST_CASE("evaluate_pals_expression: functions", "[expr]") {
+    REQUIRE(close(eval_ok("sqrt(2)"), std::sqrt(2.0)));
+    REQUIRE(close(eval_ok("0.1*log(abs(-0.34))"), 0.1 * std::log(0.34)));
+    REQUIRE(eval_ok("modulo(7, 3)") == 1.0);
+    REQUIRE(eval_ok("floor(-1.5)") == -2.0);
+    REQUIRE(eval_ok("ceiling(-1.5)") == -1.0);
+    REQUIRE(eval_ok("int(-1.9)") == -1.0);     // toward zero
+    REQUIRE(eval_ok("nint(2.5)") == 3.0);      // nearest
+    REQUIRE(eval_ok("sign(-3)") == -1.0);
+    REQUIRE(eval_ok("sinc(0)") == 1.0);
+    REQUIRE(close(eval_ok("atan2(1, 1)"), std::atan(1.0)));
+    REQUIRE(close(eval_ok("factorial(5)"), 120.0));
+}
+
+TEST_CASE("evaluate_pals_expression: built-in constants", "[expr]") {
+    REQUIRE(close(eval_ok("pi"), 3.14159265358979323846));
+    REQUIRE(eval_ok("c_light") == 2.99792458e8);
+    // classical_radius_factor and k_boltzmann are derived from AAPC quantities.
+    REQUIRE(close(eval_ok("classical_radius_factor"),
+                  eval_ok("r_electron") * eval_ok("mass_of(electron)")));
+}
+
+TEST_CASE("evaluate_pals_expression: particle-data functions from libapc",
+          "[expr]") {
+    // Values mirror AtomicAndPhysicalConstantsCLib (CODATA 2022).
+    REQUIRE(close(eval_ok("mass_of(proton)"), 938272089.43000007));
+    REQUIRE(eval_ok("charge_of(electron)") == -1.0);
+    REQUIRE(eval_ok("charge_of(anti-proton)") == -1.0);
+    REQUIRE(close(eval_ok("2 * mass_of(electron)"), 2 * 510998.95069000003));
+    // A bare isotope is the neutral atom; the ionised form carries the charge.
+    REQUIRE(eval_ok("charge_of(3He)") == 0.0);
+    REQUIRE(eval_ok("charge_of(helion)") == 2.0);
+}
+
+TEST_CASE("evaluate_pals_expression: expr() wrapper is accepted", "[expr]") {
+    REQUIRE(eval_ok("expr(3.74 * 2)") == 7.48);
+    REQUIRE(eval_ok("expr( (1 + 2) * 3 )") == 9.0);
+}
+
+TEST_CASE("evaluate_pals_expression: non-evaluable inputs report failure",
+          "[expr]") {
+    bool ok = true;
+    // random()/random_gauss() are deferred, so not evaluable here.
+    evaluate_pals_expression("0.01 + 0.003 * random_gauss()", &ok);
+    REQUIRE_FALSE(ok);
+    ok = true;
+    evaluate_pals_expression("thingB", &ok);          // unknown identifier
+    REQUIRE_FALSE(ok);
+    ok = true;
+    evaluate_pals_expression("mass_of(nonsense)", &ok);  // unknown species
+    REQUIRE_FALSE(ok);
+    ok = true;
+    evaluate_pals_expression("1 + ", &ok);            // parse error
+    REQUIRE_FALSE(ok);
+    ok = true;
+    evaluate_pals_expression(nullptr, &ok);           // null input
+    REQUIRE_FALSE(ok);
+}
+
+// Navigate root -> PALS -> facility -> the value node keyed `name` inside the
+// facility entry whose single key is `entry` (facility is a sequence of
+// single-key maps).
+static YAMLNodeId facility_param(YAMLTreeHandle t, const char* entry) {
+    YAMLNodeId fac = facility_of(t);
+    size_t n = get_size(t, fac);
+    for (size_t i = 0; i < n; i++) {
+        YAMLNodeId e = get_child_by_index(t, fac, i);
+        YAMLNodeId c = get_child_by_key(t, e, entry);
+        if (c != YAML_NULL_ID) return c;
+    }
+    return YAML_NULL_ID;
+}
+
+static double num_val(YAMLTreeHandle t, YAMLNodeId n) {
+    char* s = as_string(t, n);
+    double v = s ? std::strtod(s, nullptr) : NAN;
+    yaml_free_string(s);
+    return v;
+}
+
+TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
+          "[expr][lattices]") {
+    const char* path = "tmp_expr.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - variables:\n"
+              "        - a_var: 3.75e7 / c_light^2\n"
+              "        - b_var: -0.34\n"
+              "    - m_e:\n"
+              "        kind: constant\n"
+              "        value: mass_of(electron)\n"
+              "    - cleo:\n"
+              "        kind: Solenoid\n"
+              "        length: 0.1*log(abs(b_var))\n"
+              "        MagneticMultipoleP:\n"
+              "          Kn1: expr(3.74 * a_var)\n"
+              "          Kn2: 0.01 + 0.003*random_gauss()\n"
+              "    - main_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - cleo\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - main_line\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+
+    const double a_var = 3.75e7 / (2.99792458e8 * 2.99792458e8);
+
+    YAMLNodeId cleo = facility_param(lat.expanded, "cleo");
+    REQUIRE(cleo != YAML_NULL_ID);
+
+    // Immediate expression using a user variable.
+    YAMLNodeId len = get_child_by_key(lat.expanded, cleo, "length");
+    REQUIRE(close(num_val(lat.expanded, len), 0.1 * std::log(0.34)));
+
+    YAMLNodeId mmp = get_child_by_key(lat.expanded, cleo, "MagneticMultipoleP");
+    // expr()-delayed expression is evaluated to a number in the expanded tree.
+    YAMLNodeId kn1 = get_child_by_key(lat.expanded, mmp, "Kn1");
+    REQUIRE(close(num_val(lat.expanded, kn1), 3.74 * a_var));
+
+    // random_gauss() is deferred: the text is left untouched.
+    YAMLNodeId kn2 = get_child_by_key(lat.expanded, mmp, "Kn2");
+    REQUIRE(val_eq(lat.expanded, kn2, "0.01 + 0.003*random_gauss()"));
+
+    // Full-form constant defined via a particle function.
+    YAMLNodeId m_e = facility_param(lat.expanded, "m_e");
+    YAMLNodeId m_e_val = get_child_by_key(lat.expanded, m_e, "value");
+    REQUIRE(close(num_val(lat.expanded, m_e_val), 510998.95069000003));
+
+    // The combined tree keeps the original expression text (only `expanded`
+    // is evaluated).
+    YAMLNodeId c_cleo = facility_param(lat.combined, "cleo");
+    YAMLNodeId c_len = get_child_by_key(lat.combined, c_cleo, "length");
+    REQUIRE(val_eq(lat.combined, c_len, "0.1*log(abs(b_var))"));
+
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    rm_tmp(path);
 }


### PR DESCRIPTION
## Summary

Makes the `expanded` tree returned by `parse_and_expand_PALS` have all mathematical expressions evaluated to numbers, per the PALS standard. Particle-data functions and the named physical constants are provided by [AtomicAndPhysicalConstantsCLib](https://github.com/pals-project/AtomicAndPhysicalConstantsCLib) (libapc), fetched via CMake `FetchContent`, so PALS shares the ecosystem's numbers.

## What's evaluated

As a final pass of expansion, every scalar value in the `expanded` tree that is a PALS expression is replaced with its number:

- **Full grammar**: arithmetic `+ - * / ^` (right-associative power; unary minus looser than `^`, so `-2^2 = -4`), parentheses, unary signs.
- **Functions**: `sqrt`, `log`, `exp`, the trig/hyperbolic family, `abs`, `factorial`, `int`/`nint`/`sign`/`floor`/`ceiling`, `modulo`, `atan2`, `sinc`, …
- **Built-in constants**: `pi`, `c_light`, `r_electron`, `fine_structure`, `n_avogadro`, … (sourced from libapc where available; `pi`, `k_boltzmann`, `classical_radius_factor` derived).
- **Particle-data functions**: `mass_of`, `charge_of`, `anomalous_moment_of` — delegated to libapc.
- **User constants/variables**: both the `kind: constant`/`value:` and compact `constants:`/`variables:` forms, resolved in dependency order with cycle guarding.

Both immediate and `expr(...)`-delayed expressions become numbers in the expanded tree. Values that are not expressions — element/line name references, `kind:` names, booleans — are left untouched. Expressions containing `random()`/`random_gauss()` are deferred (left as text) so the expanded tree stays reproducible. The `combined` and `original` trees always keep the original expression text. Node ids are unchanged (only scalar text is rewritten), so the correspondence map stays valid.

## API

New public `evaluate_pals_expression(const char* expr, bool* ok)` evaluates a single standalone expression string (user symbols not in scope). Handy for the forthcoming PALSJulia wrapper.

## Files

| Path | |
|---|---|
| `src/pals_expression.{h,cpp}` | New recursive-descent evaluator (grammar, functions, built-in constants, libapc particle functions) |
| `src/yaml_c_wrapper.cpp` | Post-expansion evaluation pass (collect user defs, lazy resolver, tree walk) + the public C API |
| `src/yaml_c_wrapper.h` | Declares `evaluate_pals_expression` |
| `CMakeLists.txt` | FetchContent + link libapc; add the new source |
| `tests/test_yaml_c_wrapper.cpp` | 7 new cases + one updated correspondence assertion |
| `README.md` | New "Expression Evaluation" section |

## Verification

- Clean-slate `cmake` build (fetches & builds libapc) + `ctest` → **80/80 pass**, no warnings in the new sources.
- Integration test confirms, on a real lattice, that immediate expressions, `expr()`-delayed expressions, user variables, and `mass_of(...)` are all evaluated, while `random_gauss()` is left as text and `combined` keeps the original expression.

## Note on units

`mu_0`/`epsilon_0` flow straight from libapc, so the pending AtomicAndPhysicalConstants eV-unit change needs no evaluator change — it will be picked up automatically when libapc's generated constants are regenerated against AAPC 0.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
