### PR TITLE
Resolve map-form constants/variables by name

### DIFF
--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -704,19 +704,28 @@ static void collect_defs(const ryml::Tree& t, size_t node,
         }
     }
 
-    // Compact form: a `constants:`/`variables:` sequence of single-key maps.
+    // Compact form: a `constants:`/`variables:` block. The standard writes it
+    // as a sequence of single-key maps (`- const_a: ...`), but the plain-map
+    // form (`const_a: ...` directly under the key) is also accepted.
     if (t.has_key(node)) {
         std::string k(t.key(node).str, t.key(node).len);
-        if ((k == "constants" || k == "variables") && t.is_seq(node)) {
-            for (size_t el = t.first_child(node); el != ryml::NONE;
-                 el = t.next_sibling(el)) {
-                if (!t.is_map(el)) continue;
-                for (size_t kv = t.first_child(el); kv != ryml::NONE;
-                     kv = t.next_sibling(kv)) {
-                    if (t.has_key(kv) && t.has_val(kv))
-                        defs.emplace(
-                            std::string(t.key(kv).str, t.key(kv).len),
-                            std::string(t.val(kv).str, t.val(kv).len));
+        if (k == "constants" || k == "variables") {
+            auto emit = [&](size_t kv) {
+                if (t.has_key(kv) && t.has_val(kv))
+                    defs.emplace(std::string(t.key(kv).str, t.key(kv).len),
+                                 std::string(t.val(kv).str, t.val(kv).len));
+            };
+            if (t.is_map(node)) {
+                for (size_t kv = t.first_child(node); kv != ryml::NONE;
+                     kv = t.next_sibling(kv))
+                    emit(kv);
+            } else if (t.is_seq(node)) {
+                for (size_t el = t.first_child(node); el != ryml::NONE;
+                     el = t.next_sibling(el)) {
+                    if (!t.is_map(el)) continue;
+                    for (size_t kv = t.first_child(el); kv != ryml::NONE;
+                         kv = t.next_sibling(kv))
+                        emit(kv);
                 }
             }
         }

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1254,6 +1254,62 @@ TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
     rm_tmp(path);
 }
 
+TEST_CASE("parse_and_expand_PALS resolves map-form constants/variables",
+          "[expr][lattices]") {
+    // The compact `constants:`/`variables:` block may be written as a plain map
+    // (`a_const: ...`) as well as the standard seq-of-single-key-maps form; a
+    // later definition must be able to reference an earlier one by name.
+    const char* path = "tmp_mapdefs.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - constants:\n"
+              "        a_const: 0.3 * r_electron\n"
+              "        b_const: 0.45\n"
+              "    - variables:\n"
+              "        a_var: a_const^2\n"
+              "        b_var: 0.37 * atan2(0.1, 0.2)\n"
+              "    - d1:\n"
+              "        kind: Drift\n"
+              "        length: a_const + b_const\n"
+              "    - main_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - d1\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - main_line\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+
+    const double a_const = 0.3 * evaluate_pals_expression("r_electron", nullptr);
+
+    YAMLNodeId consts = facility_param(lat.expanded, "constants");
+    REQUIRE(close(num_val(lat.expanded,
+                          get_child_by_key(lat.expanded, consts, "a_const")),
+                  a_const));
+
+    // a_var references the map-form constant a_const defined above it.
+    YAMLNodeId vars = facility_param(lat.expanded, "variables");
+    REQUIRE(close(num_val(lat.expanded,
+                          get_child_by_key(lat.expanded, vars, "a_var")),
+                  a_const * a_const));
+
+    // An element parameter may reference the map-form definitions too.
+    YAMLNodeId d1 = facility_param(lat.expanded, "d1");
+    REQUIRE(close(num_val(lat.expanded, get_child_by_key(lat.expanded, d1,
+                                                         "length")),
+                  a_const + 0.45));
+
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    rm_tmp(path);
+}
+
 TEST_CASE("parse_and_expand_PALS evaluates controller expressions",
           "[expr][lattices][controller]") {
     const char* path = "tmp_controller.pals.yaml";


### PR DESCRIPTION
## Summary

Fixes a bug where a `constants:`/`variables:` definition written in the plain-**map** form could not be referenced by name from another expression, so the reference was left unevaluated in the expanded tree.

For example, in:

```yaml
- constants:
    a_const: 0.3 * r_electron
- variables:
    a_var: a_const^2
```

`a_const` was evaluated in place, but `a_var: a_const^2` failed to resolve `a_const` and stayed as text.

## Cause

The standard documents the compact block as a sequence of single-key maps (`- a_const: ...`), and `collect_defs` only gathered that seq form into the symbol table. The plain-map form (`a_const: ...` directly under the key) — used in real lattices and in the repo's own `correspondence_test` lattice — was skipped, so map-form names were never available as symbols.

## Fix

`collect_defs` now accepts **both** the seq and map forms (the same leniency already applied to controller `variables`). Map-form values were already evaluated in place; now they can also be referenced by name.

## Testing

- New `[expr][lattices]` case: map-form `a_const` referenced by `a_var: a_const^2` and by an element parameter (`length: a_const + b_const`).
- Full suite green: **82/82 test cases, 383 assertions**.
- Verified against the reported lattice end-to-end through the PALSJulia wrapper: `a_var` now evaluates to `(0.3·r_electron)²`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
