### PR TITLE
Require species names to be quoted in particle functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ in `controls:` pairs a `parameter` target with an `expression`. Controller
 value written into the control entry. The `parameter` target specs and
 `control_type` are names and are left untouched.
 
-The particle-data functions `mass_of`, `charge_of`, and `anomalous_moment_of`, and
-the physical values behind the named constants, are provided by
+The particle-data functions `mass_of`, `charge_of`, and `anomalous_moment_of` take
+a quoted species name (e.g. `mass_of("3He")`); an unquoted name is an error. These
+functions and the physical values behind the named constants are provided by
 [AtomicAndPhysicalConstantsCLib](https://github.com/pals-project/AtomicAndPhysicalConstantsCLib)
 (a C++ mirror of [AtomicAndPhysicalConstants.jl](https://github.com/bmad-sim/AtomicAndPhysicalConstants.jl)),
 fetched automatically by CMake. A single expression can also be evaluated on its

--- a/src/pals_expression.cpp
+++ b/src/pals_expression.cpp
@@ -9,9 +9,10 @@
  *   unary   := ('+' | '-') unary | primary
  *   primary := number | name | name '(' args ')' | '(' expr ')'
  *
- * The particle functions mass_of / charge_of / anomalous_moment_of take a bare
- * species name (e.g. `mass_of(He3)`), not a numeric sub-expression, so their
- * argument is read as raw text and passed to AtomicAndPhysicalConstantsCLib.
+ * The particle functions mass_of / charge_of / anomalous_moment_of take a
+ * quoted species name (e.g. `mass_of("3He")`), not a numeric sub-expression, so
+ * their argument is read as raw text and passed to
+ * AtomicAndPhysicalConstantsCLib. An unquoted species name is an error.
  */
 
 #include "pals_expression.h"
@@ -187,8 +188,14 @@ class Parser {
     if (depth != 0) throw ParseError{};
     size_t a = out.find_first_not_of(" \t");
     size_t b = out.find_last_not_of(" \t");
-    if (a == std::string::npos) return "";
-    return out.substr(a, b - a + 1);
+    std::string arg = (a == std::string::npos) ? "" : out.substr(a, b - a + 1);
+    // A species name must always be quoted (single or double), e.g.
+    // mass_of("#3He"); an unquoted name is an error. Strip the quotes before
+    // handing the name to AtomicAndPhysicalConstantsCLib.
+    if (arg.size() < 2 || (arg.front() != '"' && arg.front() != '\'') ||
+        arg.back() != arg.front())
+      throw ParseError{};
+    return arg.substr(1, arg.size() - 2);
   }
 
   double name() {

--- a/src/pals_expression.h
+++ b/src/pals_expression.h
@@ -7,7 +7,8 @@
  *        Expressions", "Functions", and "Constants and Variables" sections of
  *        the PALS standard).
  *
- * Particle-data functions (mass_of, charge_of, anomalous_moment_of) and the
+ * Particle-data functions (mass_of, charge_of, anomalous_moment_of), which take
+ * a quoted species name such as mass_of("3He"), and the
  * named physical constants (c_light, r_electron, ...) are sourced from
  * AtomicAndPhysicalConstantsCLib so the whole PALS/Bmad ecosystem shares one
  * set of numbers.

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -105,8 +105,8 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
  * signs, parentheses, the built-in constants (pi, c_light, r_electron, ...),
  * the math functions (sqrt, log, sin, floor, modulo, ...), and the
  * particle-data functions mass_of / charge_of / anomalous_moment_of (backed by
- * AtomicAndPhysicalConstantsCLib). A leading `expr(...)` wrapper is accepted
- * and unwrapped.
+ * AtomicAndPhysicalConstantsCLib), whose species-name argument must be quoted,
+ * e.g. mass_of("3He"). A leading `expr(...)` wrapper is accepted and unwrapped.
  *
  * This entry point evaluates a standalone string: user-defined constants and
  * variables are NOT in scope (use parse_and_expand_PALS() for whole-lattice

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1127,19 +1127,30 @@ TEST_CASE("evaluate_pals_expression: built-in constants", "[expr]") {
     REQUIRE(eval_ok("c_light") == 2.99792458e8);
     // classical_radius_factor and k_boltzmann are derived from AAPC quantities.
     REQUIRE(close(eval_ok("classical_radius_factor"),
-                  eval_ok("r_electron") * eval_ok("mass_of(electron)")));
+                  eval_ok("r_electron") * eval_ok("mass_of(\"electron\")")));
 }
 
 TEST_CASE("evaluate_pals_expression: particle-data functions from libapc",
           "[expr]") {
-    // Values mirror AtomicAndPhysicalConstantsCLib (CODATA 2022).
-    REQUIRE(close(eval_ok("mass_of(proton)"), 938272089.43000007));
-    REQUIRE(eval_ok("charge_of(electron)") == -1.0);
-    REQUIRE(eval_ok("charge_of(anti-proton)") == -1.0);
-    REQUIRE(close(eval_ok("2 * mass_of(electron)"), 2 * 510998.95069000003));
+    // Species names must always be quoted (single or double). Values mirror
+    // AtomicAndPhysicalConstantsCLib (CODATA 2022).
+    REQUIRE(close(eval_ok("mass_of(\"proton\")"), 938272089.43000007));
+    REQUIRE(eval_ok("charge_of('electron')") == -1.0);
+    REQUIRE(eval_ok("charge_of(\"anti-proton\")") == -1.0);
+    REQUIRE(close(eval_ok("2 * mass_of(\"electron\")"), 2 * 510998.95069000003));
     // A bare isotope is the neutral atom; the ionised form carries the charge.
-    REQUIRE(eval_ok("charge_of(3He)") == 0.0);
-    REQUIRE(eval_ok("charge_of(helion)") == 2.0);
+    REQUIRE(eval_ok("charge_of(\"3He\")") == 0.0);
+    REQUIRE(eval_ok("charge_of(\"helion\")") == 2.0);
+    // The `#` isotope form is unaffected by YAML's comment rule once quoted.
+    REQUIRE(close(eval_ok("mass_of(\"#3He\")"), eval_ok("mass_of(\"3He\")")));
+
+    // An unquoted species name is an error.
+    bool ok = true;
+    evaluate_pals_expression("mass_of(electron)", &ok);
+    REQUIRE_FALSE(ok);
+    ok = true;
+    evaluate_pals_expression("charge_of(3He)", &ok);
+    REQUIRE_FALSE(ok);
 }
 
 TEST_CASE("evaluate_pals_expression: expr() wrapper is accepted", "[expr]") {
@@ -1157,7 +1168,7 @@ TEST_CASE("evaluate_pals_expression: non-evaluable inputs report failure",
     evaluate_pals_expression("thingB", &ok);          // unknown identifier
     REQUIRE_FALSE(ok);
     ok = true;
-    evaluate_pals_expression("mass_of(nonsense)", &ok);  // unknown species
+    evaluate_pals_expression("mass_of(\"nonsense\")", &ok);  // unknown species
     REQUIRE_FALSE(ok);
     ok = true;
     evaluate_pals_expression("1 + ", &ok);            // parse error
@@ -1199,7 +1210,7 @@ TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
               "        - b_var: -0.34\n"
               "    - m_e:\n"
               "        kind: constant\n"
-              "        value: mass_of(electron)\n"
+              "        value: mass_of(\"electron\")\n"
               "    - cleo:\n"
               "        kind: Solenoid\n"
               "        length: 0.1*log(abs(b_var))\n"


### PR DESCRIPTION
## Summary

Species names passed to the particle-data functions `mass_of` / `charge_of` / `anomalous_moment_of` must now be **quoted** (single or double), e.g. `mass_of("3He")`. An unquoted name is an error (the expression fails to evaluate and is left as text). The quotes are stripped before the name reaches AtomicAndPhysicalConstantsCLib.

## Why

Quoting lets a species name that contains a `#` — such as the isotope `"#3He"` — be written without tripping YAML's comment rule, and makes the species-name argument unambiguous. Reported case:

```yaml
- constants:
    b_const: 0.45 * mass_of("#3He")
```

previously failed because the quotes were passed through literally to libapc; now it evaluates.

## Changes

- `read_raw_arg` (`pals_expression.cpp`) requires a matching pair of surrounding quotes and strips them; an unquoted argument throws.
- Tests, README, and the header/module doc comments updated to the quoted form, plus new cases asserting that unquoted `mass_of(electron)` / `charge_of(3He)` are errors and that `mass_of("#3He") == mass_of("3He")`.

## Testing

Full suite green: **81 test cases, 384 assertions**. Verified end-to-end through the PALSJulia wrapper: `0.45 * mass_of("#3He")` → `1.264e9`, and unquoted `mass_of(electron)` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
