### PR TITLE
Substitute species-valued constants referenced as parameter values

### DIFF
--- a/docs/src/guide/expressions.md
+++ b/docs/src/guide/expressions.md
@@ -98,6 +98,17 @@ and every expression refer to it:
     b_const: 0.45 * mass_of(species) # resolves species -> "#3He"
 ```
 
+Such a species-valued constant may also be referenced **directly** wherever a
+species name is expected: a bare identifier used as a parameter value is
+replaced by the constant's species string in the expanded tree.
+
+```yaml
+- begin:
+    kind: BeginningEle
+    ReferenceP:
+      species_ref: species          # -> "#3He" in `expanded`
+```
+
 ## User constants and variables
 
 A lattice can define its own constants and variables and refer to them by name

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -870,9 +870,17 @@ static void substitute_values(ryml::Tree& t, size_t node,
             std::string body = strip_expr_wrapper(
                 std::string(t.val(node).str, t.val(node).len), was_expr);
             pals::EvalOutcome r = pals::eval_expression(body, resolve, species);
+            std::string sp;
             if (r.ok) {
                 t.set_val(node,
                           t.to_arena(ryml::to_csubstr(format_double(r.value))));
+            } else if (!r.deferred && species && species(body, sp)) {
+                // A bare identifier that names a species-valued constant or
+                // variable (e.g. `species_ref: species` with `species: "#3He"`)
+                // is replaced by its species-name string. Double-quoted so a
+                // leading `#` survives YAML's comment rule on re-emit.
+                t.set_val(node, t.to_arena(ryml::to_csubstr(sp)));
+                t.set_val_style(node, ryml::VAL_DQUO);
             } else if (!r.deferred && looks_like_expression(body, was_expr)) {
                 std::string loc = short_location(t, node);
                 std::string msg = "could not evaluate expression";

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1386,6 +1386,8 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
               "        b_const: 0.45 * mass_of(species)\n"
               "    - DH1A:\n"
               "        kind: Bend\n"
+              "        ReferenceP:\n"
+              "          species_ref: species\n"
               "        BendP:\n"
               "          e_tot: 1.1 * mass_of(species)\n"
               "    - main_line:\n"
@@ -1413,6 +1415,13 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
     REQUIRE(close(num_val(lat.expanded,
                           get_child_by_key(lat.expanded, bendp, "e_tot")),
                   1.1 * m_3he));
+
+    // A bare identifier naming the species constant (`species_ref: species`) is
+    // replaced by its species-name string in the expanded tree.
+    YAMLNodeId refp = get_child_by_key(lat.expanded, dh1a, "ReferenceP");
+    REQUIRE(val_eq(lat.expanded,
+                   get_child_by_key(lat.expanded, refp, "species_ref"),
+                   "#3He"));
 
     // The species constant itself stays as its (string) species name.
     REQUIRE(val_eq(lat.expanded,


### PR DESCRIPTION
## Summary

A scalar value that is a bare identifier naming a species-valued constant or variable is now replaced by that constant's species-name string in the **expanded** tree — the string-valued analog of numeric-constant substitution:

```yaml
- constants:
    species: "#3He"
- begin:
    kind: BeginningEle
    ReferenceP:
      species_ref: species   # -> "#3He" in `expanded`
```

Previously this was left as the literal text `species`.

## Details

- In `substitute_values`, when numeric evaluation of a scalar fails and the value is not a deferred `random()` expression, the value is looked up through the existing species resolver; if it names a species-valued constant/variable, the value is replaced by the resolved species string. The node is marked `VAL_DQUO` so a leading `#` survives YAML's comment rule on re-emit.
- Fires only when numeric evaluation fails, so numeric constants (which evaluate to a number) and element/line references (not in the symbol table, and already skipped via `non_expr_keys`/`line:`) are unaffected.

## Test plan

- Extended the species-name-constant test with a `species_ref: species` reference that must expand to `#3He` (verified in the definition element and in expanded beamline instances).
- Full C++ suite passes (86 test cases via ctest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)