### PR TITLE
Accept species-valued constants as particle-function arguments

### DIFF
--- a/docs/src/guide/expressions.md
+++ b/docs/src/guide/expressions.md
@@ -88,6 +88,16 @@ q_he:    charge_of("helion")
 b_const: 0.45 * mass_of("#3He")
 ```
 
+The argument may also be a **user constant or variable whose value is a species
+name**, passed by name (without quotes). This lets one definition fix the species
+and every expression refer to it:
+
+```yaml
+- constants:
+    species: "#3He"                 # a species-valued constant
+    b_const: 0.45 * mass_of(species) # resolves species -> "#3He"
+```
+
 ## User constants and variables
 
 A lattice can define its own constants and variables and refer to them by name

--- a/src/pals_expression.cpp
+++ b/src/pals_expression.cpp
@@ -36,8 +36,9 @@ struct ParseError {};
 
 class Parser {
  public:
-  Parser(const std::string& s, const SymbolLookup& lookup)
-      : s_(s), lookup_(lookup) {}
+  Parser(const std::string& s, const SymbolLookup& lookup,
+         const SpeciesLookup& species)
+      : s_(s), lookup_(lookup), species_(species) {}
 
   double parse() {
     double v = expr();
@@ -50,6 +51,7 @@ class Parser {
  private:
   const std::string& s_;
   const SymbolLookup& lookup_;
+  const SpeciesLookup& species_;
   size_t pos_ = 0;
   bool deferred_ = false;
 
@@ -177,8 +179,9 @@ class Parser {
     return s_.substr(start, pos_ - start);
   }
 
-  // Reads a raw species-name argument up to the matching ')'. The opening '('
-  // must already be consumed.
+  // Reads the raw, whitespace-trimmed argument text up to the matching ')'. The
+  // opening '(' must already be consumed. No quote handling — the caller
+  // decides whether it is a quoted literal or a symbol.
   std::string read_raw_arg() {
     int depth = 1;
     std::string out;
@@ -198,19 +201,14 @@ class Parser {
     if (depth != 0) throw ParseError{};
     size_t a = out.find_first_not_of(" \t");
     size_t b = out.find_last_not_of(" \t");
-    std::string arg = (a == std::string::npos) ? "" : out.substr(a, b - a + 1);
-    // A species name must always be quoted (single or double), e.g.
-    // mass_of("#3He"); an unquoted name is an error. Strip the quotes before
-    // handing the name to AtomicAndPhysicalConstantsCLib.
-    if (arg.size() < 2 || (arg.front() != '"' && arg.front() != '\'') ||
-        arg.back() != arg.front())
-      throw ParseError{};
-    std::string name = arg.substr(1, arg.size() - 2);
+    return (a == std::string::npos) ? "" : out.substr(a, b - a + 1);
+  }
 
-    // A mass number must be written with a leading '#', e.g. "#3He" not "3He"
-    // (matching AtomicAndPhysicalConstants.jl). The mass number, when present,
-    // leads the name (after an optional "anti-" prefix), so a leading ASCII
-    // digit signals a missing '#'.
+  // Enforces the leading-'#' rule for mass numbers: a mass number must be
+  // written "#3He", not "3He" (matching AtomicAndPhysicalConstants.jl). The
+  // mass number, when present, leads the name (after an optional "anti-"
+  // prefix), so a leading ASCII digit signals a missing '#'.
+  static void check_mass_number(const std::string& name) {
     std::string core = name;
     for (const char* pre : {"anti-", "Anti-", "anti", "Anti"}) {
       if (core.rfind(pre, 0) == 0) {
@@ -220,6 +218,24 @@ class Parser {
     }
     if (!core.empty() && std::isdigit(static_cast<unsigned char>(core.front())))
       throw ParseError{};
+  }
+
+  // Reads the species-name argument of a particle-data function. It is either a
+  // quoted literal (mass_of("#3He")) or a bare identifier that resolves through
+  // the species symbol table to a species string (mass_of(species), where
+  // `species: "#3He"`). The opening '(' must already be consumed.
+  std::string read_species_arg() {
+    std::string arg = read_raw_arg();
+    std::string name;
+    if (arg.size() >= 2 && (arg.front() == '"' || arg.front() == '\'') &&
+        arg.back() == arg.front()) {
+      name = arg.substr(1, arg.size() - 2);  // quoted literal
+    } else if (!species_ || !species_(arg, name)) {
+      // Not quoted and not a known species symbol: an unquoted literal name is
+      // an error, and an unknown symbol cannot be resolved.
+      throw ParseError{};
+    }
+    check_mass_number(name);
     return name;
   }
 
@@ -251,9 +267,10 @@ class Parser {
   }
 
   double call(const std::string& fn) {
-    // Particle-data functions take a bare species name, not an expression.
+    // Particle-data functions take a species name (quoted literal or a symbol
+    // that resolves to one), not a numeric expression.
     if (fn == "mass_of" || fn == "charge_of" || fn == "anomalous_moment_of") {
-      std::string sp = read_raw_arg();
+      std::string sp = read_species_arg();
       try {
         if (fn == "mass_of") return apc::mass_of(sp);
         if (fn == "charge_of") return apc::charge_of(sp);
@@ -343,10 +360,11 @@ bool builtin_constant(const std::string& name, double& out) {
   return false;
 }
 
-EvalOutcome eval_expression(const std::string& text, const SymbolLookup& lookup) {
+EvalOutcome eval_expression(const std::string& text, const SymbolLookup& lookup,
+                            const SpeciesLookup& species) {
   EvalOutcome r;
   try {
-    Parser p(text, lookup);
+    Parser p(text, lookup, species);
     double v = p.parse();
     if (p.deferred()) {
       r.deferred = true;

--- a/src/pals_expression.h
+++ b/src/pals_expression.h
@@ -39,10 +39,21 @@ struct EvalOutcome {
 // resolved inside the evaluator and need not be provided here.
 using SymbolLookup = std::function<bool(const std::string& name, double& out)>;
 
+// Looks up a user-defined *species-name* symbol by name (a constant/variable
+// whose value is a species string, e.g. `species: "#3He"`). Returns true and
+// sets `out` to the species name if the name is known. Lets the particle-data
+// functions accept a symbol, e.g. `mass_of(species)`, not only a quoted
+// literal `mass_of("#3He")`. An empty std::function means no such symbols.
+using SpeciesLookup =
+    std::function<bool(const std::string& name, std::string& out)>;
+
 // Evaluates `text` as a PALS mathematical expression. A leading `expr(...)`
 // wrapper, if present, must be stripped by the caller. `lookup` resolves user
-// symbols; an empty std::function is fine when none are available.
-EvalOutcome eval_expression(const std::string& text, const SymbolLookup& lookup);
+// symbols; an empty std::function is fine when none are available. `species`
+// resolves a bare identifier passed to a particle-data function to a species
+// name; an empty std::function restricts those functions to quoted literals.
+EvalOutcome eval_expression(const std::string& text, const SymbolLookup& lookup,
+                            const SpeciesLookup& species = {});
 
 // If `name` is a built-in PALS constant, sets `out` to its value and returns
 // true; otherwise returns false.

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -849,6 +849,7 @@ static bool looks_like_expression(const std::string& body, bool was_expr) {
 // `problems`.
 static void substitute_values(ryml::Tree& t, size_t node,
                               const pals::SymbolLookup& resolve,
+                              const pals::SpeciesLookup& species,
                               ProblemList& problems) {
     if (node == ryml::NONE || is_controller(t, node)) return;
 
@@ -868,7 +869,7 @@ static void substitute_values(ryml::Tree& t, size_t node,
             bool was_expr = false;
             std::string body = strip_expr_wrapper(
                 std::string(t.val(node).str, t.val(node).len), was_expr);
-            pals::EvalOutcome r = pals::eval_expression(body, resolve);
+            pals::EvalOutcome r = pals::eval_expression(body, resolve, species);
             if (r.ok) {
                 t.set_val(node,
                           t.to_arena(ryml::to_csubstr(format_double(r.value))));
@@ -884,7 +885,7 @@ static void substitute_values(ryml::Tree& t, size_t node,
 
     for (size_t c = t.first_child(node); c != ryml::NONE;
          c = t.next_sibling(c))
-        substitute_values(t, c, resolve, problems);
+        substitute_values(t, c, resolve, species, problems);
 }
 
 // Collects every `kind: Controller` node in the subtree.
@@ -940,6 +941,7 @@ static void for_each_ctrl_var(const ryml::Tree& t, size_t vars, F&& emit) {
 // per the PALS expansion model the expanded tree carries the computed value.
 static void evaluate_controllers(ryml::Tree& t,
                                  const pals::SymbolLookup& global_resolve,
+                                 const pals::SpeciesLookup& species,
                                  ProblemList& problems) {
     std::vector<size_t> controllers;
     collect_controllers(t, t.root_id(), controllers);
@@ -1002,7 +1004,7 @@ static void evaluate_controllers(ryml::Tree& t,
             pals::SymbolLookup res = make_resolver(v.ctrl);
             bool was_expr = false;
             std::string body = strip_expr_wrapper(v.text, was_expr);
-            pals::EvalOutcome r = pals::eval_expression(body, res);
+            pals::EvalOutcome r = pals::eval_expression(body, res, species);
             if (r.ok) {
                 locals[v.ctrl][v.bare] = r.value;
                 qualified[v.qname] = r.value;
@@ -1040,7 +1042,7 @@ static void evaluate_controllers(ryml::Tree& t,
             bool was_expr = false;
             std::string body = strip_expr_wrapper(
                 std::string(t.val(enode).str, t.val(enode).len), was_expr);
-            pals::EvalOutcome r = pals::eval_expression(body, res);
+            pals::EvalOutcome r = pals::eval_expression(body, res, species);
             if (r.ok)
                 t.set_val(enode,
                           t.to_arena(ryml::to_csubstr(format_double(r.value))));
@@ -1085,6 +1087,26 @@ static void evaluate_expressions(ryml::Tree& t, ProblemList& problems) {
     std::map<std::string, size_t> emap;
     make_ele_map(emap, t, t.root_id());
 
+    // Resolves a symbol whose value is a species-name string (e.g.
+    // `species: "#3He"`), so a particle-data function may take it by name:
+    // `mass_of(species)`. The stored value is returned verbatim (trimmed, with
+    // any surrounding quotes stripped); the expression evaluator validates it.
+    pals::SpeciesLookup species = [&defs](const std::string& name,
+                                          std::string& out) -> bool {
+        auto di = defs.find(name);
+        if (di == defs.end()) return false;
+        std::string v = di->second;
+        size_t a = v.find_first_not_of(" \t\r\n");
+        size_t b = v.find_last_not_of(" \t\r\n");
+        if (a == std::string::npos) return false;
+        v = v.substr(a, b - a + 1);
+        if (v.size() >= 2 && (v.front() == '"' || v.front() == '\'') &&
+            v.back() == v.front())
+            v = v.substr(1, v.size() - 2);
+        out = v;
+        return true;
+    };
+
     // Lazily evaluate user symbols on demand, memoizing results and guarding
     // against reference cycles. A symbol whose defining expression is itself
     // unresolvable is reported as unknown.
@@ -1092,7 +1114,7 @@ static void evaluate_expressions(ryml::Tree& t, ProblemList& problems) {
     auto active = std::make_shared<std::set<std::string>>();
     std::shared_ptr<pals::SymbolLookup> resolve =
         std::make_shared<pals::SymbolLookup>();
-    *resolve = [&defs, &t, &emap, cache, active, resolve](
+    *resolve = [&defs, &t, &emap, cache, active, resolve, species](
                    const std::string& name, double& out) -> bool {
         auto ci = cache->find(name);
         if (ci != cache->end()) {
@@ -1114,7 +1136,7 @@ static void evaluate_expressions(ryml::Tree& t, ProblemList& problems) {
         if (!active->insert(name).second) return false;  // cycle
         bool was_expr = false;
         body = strip_expr_wrapper(body, was_expr);
-        pals::EvalOutcome r = pals::eval_expression(body, *resolve);
+        pals::EvalOutcome r = pals::eval_expression(body, *resolve, species);
         active->erase(name);
         if (!r.ok) return false;
         (*cache)[name] = r.value;
@@ -1124,8 +1146,8 @@ static void evaluate_expressions(ryml::Tree& t, ProblemList& problems) {
 
     // Controllers first (controller-scoped symbol tables), then the generic
     // pass over the rest of the tree (which skips controller subtrees).
-    evaluate_controllers(t, *resolve, problems);
-    substitute_values(t, t.root_id(), *resolve, problems);
+    evaluate_controllers(t, *resolve, species, problems);
+    substitute_values(t, t.root_id(), *resolve, species, problems);
 }
 
 static YAMLTreeHandle make_expanded_from_combined(ParsedData* comb,

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1373,6 +1373,61 @@ TEST_CASE("parse_and_expand_PALS resolves element-parameter references",
     rm_tmp(path);
 }
 
+TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
+          "[expr][lattices]") {
+    // A particle-data function may take a symbol whose value is a species name
+    // (`mass_of(species)` where `species: "#3He"`), not only a quoted literal.
+    const char* path = "tmp_speciesconst.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - constants:\n"
+              "        species: \"#3He\"\n"
+              "        b_const: 0.45 * mass_of(species)\n"
+              "    - DH1A:\n"
+              "        kind: Bend\n"
+              "        BendP:\n"
+              "          e_tot: 1.1 * mass_of(species)\n"
+              "    - main_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - DH1A\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - main_line\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+
+    const double m_3he = 2809413524.398952;  // mass_of("#3He"), CODATA 2022
+
+    YAMLNodeId consts = facility_param(lat.expanded, "constants");
+    REQUIRE(close(num_val(lat.expanded,
+                          get_child_by_key(lat.expanded, consts, "b_const")),
+                  0.45 * m_3he));
+
+    YAMLNodeId dh1a = facility_param(lat.expanded, "DH1A");
+    YAMLNodeId bendp = get_child_by_key(lat.expanded, dh1a, "BendP");
+    REQUIRE(close(num_val(lat.expanded,
+                          get_child_by_key(lat.expanded, bendp, "e_tot")),
+                  1.1 * m_3he));
+
+    // The species constant itself stays as its (string) species name.
+    REQUIRE(val_eq(lat.expanded,
+                   get_child_by_key(lat.expanded, consts, "species"), "#3He"));
+
+    // No spurious problems.
+    REQUIRE(lat.problems.count == 0);
+    free_lattice_problems(lat.problems);
+
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    rm_tmp(path);
+}
+
 TEST_CASE("parse_and_expand_PALS reports expansion problems",
           "[expr][lattices][problems]") {
     // Every silent failure of expansion/evaluation is surfaced in the


### PR DESCRIPTION
## Summary

`mass_of` / `charge_of` / `anomalous_moment_of` previously required a **quoted** species literal. They now also accept a bare identifier that resolves — through a new string-valued `SpeciesLookup` — to a constant or variable whose value is a species name. One definition can fix the species and every expression refer to it:

```yaml
- constants:
    species: "#3He"                  # a species-valued constant
    b_const: 0.45 * mass_of(species) # resolves species -> "#3He"
```

The leading-`#` mass-number rule still applies to the resolved name, and quoted literals behave exactly as before.

## Changes

- `pals_expression.{h,cpp}`: add `SpeciesLookup` type; `eval_expression` takes an optional species resolver; split `read_raw_arg` from a new `read_species_arg` that accepts a quoted literal *or* a resolvable identifier; factor out `check_mass_number`.
- `yaml_c_wrapper.cpp`: build a species lookup from the collected constant/variable definitions and thread it through `evaluate_expressions` → resolver / `evaluate_controllers` / `substitute_values`.
- Tests + `docs/src/guide/expressions.md` updated.

## Test plan

- Full C++ suite passes (86 test cases).
- New case: `parse_and_expand_PALS` resolves a `species: "#3He"` constant used in `mass_of(species)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)