### PR TITLE
Document expression grammar; use APC acronym

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,20 @@ full PALS expression grammar — arithmetic (`+ - * / ^`), parentheses, the
 [built-in constants](https://github.com/pals-project/pals) (`pi`, `c_light`,
 `r_electron`, …), the math functions (`sqrt`, `log`, `sin`, `floor`, `modulo`, …),
 and user-defined constants and variables (both the `kind: constant`/`value:` and
-the compact `constants:`/`variables:` forms, resolved in dependency order). Both
-immediate expressions and `expr(...)`-delayed expressions are evaluated to a
+the compact `constants:`/`variables:` forms — the compact form may be written as
+a sequence of single-key maps or as a plain map — resolved in dependency order).
+Both immediate expressions and `expr(...)`-delayed expressions are evaluated to a
 number in the expanded tree. Values that are not expressions — element/line name
 references, `kind:` names, booleans — are left untouched, and expressions
 containing `random()`/`random_gauss()` are left as text so the expanded tree stays
 reproducible. The `combined` and `original` trees always retain the original
 expression text.
+
+Operator precedence is standard, with two conventions worth noting: `^` (power)
+is right-associative, so `2^3^2` is `2^(3^2) = 512`; and a unary sign binds
+*looser* than `^`, so `-2^2` is `-(2^2) = -4` while a signed exponent still works
+(`2^-2` is `2^(-2) = 0.25`) — the Fortran/Bmad convention used across the
+ecosystem.
 
 **Controllers.** A `kind: Controller` element bundles expressions that drive
 lattice parameters. Its `variables:` form a controller-scoped symbol table

--- a/src/pals_expression.cpp
+++ b/src/pals_expression.cpp
@@ -295,9 +295,9 @@ class Parser {
 }  // namespace
 
 bool builtin_constant(const std::string& name, double& out) {
-  // Physical values come from AtomicAndPhysicalConstantsCLib (AAPC, CODATA
+  // Physical values come from AtomicAndPhysicalConstantsCLib (APC, CODATA
   // 2022) so PALS shares the ecosystem's numbers. k_boltzmann and
-  // classical_radius_factor are derived from AAPC quantities (AAPC does not
+  // classical_radius_factor are derived from APC quantities (APC does not
   // export them directly); pi is exact.
   if (name == "pi") { out = kPi; return true; }
   if (name == "c_light") { out = apc::C_LIGHT; return true; }

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1125,7 +1125,7 @@ TEST_CASE("evaluate_pals_expression: functions", "[expr]") {
 TEST_CASE("evaluate_pals_expression: built-in constants", "[expr]") {
     REQUIRE(close(eval_ok("pi"), 3.14159265358979323846));
     REQUIRE(eval_ok("c_light") == 2.99792458e8);
-    // classical_radius_factor and k_boltzmann are derived from AAPC quantities.
+    // classical_radius_factor and k_boltzmann are derived from APC quantities.
     REQUIRE(close(eval_ok("classical_radius_factor"),
                   eval_ok("r_electron") * eval_ok("mass_of(\"electron\")")));
 }


### PR DESCRIPTION
## Summary

Two small documentation fixes, companion to the PALSJulia expression-evaluation guide (PALSJulia.jl #37):

- **Acronym:** the constants library is `AtomicAndPhysicalConstantsCLib` → **APC** (not AAPC). Corrected in the `builtin_constant` and particle-data test comments.
- **README:** brought the *Expression Evaluation* section to parity with the PALSJulia guide —
  - the compact `constants:`/`variables:` form may be written as a sequence of single-key maps **or** a plain map;
  - documented operator precedence: right-associative `^` (`2^3^2 = 512`) and unary sign binding looser than `^` (`-2^2 = -4`, `2^-2 = 0.25`).

## Testing

Comment/doc-only changes. Full `[expr]` suite still green (9 cases, 90 assertions); grammar claims verified against the evaluator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
