### PR TITLE
Add regression tests for map key insertion order

### DIFF
--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <map>
 #include <string>
+#include <vector>
 
 #include "../src/yaml_c_wrapper.h"
 
@@ -24,6 +25,15 @@ static void rm_tmp(const std::string& path) {
 // Convenience: get a string value and compare, then free it.
 static bool val_eq(YAMLTreeHandle tree, YAMLNodeId node, const char* expected) {
     char* s = as_string(tree, node);
+    if (!s) return false;
+    bool ok = std::string(s) == expected;
+    yaml_free_string(s);
+    return ok;
+}
+
+// Convenience: compare a node's key, then free it.
+static bool key_eq(YAMLTreeHandle tree, YAMLNodeId node, const char* expected) {
+    char* s = get_node_key(tree, node);
     if (!s) return false;
     bool ok = std::string(s) == expected;
     yaml_free_string(s);
@@ -801,17 +811,129 @@ TEST_CASE("build_correspondence_map maps one source to many expanded copies",
 }
 
 // ============================================================
-// NAME MATCHING
+// KEY ORDER
 // ============================================================
 
-// Convenience: compare a node's key, then free it.
-static bool key_eq(YAMLTreeHandle tree, YAMLNodeId node, const char* expected) {
-    char* s = get_node_key(tree, node);
-    if (!s) return false;
-    bool ok = std::string(s) == expected;
-    yaml_free_string(s);
-    return ok;
+// A lattice file is meant to be read by people, so a map's keys must come back
+// in the order the author wrote them, never sorted. Order is preserved rather
+// than imposed: the YAML backend stores map children in a sequence, and the
+// expansion passes copy children in order. Nothing asserts that on its own,
+// which is what these tests are for.
+
+// The keys of `node`'s children, in order. Keyless children (sequence items)
+// contribute an empty string.
+static std::vector<std::string> keys_of(YAMLTreeHandle tree, YAMLNodeId node) {
+    std::vector<std::string> keys;
+    for (size_t i = 0; i < get_size(tree, node); i++) {
+        char* k = get_node_key(tree, get_child_by_index(tree, node, i));
+        keys.push_back(k ? k : "");
+        yaml_free_string(k);
+    }
+    return keys;
 }
+
+TEST_CASE("Map keys keep their file order through a parse/emit round-trip",
+          "[key_order]") {
+    const char* path = "tmp_key_order.yaml";
+    // Deliberately not alphabetical: sorting would give alpha, bravo, mike, zulu.
+    write_tmp(path, "zulu: 1\nalpha: 2\nmike: 3\nbravo: 4\n");
+
+    const std::vector<std::string> expected = {"zulu", "alpha", "mike", "bravo"};
+
+    YAMLTreeHandle tree = parse_file(path);
+    REQUIRE(keys_of(tree, get_root(tree)) == expected);
+
+    // ... and again after emitting and reading the result back.
+    const char* out = "tmp_key_order_out.yaml";
+    REQUIRE(write_file(tree, out));
+    YAMLTreeHandle reloaded = parse_file(out);
+    REQUIRE(keys_of(reloaded, get_root(reloaded)) == expected);
+
+    delete_tree(tree);
+    delete_tree(reloaded);
+    rm_tmp(path);
+    rm_tmp(out);
+}
+
+TEST_CASE("add_scalar inserts at the requested position", "[key_order]") {
+    YAMLTreeHandle tree = parse_string("zulu: 1\nalpha: 2");
+    YAMLNodeId root = get_root(tree);
+    add_scalar(tree, root, "omega", "3", END);  // append
+    add_scalar(tree, root, "first", "0", 0);    // prepend
+
+    const std::vector<std::string> expected = {"first", "zulu", "alpha", "omega"};
+    REQUIRE(keys_of(tree, root) == expected);
+
+    delete_tree(tree);
+}
+
+TEST_CASE("Expansion preserves the key order of the source file", "[key_order]") {
+    const char* path = "tmp_key_order.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - thingB:\n"
+              "        kind: Sextupole\n"
+              "        length: 2\n"
+              "    - main_line:\n"
+              "        kind: BeamLine\n"
+              "        multipass: true\n"
+              "        length: 37.8\n"
+              "        zero_point: thingC\n"
+              "        line:\n"
+              "          - thingZ:\n"
+              "              inherit: thingB\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - main_line\n"
+              "    - use: lat1\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+
+    // `main_line`'s keys are not in alphabetical order — sorting would move
+    // `length` above `line` and `multipass` to the end — so the order below
+    // can only come from the source file.
+    const std::vector<std::string> expected = {"kind", "multipass", "length",
+                                               "zero_point", "line"};
+
+    // The combined tree splices includes; `main_line` is facility item 1.
+    YAMLNodeId c_line = get_child_by_index(
+        lat.combined,
+        get_child_by_index(lat.combined, facility_of(lat.combined), 1), 0);
+    REQUIRE(key_eq(lat.combined, c_line, "main_line"));
+    REQUIRE(keys_of(lat.combined, c_line) == expected);
+
+    // In the expanded tree the line is inlined under lat1's `branches`.
+    YAMLNodeId lat1 = get_child_by_index(
+        lat.expanded,
+        get_child_by_index(lat.expanded, facility_of(lat.expanded), 2), 0);
+    REQUIRE(key_eq(lat.expanded, lat1, "lat1"));
+    YAMLNodeId branches = get_child_by_key(lat.expanded, lat1, "branches");
+    YAMLNodeId e_line = get_child_by_index(
+        lat.expanded, get_child_by_index(lat.expanded, branches, 0), 0);
+    REQUIRE(key_eq(lat.expanded, e_line, "main_line"));
+    REQUIRE(keys_of(lat.expanded, e_line) == expected);
+
+    // Merging `inherit: thingB` brings the parent's keys in ahead of the
+    // child's own, rather than sorting the merged result.
+    YAMLNodeId line_seq = get_child_by_key(lat.expanded, e_line, "line");
+    YAMLNodeId thingZ = get_child_by_index(
+        lat.expanded, get_child_by_index(lat.expanded, line_seq, 0), 0);
+    REQUIRE(key_eq(lat.expanded, thingZ, "thingZ"));
+    const std::vector<std::string> inherited = {"kind", "length", "inherit"};
+    REQUIRE(keys_of(lat.expanded, thingZ) == inherited);
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    rm_tmp(path);
+}
+
+// ============================================================
+// NAME MATCHING
+// ============================================================
 
 // A small two-lattice lattice covering constants, variables, elements with
 // ungrouped (length) and grouped (BendP.e1) parameters, a sub-line (sub/S1),


### PR DESCRIPTION
Closes #18.

Insertion order is no longer an issue: the migration from yaml-cpp to rapidyaml in #20 fixed it. That PR didn't reference the issue, so it stayed open. This adds the regression tests that were missing.

## Current behaviour

Order is preserved everywhere it was checked. rapidyaml stores map children in a sequence rather than a sorted container, and the expansion passes copy children in order. The `std::map`s in `yaml_c_wrapper.cpp` are lookup side tables (provenance, element-name → node id) and never hold node ordering, so nothing on the output path sorts.

## Why add tests for something that already works

Order is currently preserved as a property of the backend's design, not something the suite asserts. A future change to the expansion passes could regress it and nothing would fail. A lattice file is a document a person reads — `kind` should stay above `length` because the author put it there — so this is worth pinning down.

## What is covered

| path | test |
|---|---|
| parse → emit → parse | `Map keys keep their file order through a parse/emit round-trip` |
| positional insert | `add_scalar inserts at the requested position` (`END` and index `0`) |
| `parse_and_expand_PALS` | `Expansion preserves the key order of the source file` — checks `combined` and `expanded`, plus the `inherit` merge |

Every test uses keys that are deliberately not in alphabetical order (`zulu, alpha, mike, bravo`; `kind, multipass, length, zero_point, line`), so the expected order cannot be produced by sorting.

The `inherit` case is the interesting one: merging `inherit: thingB` brings the parent's keys in ahead of the child's own (`kind, length, inherit`) rather than sorting the merged result.

## Checks

Full suite passes: 417 assertions in 89 test cases.

The tests were verified to be non-vacuous by making the key-reading helper `std::sort` its result — all three fail under that mutation, with exactly the diff the bug would produce:

```
  { "kind", "length", "line", "multipass", "zero_point" }   // sorted
  ==
  { "kind", "multipass", "length", "zero_point", "line" }   // file order
```

The only other change is moving the `key_eq` helper up beside `val_eq` so both are in scope for the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
