### PR TITLE
Pin apc to v0.11.1 and update the APC reference values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,10 +45,13 @@ set(PCRE2_STATIC_PIC ON CACHE BOOL "" FORCE)
 # (mass_of / charge_of / anomalous_moment_of) and the named physical constants
 # used by the PALS expression evaluator. Its values mirror
 # AtomicAndPhysicalConstants.jl so the whole ecosystem shares one set of numbers.
+# Pinned to a tag, not main: the reference values in the tests are tied to a
+# specific APC release, so an upstream push must not silently change them here.
+# apc's version tracks the APC release it mirrors (v0.11.1 = APC v0.11.1).
 FetchContent_Declare(
   apc
   GIT_REPOSITORY https://github.com/pals-project/AtomicAndPhysicalConstantsCLib.git
-  GIT_TAG main
+  GIT_TAG v0.11.1
 )
 set(APC_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1250,6 +1250,13 @@ TEST_CASE("evaluate_pals_expression: built-in constants", "[expr]") {
     // classical_radius_factor and k_boltzmann are derived from APC quantities.
     REQUIRE(close(eval_ok("classical_radius_factor"),
                   eval_ok("r_electron") * eval_ok("mass_of(\"electron\")")));
+
+    // epsilon_0 and mu_0 are in the PALS standard's eV units — 1/(eV*m) and
+    // eV*sec^2/m respectively, not the SI F/m and N/A^2. In these units the
+    // identity eps_0 * mu_0 * c^2 == 1 holds, which pins both values at once.
+    REQUIRE(close(eval_ok("epsilon_0"), 5.5263493618e7));
+    REQUIRE(close(eval_ok("mu_0"), 2.013354537e-25));
+    REQUIRE(close(eval_ok("epsilon_0 * mu_0 * c_light^2"), 1.0));
 }
 
 TEST_CASE("evaluate_pals_expression: particle-data functions from libapc",
@@ -1264,7 +1271,7 @@ TEST_CASE("evaluate_pals_expression: particle-data functions from libapc",
     // neutral; the ionised form carries the charge.
     REQUIRE(eval_ok("charge_of(\"#3He\")") == 0.0);
     REQUIRE(eval_ok("charge_of(\"helion\")") == 2.0);
-    REQUIRE(close(eval_ok("mass_of(\"#3He\")"), 2809413524.398952));
+    REQUIRE(close(eval_ok("mass_of(\"#3He\")"), 2809413528.3197904));
 
     // An unquoted species name is an error.
     bool ok = true;
@@ -1525,7 +1532,7 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(lat.expanded != nullptr);
 
-    const double m_3he = 2809413524.398952;  // mass_of("#3He"), CODATA 2022
+    const double m_3he = 2809413528.3197904;  // mass_of("#3He"), CODATA 2022
 
     YAMLNodeId consts = facility_param(lat.expanded, "constants");
     REQUIRE(close(num_val(lat.expanded,


### PR DESCRIPTION
Follows [AtomicAndPhysicalConstantsCLib#4](https://github.com/pals-project/AtomicAndPhysicalConstantsCLib/pull/4), which re-ported that mirror from APC v0.9 to **APC v0.11.1**.

## Pin instead of tracking `main`

The `apc` dependency used `GIT_TAG main`, so an upstream push could change the numbers under our tests with no change in this repo — CI could go red without anyone touching pals-cpp. The reference values here are tied to a specific APC release, so the tag is now pinned. `apc`'s version tracks the APC release it mirrors: **v0.11.1 is the C++ view of AtomicAndPhysicalConstants.jl v0.11.1**.

## Reference values that moved

The v0.11.1 re-port changes two values used here:

- **`epsilon_0` and `mu_0`** are now expressed in the PALS standard's eV units — `1/(eV*m)` and `eV*sec^2/m`, not the SI `F/m` and `N/A^2`. Both are checked, along with the identity `eps_0 * mu_0 * c^2 == 1`, which pins them against each other rather than trusting two independent literals.
- **`mass_of("#3He")`** moves in the 8th digit (`2809413524.398952` to `2809413528.3197904`), following `EV_PER_AMU`'s CODATA update.

Nothing else in the suite depends on a value the re-port touched. In particular pals-cpp never asks for an atom's `anomalous_moment_of`, which now returns NaN upstream.

## Checks

Verified with a clean configure that has no `FETCHCONTENT_SOURCE_DIR_APC` override, so it resolves the pinned tag exactly as CI does: it fetches `73b1d58` (apc v0.11.1) and all **89 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
