### PR TITLE
Evaluate element-parameter references in expressions

### DIFF
--- a/docs/src/guide/expressions.md
+++ b/docs/src/guide/expressions.md
@@ -111,6 +111,28 @@ Definitions are resolved in dependency order, so a later value may reference an
 earlier one (`a_var` uses `a_const` above). A reference that cannot be resolved,
 or a genuine cycle, leaves the value as text rather than aborting the expansion.
 
+## Element-parameter references
+
+An expression may also reference another element's parameter by name, using the
+`element>group.sub. ... .param` syntax (the same parameter path used elsewhere in
+the standard). It resolves to that parameter's value, itself evaluated as an
+expression:
+
+```yaml
+- thingB:
+    kind: Sextupole
+    MagneticMultipoleP:
+      Kn2L: 0.1
+- DH1A:
+    kind: Bend
+    BendP:
+      edge_int2: 0.02 * thingB>MagneticMultipoleP.Kn2L   # → 0.002
+```
+
+The reference names one specific element (an exact name — pattern matching is
+not used in a value expression) and its full parameter path. As with any other
+reference, one that cannot be resolved leaves the value as text.
+
 ## Controllers
 
 A `Controller` element bundles expressions that drive lattice parameters. Its

--- a/src/pals_expression.cpp
+++ b/src/pals_expression.cpp
@@ -155,14 +155,24 @@ class Parser {
   std::string read_identifier() {
     skip_ws();
     size_t start = pos_;
+    bool seen_gt = false;
     while (pos_ < s_.size()) {
       char c = s_[pos_];
-      // `>` joins a controller name to one of its variables (`ps27>cur1`); PALS
-      // has no `>` operator, so it is unambiguous inside an identifier.
-      if (std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '>')
+      // `>` joins a controller name to one of its variables (`ps27>cur1`) or an
+      // element name to a parameter path (`thingB>MagneticMultipoleP.Kn2L`);
+      // PALS has no `>` operator, so it is unambiguous inside an identifier.
+      if (std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '>') {
+        if (c == '>') seen_gt = true;
         ++pos_;
-      else
+      } else if (c == '.' && seen_gt) {
+        // A `.` is part of the identifier only inside an element-parameter
+        // reference (after `>`), where it separates the parameter group from
+        // the parameter. Elsewhere `.` begins a number and is not an identifier
+        // character.
+        ++pos_;
+      } else {
         break;
+      }
     }
     return s_.substr(start, pos_ - start);
   }

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -631,6 +631,13 @@ static size_t find_lattice(ryml::Tree& t, const std::string& name) {
 // live in pals_expression.cpp; this layer supplies user constants/variables and
 // walks the tree.
 
+// Defined in the NAME MATCHING section below; reused here to resolve
+// element-parameter references (`element>group.sub. ... .param`) that appear
+// inside expressions.
+static std::vector<std::string> split_dots(const std::string& s);
+static size_t resolve_param_path(const ryml::Tree& t, size_t ele,
+                                 const std::vector<std::string>& path);
+
 // Keys whose scalar values are names/flags, never expressions. Skipping them
 // avoids a stray collision between such a name and a constant (e.g. an element
 // literally named `pi`).
@@ -923,10 +930,37 @@ static void evaluate_controllers(ryml::Tree& t,
     }
 }
 
+// Resolves an element-parameter reference `element>group.sub. ... .param` to
+// the scalar value node it names, or NONE. Only the exact single-element form
+// is supported (a value expression references one specific parameter; pattern
+// matching and branch/lattice qualifiers are not permitted here, per the
+// standard). `emap` maps element names to their definition maps.
+static size_t resolve_ele_param_ref(const ryml::Tree& t,
+                                    const std::map<std::string, size_t>& emap,
+                                    const std::string& ref) {
+    size_t gt = ref.find('>');
+    if (gt == std::string::npos) return ryml::NONE;
+    std::string elem = ref.substr(0, gt);
+    std::string rest = ref.substr(gt + 1);
+    // Reject empty parts and any remaining '>' (e.g. `branch>>ele>...`).
+    if (elem.empty() || rest.empty() || rest.find('>') != std::string::npos)
+        return ryml::NONE;
+    auto it = emap.find(elem);
+    if (it == emap.end()) return ryml::NONE;
+    size_t node = resolve_param_path(t, it->second, split_dots(rest));
+    if (node == ryml::NONE || !t.has_val(node)) return ryml::NONE;
+    return node;
+}
+
 // Evaluates all expressions in the (already expanded) tree in place.
 static void evaluate_expressions(ryml::Tree& t) {
     std::map<std::string, std::string> defs;
     collect_defs(t, t.root_id(), defs);
+
+    // Element name -> definition map, so expressions may reference another
+    // element's parameter via `element>group. ... .param`.
+    std::map<std::string, size_t> emap;
+    make_ele_map(emap, t, t.root_id());
 
     // Lazily evaluate user symbols on demand, memoizing results and guarding
     // against reference cycles. A symbol whose defining expression is itself
@@ -935,18 +969,28 @@ static void evaluate_expressions(ryml::Tree& t) {
     auto active = std::make_shared<std::set<std::string>>();
     std::shared_ptr<pals::SymbolLookup> resolve =
         std::make_shared<pals::SymbolLookup>();
-    *resolve = [&defs, cache, active, resolve](const std::string& name,
-                                               double& out) -> bool {
+    *resolve = [&defs, &t, &emap, cache, active, resolve](
+                   const std::string& name, double& out) -> bool {
         auto ci = cache->find(name);
         if (ci != cache->end()) {
             out = ci->second;
             return true;
         }
-        auto di = defs.find(name);
-        if (di == defs.end()) return false;
+        // An element-parameter reference (`element>group. ... .param`) resolves
+        // to that parameter's value, evaluated as an expression in turn.
+        std::string body;
+        if (name.find('>') != std::string::npos) {
+            size_t vn = resolve_ele_param_ref(t, emap, name);
+            if (vn == ryml::NONE) return false;
+            body = std::string(t.val(vn).str, t.val(vn).len);
+        } else {
+            auto di = defs.find(name);
+            if (di == defs.end()) return false;
+            body = di->second;
+        }
         if (!active->insert(name).second) return false;  // cycle
         bool was_expr = false;
-        std::string body = strip_expr_wrapper(di->second, was_expr);
+        body = strip_expr_wrapper(body, was_expr);
         pals::EvalOutcome r = pals::eval_expression(body, *resolve);
         active->erase(name);
         if (!r.ok) return false;

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1325,6 +1325,50 @@ TEST_CASE("parse_and_expand_PALS resolves map-form constants/variables",
     rm_tmp(path);
 }
 
+TEST_CASE("parse_and_expand_PALS resolves element-parameter references",
+          "[expr][lattices]") {
+    // An expression may reference another element's parameter with the
+    // `element>group.sub. ... .param` syntax; it resolves to that parameter's
+    // value (evaluated as an expression in turn).
+    const char* path = "tmp_eleparamref.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - thingB:\n"
+              "        kind: Sextupole\n"
+              "        length: 0.3\n"
+              "        MagneticMultipoleP:\n"
+              "          Kn2L: 0.1\n"
+              "    - DH1A:\n"
+              "        kind: Bend\n"
+              "        length: 0.2\n"
+              "        BendP:\n"
+              "          edge_int2: 0.02 * thingB>MagneticMultipoleP.Kn2L\n"
+              "    - main_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - DH1A\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - main_line\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+
+    YAMLNodeId dh1a = facility_param(lat.expanded, "DH1A");
+    YAMLNodeId bendp = get_child_by_key(lat.expanded, dh1a, "BendP");
+    REQUIRE(close(
+        num_val(lat.expanded, get_child_by_key(lat.expanded, bendp, "edge_int2")),
+        0.02 * 0.1));
+
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    rm_tmp(path);
+}
+
 TEST_CASE("parse_and_expand_PALS evaluates controller expressions",
           "[expr][lattices][controller]") {
     const char* path = "tmp_controller.pals.yaml";


### PR DESCRIPTION
## Problem

An expression could reference built-in constants, user constants/variables, and (within a controller) controller variables — but not another element's parameter. A value written as

```yaml
edge_int2: 0.02 * thingB>MagneticMultipoleP.Kn2L
```

was left as text in the `expanded` tree instead of being evaluated. Two things blocked it:

1. The expression **lexer** stopped at the `.` in the parameter path, so `thingB>MagneticMultipoleP.Kn2L` never parsed as one name.
2. The **evaluator** had no resolver for cross-element parameter references.

## Fix

- `read_identifier` reads a `.` as part of an identifier **only after a `>` has been seen** — the one place a `.` is an identifier character (elsewhere it begins a number). So `thingB>MagneticMultipoleP.Kn2L` lexes as a single reference.
- The expression resolver now handles a name containing `>` by resolving `element>group.sub. … .param` against the element map to the referenced parameter's value, which is itself evaluated as an expression (reusing the existing cycle guard and memoization). Only the exact single-element form is supported — pattern matching is not used in a value expression, per the standard.

With this, `edge_int2` above evaluates to `0.002`.

## Tests / docs

- New test case `parse_and_expand_PALS resolves element-parameter references` (83/83 tests pass).
- Documented the feature in `docs/src/guide/expressions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)