### PR TITLE
Require '#' prefix for mass numbers in species names

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ value written into the control entry. The `parameter` target specs and
 `control_type` are names and are left untouched.
 
 The particle-data functions `mass_of`, `charge_of`, and `anomalous_moment_of` take
-a quoted species name (e.g. `mass_of("3He")`); an unquoted name is an error. These
+a quoted species name (e.g. `mass_of("#3He")`); an unquoted name is an error. A
+mass number must carry a leading `#` (`"#3He"`, not `"3He"`). These
 functions and the physical values behind the named constants are provided by
 [AtomicAndPhysicalConstantsCLib](https://github.com/pals-project/AtomicAndPhysicalConstantsCLib)
 (a C++ mirror of [AtomicAndPhysicalConstants.jl](https://github.com/bmad-sim/AtomicAndPhysicalConstants.jl)),

--- a/docs/src/guide/expressions.md
+++ b/docs/src/guide/expressions.md
@@ -77,8 +77,10 @@ helpers `int` (toward zero), `nint` (nearest), `floor`, `ceiling`, and
 `mass_of`, `charge_of`, and `anomalous_moment_of` look a particle up by name and
 return its mass (eV), charge (units of `e`), or anomalous magnetic moment, drawn
 from APC. **The species name must be quoted** (single or double quotes); an
-unquoted name is an error. Quoting also lets an isotope name that contains a `#`
-be written without tripping YAML's comment rule:
+unquoted name is an error. A mass number must carry a leading `#` — write
+`"#3He"`, not `"3He"` (matching
+[AtomicAndPhysicalConstants.jl](https://github.com/bmad-sim/AtomicAndPhysicalConstants.jl)).
+Quoting also lets that `#` be written without tripping YAML's comment rule:
 
 ```yaml
 m_e:     mass_of("electron")

--- a/src/pals_expression.cpp
+++ b/src/pals_expression.cpp
@@ -10,7 +10,7 @@
  *   primary := number | name | name '(' args ')' | '(' expr ')'
  *
  * The particle functions mass_of / charge_of / anomalous_moment_of take a
- * quoted species name (e.g. `mass_of("3He")`), not a numeric sub-expression, so
+ * quoted species name (e.g. `mass_of("#3He")`), not a numeric sub-expression, so
  * their argument is read as raw text and passed to
  * AtomicAndPhysicalConstantsCLib. An unquoted species name is an error.
  */
@@ -195,7 +195,22 @@ class Parser {
     if (arg.size() < 2 || (arg.front() != '"' && arg.front() != '\'') ||
         arg.back() != arg.front())
       throw ParseError{};
-    return arg.substr(1, arg.size() - 2);
+    std::string name = arg.substr(1, arg.size() - 2);
+
+    // A mass number must be written with a leading '#', e.g. "#3He" not "3He"
+    // (matching AtomicAndPhysicalConstants.jl). The mass number, when present,
+    // leads the name (after an optional "anti-" prefix), so a leading ASCII
+    // digit signals a missing '#'.
+    std::string core = name;
+    for (const char* pre : {"anti-", "Anti-", "anti", "Anti"}) {
+      if (core.rfind(pre, 0) == 0) {
+        core.erase(0, std::string(pre).size());
+        break;
+      }
+    }
+    if (!core.empty() && std::isdigit(static_cast<unsigned char>(core.front())))
+      throw ParseError{};
+    return name;
   }
 
   double name() {

--- a/src/pals_expression.h
+++ b/src/pals_expression.h
@@ -8,7 +8,7 @@
  *        the PALS standard).
  *
  * Particle-data functions (mass_of, charge_of, anomalous_moment_of), which take
- * a quoted species name such as mass_of("3He"), and the
+ * a quoted species name such as mass_of("#3He"), and the
  * named physical constants (c_light, r_electron, ...) are sourced from
  * AtomicAndPhysicalConstantsCLib so the whole PALS/Bmad ecosystem shares one
  * set of numbers.

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -106,7 +106,7 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
  * the math functions (sqrt, log, sin, floor, modulo, ...), and the
  * particle-data functions mass_of / charge_of / anomalous_moment_of (backed by
  * AtomicAndPhysicalConstantsCLib), whose species-name argument must be quoted,
- * e.g. mass_of("3He"). A leading `expr(...)` wrapper is accepted and unwrapped.
+ * e.g. mass_of("#3He"). A leading `expr(...)` wrapper is accepted and unwrapped.
  *
  * This entry point evaluates a standalone string: user-defined constants and
  * variables are NOT in scope (use parse_and_expand_PALS() for whole-lattice

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1138,18 +1138,22 @@ TEST_CASE("evaluate_pals_expression: particle-data functions from libapc",
     REQUIRE(eval_ok("charge_of('electron')") == -1.0);
     REQUIRE(eval_ok("charge_of(\"anti-proton\")") == -1.0);
     REQUIRE(close(eval_ok("2 * mass_of(\"electron\")"), 2 * 510998.95069000003));
-    // A bare isotope is the neutral atom; the ionised form carries the charge.
-    REQUIRE(eval_ok("charge_of(\"3He\")") == 0.0);
+    // A mass number must carry a leading '#' (e.g. "#3He"). The bare atom is
+    // neutral; the ionised form carries the charge.
+    REQUIRE(eval_ok("charge_of(\"#3He\")") == 0.0);
     REQUIRE(eval_ok("charge_of(\"helion\")") == 2.0);
-    // The `#` isotope form is unaffected by YAML's comment rule once quoted.
-    REQUIRE(close(eval_ok("mass_of(\"#3He\")"), eval_ok("mass_of(\"3He\")")));
+    REQUIRE(close(eval_ok("mass_of(\"#3He\")"), 2809413524.398952));
 
     // An unquoted species name is an error.
     bool ok = true;
     evaluate_pals_expression("mass_of(electron)", &ok);
     REQUIRE_FALSE(ok);
     ok = true;
-    evaluate_pals_expression("charge_of(3He)", &ok);
+    evaluate_pals_expression("charge_of(#3He)", &ok);
+    REQUIRE_FALSE(ok);
+    // A mass number without the '#' prefix is an error, even when quoted.
+    ok = true;
+    evaluate_pals_expression("mass_of(\"3He\")", &ok);
     REQUIRE_FALSE(ok);
 }
 


### PR DESCRIPTION
## Summary

Enforces the new species-name rule from [AtomicAndPhysicalConstants.jl#291](https://github.com/bmad-sim/AtomicAndPhysicalConstants.jl/pull/291): a species **mass number must carry a leading `#`**. `mass_of("#3He")` is accepted; `mass_of("3He")` is now an error — even when quoted.

The check is enforced **directly in pals-cpp** (`read_raw_arg`), right where the existing quote-required rule lives: after an optional `anti-` prefix, a species name whose mass number is a bare ASCII digit is rejected. That keeps the rule in force regardless of which APC version is linked, so this PR is self-contained and does **not** depend on the APC change landing first.

APC itself gains the same enforcement independently in [AtomicAndPhysicalConstantsCLib#3](https://github.com/pals-project/AtomicAndPhysicalConstantsCLib/pull/3) (belt-and-suspenders); that PR is awaiting outside approval and is not a prerequisite here.

## Changes

- **`src/pals_expression.cpp`** — `read_raw_arg` rejects an unprefixed mass number (leading ASCII digit after an optional `anti-`).
- **`tests/test_yaml_c_wrapper.cpp`** — use `"#3He"`; assert a quoted-but-unprefixed `"3He"` fails, alongside the existing unquoted-name error.
- **`src/pals_expression.{h,cpp}`, `src/yaml_c_wrapper.h`, `README.md`, `docs/src/guide/expressions.md`** — examples/docs updated to `mass_of("#3He")` and the leading-`#` requirement noted.

## Testing

Built against the current (unmodified) APC `main` — all 82 tests pass, including the new `"3He"`-is-an-error assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)