### PR TITLE
Split the expanded tree into expanded + leftover

### DIFF
--- a/docs/src/guide/usage.md
+++ b/docs/src/guide/usage.md
@@ -20,9 +20,10 @@ tests. Put lattice files under `lattice_files/`.
 ## Expanding a lattice
 
 `parse_and_expand_PALS` reads a lattice file, resolves its includes, expands the
-selected lattice, and returns a `lattices` struct with three independent views —
-`original`, `combined`, and `expanded` (see [What it does](../index.md)). Each is
-a `YAMLTreeHandle` and must be freed with `delete_tree`.
+selected lattice, and returns a `lattices` struct with four independent views —
+`original`, `combined`, `expanded`, and `leftover` (see
+[What it does](../index.md)). Each is a `YAMLTreeHandle` and must be freed with
+`delete_tree`.
 
 ```cpp
 #include "yaml_c_wrapper.h"
@@ -41,6 +42,7 @@ free_lattice_problems(lat.problems);
 delete_tree(lat.original);
 delete_tree(lat.combined);
 delete_tree(lat.expanded);
+delete_tree(lat.leftover);
 ```
 
 The second argument names the lattice to expand. Pass `nullptr` (or an empty
@@ -72,7 +74,7 @@ and `deep_copy_children`. Serialize with `node_to_string` / `tree_to_string`, or
 
 Two more entry points build on the expanded tree:
 
-- `build_correspondence_map` links a node across the three views (their
+- `build_correspondence_map` links a node across the four views (their
   provenance is recorded as the trees are derived from one another).
 - `match_names` finds every named construct that a PALS *Name Matching* string
   refers to.
@@ -88,7 +90,7 @@ The `examples/` directory contains runnable programs:
   ./example_rw
   ```
 
-- **`examples/print_lattices`** — expand a lattice and print all three views. It
+- **`examples/print_lattices`** — expand a lattice and print all four views. It
   takes a file name and an optional `-lat <name>` flag:
 
   ```console

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,17 +25,22 @@ api
 
 ## What it does
 
-Lattice expansion follows the PALS specification and produces three views of a
+Lattice expansion follows the PALS specification and produces four views of a
 document:
 
 1. **`original`** — the raw tree mapping each file (including `include`d files)
    to its unparsed contents.
 2. **`combined`** — the tree with every `include` directive resolved and spliced
    inline.
-3. **`expanded`** — the selected lattice fully expanded: elements substituted
-   with their definitions, `repeat`ed beamlines unrolled, `inherit`ed ancestors
-   merged, forks resolved, and every mathematical expression evaluated to a
-   number.
+3. **`expanded`** — the selected lattice fully expanded, and nothing else:
+   elements substituted with their definitions, `repeat`ed beamlines unrolled,
+   `inherit`ed ancestors merged, forks resolved, and every mathematical
+   expression evaluated to a number. It is rooted at the lattice entry itself,
+   without the `PALS`/`facility` scaffolding it was defined under.
+4. **`leftover`** — everything the expanded tree does not carry, keeping that
+   scaffolding: element and beamline definitions, `use` statements, constants,
+   controllers, and any lattice that was not the one expanded. A definition
+   substituted into the lattice is copied, so it appears in both views.
 
 See [Building and using the library](guide/usage.md) to get started,
 [Evaluating expressions](guide/expressions.md) for the expression grammar and

--- a/examples/print_lattices.cpp
+++ b/examples/print_lattices.cpp
@@ -38,6 +38,9 @@ int main(int argc, char* argv[]) {
     std::cout << tree_to_string(lat.combined) << std::endl << "\n\n";
 
     std::cout << "========== Printing expanded lattice ==========" << std::endl;
-    std::cout << tree_to_string(lat.expanded) << std::endl;
+    std::cout << tree_to_string(lat.expanded) << std::endl << "\n\n";
+
+    std::cout << "========== Printing leftover ==========" << std::endl;
+    std::cout << tree_to_string(lat.leftover) << std::endl;
     return 0;
 }

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -26,11 +26,11 @@
 // size_t within its tree.
 //
 // `provenance` links this tree back to the one it was derived from in the
-// original->combined->expanded chain: it maps a node id in *this* tree to the
-// node id in the *source* tree it was copied from. It is empty for trees that
-// are not derived from another (e.g. `original`). For `combined` it maps
-// combined ids -> original ids; for `expanded` it maps expanded ids ->
-// combined ids.
+// original -> combined -> (expanded, leftover) chain: it maps a node id in
+// *this* tree to the node id in the *source* tree it was copied from. It is
+// empty for trees that are not derived from another (e.g. `original`). For
+// `combined` it maps combined ids -> original ids; for `expanded` and
+// `leftover` alike it maps their ids -> combined ids.
 struct ParsedData {
     ryml::Tree tree;
     std::string buffer;
@@ -98,14 +98,18 @@ static void deep_copy_recursive(ryml::Tree& dst_t, size_t dst_node,
 //
 // These mirror the plain copy/duplicate routines but record, for every node
 // they create, which source node it came from. The recorded map (`prov`) is
-// what lets build_correspondence_map() link a node across the three trees.
+// what lets build_correspondence_map() link a node across the four trees.
 
 // Cross-tree deep copy (like deep_copy_recursive) that records
 // prov[dst_node] = src_node for every copied node. The destination root keeps
-// no key even if src_node has one (a tree root cannot be keyed).
-static void deep_copy_tracked(ryml::Tree& dst_t, size_t dst_node,
-                              const ryml::Tree& src_t, size_t src_node,
-                              std::map<size_t, size_t>& prov) {
+// no key even if src_node has one (a tree root cannot be keyed). `skip` names a
+// source node to leave out along with its descendants (ryml::NONE copies
+// everything); it is how the leftover tree is built as the document minus the
+// lattice that went into the expanded tree.
+static void deep_copy_tracked_except(ryml::Tree& dst_t, size_t dst_node,
+                                     const ryml::Tree& src_t, size_t src_node,
+                                     size_t skip,
+                                     std::map<size_t, size_t>& prov) {
     prov[dst_node] = src_node;
 
     // Copy type flags (MAP, SEQ, VAL, KEY). A tree root cannot carry a key, so
@@ -123,7 +127,7 @@ static void deep_copy_tracked(ryml::Tree& dst_t, size_t dst_node,
     std::vector<size_t> src_children;
     for (size_t c = src_t.first_child(src_node); c != ryml::NONE;
          c = src_t.next_sibling(c))
-        src_children.push_back(c);
+        if (c != skip) src_children.push_back(c);
 
     std::vector<size_t> dst_children;
     for (size_t i = 0; i < src_children.size(); i++) {
@@ -131,7 +135,34 @@ static void deep_copy_tracked(ryml::Tree& dst_t, size_t dst_node,
         dst_children.push_back(dst_t.append_child(dst_node));
     }
     for (size_t i = 0; i < src_children.size(); i++)
-        deep_copy_tracked(dst_t, dst_children[i], src_t, src_children[i], prov);
+        deep_copy_tracked_except(dst_t, dst_children[i], src_t, src_children[i],
+                                 skip, prov);
+}
+
+static void deep_copy_tracked(ryml::Tree& dst_t, size_t dst_node,
+                              const ryml::Tree& src_t, size_t src_node,
+                              std::map<size_t, size_t>& prov) {
+    deep_copy_tracked_except(dst_t, dst_node, src_t, src_node, ryml::NONE, prov);
+}
+
+// Rewrite `prov` (ids -> ids in some intermediate tree) so that it points at
+// whatever that intermediate tree was itself derived from, using its own
+// provenance. This is what lets `expanded` and `leftover` be cut out of the
+// temporary work tree and still record provenance straight back to `combined`:
+// the work tree is discarded, so links through it would dangle. Nodes with no
+// entry in `via` (created during expansion, e.g. `fork_pointer`) have no source
+// and drop out.
+static void chain_prov(std::map<size_t, size_t>& prov,
+                       const std::map<size_t, size_t>& via) {
+    for (auto it = prov.begin(); it != prov.end();) {
+        auto up = via.find(it->second);
+        if (up == via.end()) {
+            it = prov.erase(it);
+        } else {
+            it->second = up->second;
+            ++it;
+        }
+    }
 }
 
 // Remove every entry for `node` and its descendants from `prov`. Call this
@@ -1158,40 +1189,133 @@ static void evaluate_expressions(ryml::Tree& t, ProblemList& problems) {
     substitute_values(t, t.root_id(), *resolve, species, problems);
 }
 
-static YAMLTreeHandle make_expanded_from_combined(ParsedData* comb,
-                                                  const char* root_lattice,
-                                                  ProblemList& problems) {
-    if (!comb) return nullptr;
-    ParsedData* data = new ParsedData();
-    ryml::Tree& t = data->tree;
+// Rewrite the `fork_pointer` scalars of a freshly split-out tree. handle_fork
+// stores the raw node id of the fork's destination element, but it runs while
+// expansion is still on the work tree; cutting the lattice out into its own tree
+// renumbers every node, so each pointer has to be translated to the id its
+// target now carries. `from_work` maps work ids to ids in `t`. A pointer whose
+// target did not come across (it should always be inside the lattice) is left
+// alone and reported.
+static void remap_fork_pointers(ryml::Tree& t, size_t node,
+                                const std::map<size_t, size_t>& from_work,
+                                ProblemList& problems) {
+    if (node == ryml::NONE) return;
+
+    if (t.has_key(node) && t.key(node) == ryml::to_csubstr("fork_pointer") &&
+        t.has_val(node)) {
+        std::string old(t.val(node).str, t.val(node).len);
+        size_t target = 0;
+        try {
+            target = static_cast<size_t>(std::stoull(old));
+        } catch (...) {
+            return;
+        }
+        auto it = from_work.find(target);
+        if (it == from_work.end()) {
+            add_problem(problems,
+                        "fork_pointer target is outside the expanded lattice");
+            return;
+        }
+        std::string id_str = std::to_string(it->second);
+        t.set_val(node, t.to_arena(ryml::to_csubstr(id_str)));
+    }
+
+    for (size_t c = t.first_child(node); c != ryml::NONE; c = t.next_sibling(c))
+        remap_fork_pointers(t, c, from_work, problems);
+}
+
+// Builds the `expanded` and `leftover` trees from `combined`.
+//
+// Expansion has to run on the whole document at once — the lattice pulls in
+// element and beamline definitions from the rest of the file — so it happens on
+// a single throwaway work tree, which is then cut in two: `expanded` takes the
+// root lattice and nothing else, `leftover` takes everything the lattice left
+// behind. Both record provenance straight back to `combined`, so the work tree
+// can be discarded.
+static void make_expanded_and_leftover(ParsedData* comb,
+                                       const char* root_lattice,
+                                       ProblemList& problems,
+                                       YAMLTreeHandle& expanded_out,
+                                       YAMLTreeHandle& leftover_out) {
+    expanded_out = nullptr;
+    leftover_out = nullptr;
+    if (!comb) return;
+
+    ParsedData work;
+    ryml::Tree& t = work.tree;
     t.reserve(t.capacity() + comb->tree.capacity() + 10000);
     t.reserve_arena(t.arena_capacity() + comb->tree.arena_capacity() + 100000);
 
-    // Start expanded as a full copy of combined, recording expanded->combined
-    // provenance for every node.
+    // Start from a full copy of combined, recording work->combined provenance
+    // for every node.
     deep_copy_tracked(t, t.root_id(), comb->tree, comb->tree.root_id(),
-                      data->provenance);
+                      work.provenance);
 
     std::map<std::string, size_t> emap;
     make_ele_map(emap, t, t.root_id());
 
     std::string name_str = root_lattice ? root_lattice : "";
     size_t lat_node = find_lattice(t, name_str);
+
+    // `skip` is the node the leftover tree must not copy: the lattice, together
+    // with the facility list entry wrapping it, so leftover is not left holding
+    // an empty entry. A lattice that is not a lone entry under a wrapper (e.g.
+    // one keyed directly into a map) is skipped on its own.
+    size_t skip = ryml::NONE;
+
     if (lat_node == ryml::NONE) {
         add_problem(problems, name_str.empty()
                                   ? "no lattice found to expand"
                                   : "lattice '" + name_str + "' not found");
-        return data;
+    } else {
+        size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
+        expand(t, lat_node, emap, work.provenance, problems, branches);
+
+        // Evaluate every mathematical expression to a number (immediate and
+        // expr()-delayed alike). Node ids are unchanged -- only scalar text is
+        // rewritten -- so provenance stays valid.
+        evaluate_expressions(t, problems);
+
+        size_t wrapper = t.parent(lat_node);
+        skip = (wrapper != ryml::NONE && !t.is_root(wrapper) &&
+                t.num_children(wrapper) == 1)
+                   ? wrapper
+                   : lat_node;
     }
-    size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
 
-    expand(t, lat_node, emap, data->provenance, problems, branches);
+    // expanded: a map holding just the lattice entry, keyed by its name. The
+    // root is synthesised (a ryml root cannot itself carry a key), so it has no
+    // counterpart in combined and no provenance entry. When no lattice was
+    // found the tree stays an empty map.
+    ParsedData* exp = new ParsedData();
+    exp->tree.reserve(exp->tree.capacity() + t.capacity() + 16);
+    exp->tree.reserve_arena(exp->tree.arena_capacity() + t.arena_capacity());
+    exp->tree.ref(exp->tree.root_id()) |= ryml::MAP;
+    if (lat_node != ryml::NONE) {
+        ensure_capacity(exp->tree);
+        size_t entry = exp->tree.append_child(exp->tree.root_id());
+        deep_copy_tracked(exp->tree, entry, t, lat_node, exp->provenance);
 
-    // Final pass: evaluate every mathematical expression in the expanded tree
-    // to a number (immediate and expr()-delayed alike). Node ids are unchanged
-    // -- only scalar text is rewritten -- so provenance stays valid.
-    evaluate_expressions(t, problems);
-    return data;
+        // Before provenance is chained up to combined it still reads
+        // expanded->work, which inverts into exactly the renaming the fork
+        // pointers need.
+        std::map<size_t, size_t> from_work;
+        for (const auto& kv : exp->provenance) from_work[kv.second] = kv.first;
+        remap_fork_pointers(exp->tree, exp->tree.root_id(), from_work, problems);
+
+        chain_prov(exp->provenance, work.provenance);
+    }
+
+    // leftover: the whole document minus what went to expanded.
+    ParsedData* left = new ParsedData();
+    left->tree.reserve(left->tree.capacity() + t.capacity() + 16);
+    left->tree.reserve_arena(left->tree.arena_capacity() + t.arena_capacity());
+    deep_copy_tracked_except(left->tree, left->tree.root_id(), t, t.root_id(),
+                             skip, left->provenance);
+    chain_prov(left->provenance, work.provenance);
+
+    expanded_out = exp;
+    leftover_out = left;
 }
 
 /**
@@ -1525,13 +1649,15 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
                                       const char* root_lattice) {
     struct lattices lat = {};
     // Built as a derivation chain so provenance can be recorded at each step:
-    //   original --(splice includes)--> combined --(expand)--> expanded
+    //   original --(splice includes)--> combined --(expand, split)--> expanded
+    //                                                              \-> leftover
     lat.original = make_original(filename);
     lat.combined = make_combined_from_original(
         static_cast<ParsedData*>(lat.original), filename);
     ProblemList problems;
-    lat.expanded = make_expanded_from_combined(
-        static_cast<ParsedData*>(lat.combined), root_lattice, problems);
+    make_expanded_and_leftover(static_cast<ParsedData*>(lat.combined),
+                               root_lattice, problems, lat.expanded,
+                               lat.leftover);
 
     // Hand the problem list to the caller as an owning C string array (freed
     // with free_lattice_problems). The library never prints — the caller
@@ -1564,43 +1690,55 @@ YAML_API double evaluate_pals_expression(const char* expr, bool* ok) {
 }
 
 YAML_API struct correspondence_map build_correspondence_map(
-    YAMLTreeHandle original, YAMLTreeHandle combined, YAMLTreeHandle expanded) {
-    (void)original;  // provenance is stored in combined & expanded
+    YAMLTreeHandle original, YAMLTreeHandle combined, YAMLTreeHandle expanded,
+    YAMLTreeHandle leftover) {
+    (void)original;  // provenance is stored in combined, expanded & leftover
     struct correspondence_map out = {nullptr, 0};
-    if (!combined || !expanded) return out;
+    if (!combined || (!expanded && !leftover)) return out;
 
     ParsedData* comb = static_cast<ParsedData*>(combined);
-    ParsedData* exp = static_cast<ParsedData*>(expanded);
-    const std::map<size_t, size_t>& e2c = exp->provenance;   // expanded->combined
     const std::map<size_t, size_t>& c2o = comb->provenance;  // combined->original
-    ryml::Tree& et = exp->tree;
 
-    // Emit one link per node of the expanded tree, walking it from the root so
-    // that exactly the live nodes are visited.
     std::vector<struct node_link> links;
-    std::vector<size_t> stack;
-    if (et.root_id() != ryml::NONE) stack.push_back(et.root_id());
-    while (!stack.empty()) {
-        size_t n = stack.back();
-        stack.pop_back();
 
-        struct node_link link;
-        link.expanded = n;
-        auto ec = e2c.find(n);
-        if (ec != e2c.end()) {
-            link.combined = ec->second;
-            auto co = c2o.find(ec->second);
-            link.original = (co != c2o.end()) ? co->second : YAML_NULL_ID;
-        } else {
-            link.combined = YAML_NULL_ID;
-            link.original = YAML_NULL_ID;
+    // Emit one link per node of a derived tree, walking it from the root so that
+    // exactly the live nodes are visited. Expansion splits the document in two,
+    // so a link names a node in one derived tree and YAML_NULL_ID in the other;
+    // the shared combined id is what ties the two sides together.
+    auto walk = [&](YAMLTreeHandle handle, bool is_leftover) {
+        if (!handle) return;
+        ParsedData* pd = static_cast<ParsedData*>(handle);
+        const std::map<size_t, size_t>& d2c = pd->provenance;  // derived->combined
+        ryml::Tree& dt = pd->tree;
+
+        std::vector<size_t> stack;
+        if (dt.root_id() != ryml::NONE) stack.push_back(dt.root_id());
+        while (!stack.empty()) {
+            size_t n = stack.back();
+            stack.pop_back();
+
+            struct node_link link;
+            link.expanded = is_leftover ? YAML_NULL_ID : n;
+            link.leftover = is_leftover ? n : YAML_NULL_ID;
+            auto dc = d2c.find(n);
+            if (dc != d2c.end()) {
+                link.combined = dc->second;
+                auto co = c2o.find(dc->second);
+                link.original = (co != c2o.end()) ? co->second : YAML_NULL_ID;
+            } else {
+                link.combined = YAML_NULL_ID;
+                link.original = YAML_NULL_ID;
+            }
+            links.push_back(link);
+
+            for (size_t c = dt.first_child(n); c != ryml::NONE;
+                 c = dt.next_sibling(c))
+                stack.push_back(c);
         }
-        links.push_back(link);
+    };
 
-        for (size_t c = et.first_child(n); c != ryml::NONE;
-             c = et.next_sibling(c))
-            stack.push_back(c);
-    }
+    walk(expanded, false);
+    walk(leftover, true);
 
     out.count = links.size();
     if (out.count > 0) {

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -45,7 +45,14 @@ struct lattices {
                               // to its unparsed contents
     YAMLTreeHandle combined;  // Tree with all "include" directives resolved and
                               // spliced inline
-    YAMLTreeHandle expanded;  // Tree with the selected lattice fully expanded
+    YAMLTreeHandle expanded;  // The expanded root lattice, and nothing else: a
+                              // map holding the single `name: {kind: Lattice,
+                              // ...}` entry, without the PALS/facility
+                              // scaffolding it was defined under
+    YAMLTreeHandle leftover;  // Everything the expanded tree does not carry —
+                              // the whole PALS/facility document minus the root
+                              // lattice, so element/beamline definitions, `use`
+                              // statements, constants and any non-root Lattice
     struct string_list problems;  // Problems found while building `expanded`;
                                   // free with free_lattice_problems()
 };
@@ -53,25 +60,32 @@ struct lattices {
 
 // --- CORRESPONDENCE MAP ---
 //
-// Links a node across the three representations produced by
-// parse_and_expand_PALS(). The three trees are built as a derivation chain
-// (original -> combined -> expanded), and provenance is recorded at every copy,
-// so each link records which node in each tree a single logical entity maps to.
+// Links a node across the representations produced by parse_and_expand_PALS().
+// The trees are built as a derivation chain (original -> combined -> expanded
+// and leftover), and provenance is recorded at every copy, so each link records
+// which node in each tree a single logical entity maps to.
 //
-// The mapping is functional per link: one expanded node maps to at most one
-// combined node, which maps to at most one original node. Because expansion can
-// duplicate nodes (scalar substitution, `repeat`, `inherit`, forks), a single
-// combined/original node may appear in several links — one per expanded copy.
-// A field is YAML_NULL_ID when no corresponding node exists (e.g. the
+// The mapping is functional per link: one expanded (or leftover) node maps to at
+// most one combined node, which maps to at most one original node. Because
+// expansion can duplicate nodes (scalar substitution, `repeat`, `inherit`,
+// forks), a single combined/original node may appear in several links — one per
+// copy. A field is YAML_NULL_ID when no corresponding node exists (e.g. the
 // `fork_pointer` scalars synthesised during expansion have no original source).
+//
+// Expansion splits the document, so a link carries either an `expanded` id or a
+// `leftover` id, never both; the two are tied together through the `combined`
+// id they share. A definition that was substituted into the lattice therefore
+// yields links on both sides: one for the copy in `expanded`, one for the
+// definition still standing in `leftover`.
 struct node_link {
     YAMLNodeId original;
     YAMLNodeId combined;
     YAMLNodeId expanded;
+    YAMLNodeId leftover;
 };
 
-// A flat list of node_links. One link is emitted per node of the expanded tree.
-// Free with free_correspondence_map().
+// A flat list of node_links. One link is emitted per node of the expanded tree
+// and one per node of the leftover tree. Free with free_correspondence_map().
 struct correspondence_map {
     struct node_link* links;
     size_t count;
@@ -92,7 +106,7 @@ extern "C" {
 #endif
 
 /**
- * Builds and returns all three representations of a lattice file.
+ * Builds and returns all four representations of a lattice file.
  *
  * @param filename     Path to the top-level YAML lattice file.
  * @param root_lattice Name of the lattice to expand. If NULL or empty:
@@ -100,14 +114,20 @@ extern "C" {
  * statement, or
  *                       - expands the last lattice defined in the file if no
  * "use" is present.
- * @return A `lattices` struct containing three handles:
+ * @return A `lattices` struct containing four handles:
  *           - `original`: raw tree mapping each file (including includes) to
  * its unparsed contents.
  *           - `combined`: tree with all "include" directives resolved and
  * spliced inline.
- *           - `expanded`: tree with the selected lattice fully expanded —
- * scalars substituted, repeats unrolled, inherits merged, and forks resolved.
- *         All three handles must be freed individually with delete_tree().
+ *           - `expanded`: the selected lattice fully expanded — scalars
+ * substituted, repeats unrolled, inherits merged, and forks resolved — and
+ * nothing else. Rooted at a map holding the single `name: {kind: Lattice, ...}`
+ * entry, stripped of the PALS/facility scaffolding it was defined under.
+ *           - `leftover`: the rest of the document, keeping its PALS/facility
+ * scaffolding: element and beamline definitions, `use` statements, constants,
+ * and any Lattice that was not the one expanded. Definitions substituted into
+ * the lattice are copies, so they appear in both trees.
+ *         All four handles must be freed individually with delete_tree().
  *
  *         The returned struct also carries `problems`: an owning list of
  *         human-readable messages for every issue met while building the
@@ -153,28 +173,32 @@ YAML_API void free_lattice_problems(struct string_list problems);
 YAML_API double evaluate_pals_expression(const char* expr, bool* ok);
 
 /**
- * Builds the node correspondence between the three trees of a `lattices` value.
+ * Builds the node correspondence between the four trees of a `lattices` value.
  *
  * Returns a flat list containing one `node_link` per node of the `expanded`
- * tree. Each link gives the corresponding `combined` and `original` node ids
- * (or YAML_NULL_ID where none exists). Grouping the links by shared combined /
- * original ids recovers, for any node in any of the three trees, the set of
- * nodes it corresponds to in the other two.
+ * tree and one per node of the `leftover` tree. Each link gives the
+ * corresponding `combined` and `original` node ids (or YAML_NULL_ID where none
+ * exists). Grouping the links by shared combined / original ids recovers, for
+ * any node in any of the four trees, the set of nodes it corresponds to in the
+ * others.
  *
- * The three handles must come from the same parse_and_expand_PALS() call — the
+ * The handles must come from the same parse_and_expand_PALS() call — the
  * provenance recorded during that call is what makes the mapping exact. The
  * `original` handle is accepted for API symmetry; the mapping is derived from
- * the provenance stored in `combined` and `expanded`.
+ * the provenance stored in `combined`, `expanded` and `leftover`.
  *
  * @param original Handle to the `original` tree.
  * @param combined Handle to the `combined` tree.
  * @param expanded Handle to the `expanded` tree.
+ * @param leftover Handle to the `leftover` tree. May be NULL, in which case only
+ *                 the expanded tree is walked.
  * @return A correspondence_map. The caller must free it with
  *         free_correspondence_map(). `links` is NULL and `count` is 0 if
- *         `combined` or `expanded` is NULL.
+ *         `combined` is NULL, or if both `expanded` and `leftover` are NULL.
  */
 YAML_API struct correspondence_map build_correspondence_map(
-    YAMLTreeHandle original, YAMLTreeHandle combined, YAMLTreeHandle expanded);
+    YAMLTreeHandle original, YAMLTreeHandle combined, YAMLTreeHandle expanded,
+    YAMLTreeHandle leftover);
 
 /**
  * Frees the link array owned by a correspondence_map. Passing a map with a NULL

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -629,14 +629,113 @@ TEST_CASE("Cloning via deep_copy_node produces an independent copy", "[copy]") {
 // parse_and_expand_PALS (smoke test — requires the example lattice files)
 // ============================================================
 
-TEST_CASE("parse_and_expand_PALS returns three non-null handles", "[lattices]") {
+// Helper: navigate root -> PALS -> facility for a given tree.
+static YAMLNodeId facility_of(YAMLTreeHandle t) {
+    YAMLNodeId pals = get_child_by_key(t, get_root(t), "PALS");
+    return get_child_by_key(t, pals, "facility");
+}
+
+TEST_CASE("parse_and_expand_PALS returns four non-null handles", "[lattices]") {
     struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", nullptr);
     REQUIRE(lat.original != nullptr);
     REQUIRE(lat.combined != nullptr);
     REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.leftover != nullptr);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+// The expanded tree holds the root lattice and nothing else: no PALS/facility
+// wrapper, and only the one entry.
+TEST_CASE("expanded holds only the root lattice", "[lattices]") {
+    struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", "lat1");
+    YAMLNodeId root = get_root(lat.expanded);
+
+    REQUIRE(is_map(lat.expanded, root));
+    REQUIRE(get_size(lat.expanded, root) == 1);
+    REQUIRE(get_child_by_key(lat.expanded, root, "PALS") == YAML_NULL_ID);
+
+    YAMLNodeId entry = get_child_by_index(lat.expanded, root, 0);
+    char* key = get_node_key(lat.expanded, entry);
+    REQUIRE(std::string(key) == "lat1");
+    yaml_free_string(key);
+    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, entry, "kind"),
+                   "Lattice"));
+
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    free_lattice_problems(lat.problems);
+}
+
+// Everything else stays behind, under its PALS/facility scaffolding — including
+// the lattice that was not expanded.
+TEST_CASE("leftover keeps the rest of the document", "[lattices]") {
+    struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", "lat1");
+    YAMLNodeId fac = facility_of(lat.leftover);
+    REQUIRE(fac != YAML_NULL_ID);
+
+    bool saw_lat1 = false, saw_lat2 = false, saw_thingB = false;
+    for (size_t i = 0; i < get_size(lat.leftover, fac); i++) {
+        YAMLNodeId item = get_child_by_index(lat.leftover, fac, i);
+        if (get_size(lat.leftover, item) != 1) continue;
+        char* key = get_node_key(lat.leftover,
+                                 get_child_by_index(lat.leftover, item, 0));
+        std::string k(key ? key : "");
+        yaml_free_string(key);
+        if (k == "lat1") saw_lat1 = true;
+        if (k == "lat2") saw_lat2 = true;
+        if (k == "thingB") saw_thingB = true;
+    }
+
+    REQUIRE_FALSE(saw_lat1);  // moved to expanded
+    REQUIRE(saw_lat2);        // a non-root Lattice is leftover like anything else
+    REQUIRE(saw_thingB);      // element definitions stay put
+
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    free_lattice_problems(lat.problems);
+}
+
+// handle_fork writes the raw node id of the fork's destination element. That id
+// is assigned before the lattice is cut out into its own tree, so it must be
+// translated to survive the renumbering.
+TEST_CASE("fork_pointer resolves inside the expanded tree", "[lattices]") {
+    struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", "lat1");
+
+    // Find the fork_pointer scalar anywhere in the expanded tree.
+    YAMLNodeId fp = YAML_NULL_ID;
+    std::vector<YAMLNodeId> stack{get_root(lat.expanded)};
+    while (!stack.empty()) {
+        YAMLNodeId n = stack.back();
+        stack.pop_back();
+        char* key = get_node_key(lat.expanded, n);
+        if (key && std::string(key) == "fork_pointer") fp = n;
+        yaml_free_string(key);
+        for (size_t i = 0; i < get_size(lat.expanded, n); i++)
+            stack.push_back(get_child_by_index(lat.expanded, n, i));
+    }
+    REQUIRE(fp != YAML_NULL_ID);
+
+    char* val = as_string(lat.expanded, fp);
+    YAMLNodeId target = (YAMLNodeId)std::stoull(val);
+    yaml_free_string(val);
+
+    // It names the fork's destination_element in the branch expansion created.
+    char* dest = as_string(lat.expanded, target);
+    REQUIRE(std::string(dest) == "dump_begin");
+    yaml_free_string(dest);
+
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    free_lattice_problems(lat.problems);
 }
 
 // ============================================================
@@ -644,28 +743,28 @@ TEST_CASE("parse_and_expand_PALS returns three non-null handles", "[lattices]") 
 // ============================================================
 
 TEST_CASE("build_correspondence_map is empty for null handles", "[correspondence]") {
-    struct correspondence_map m = build_correspondence_map(nullptr, nullptr, nullptr);
+    struct correspondence_map m = build_correspondence_map(nullptr, nullptr, nullptr, nullptr);
     REQUIRE(m.count == 0);
     REQUIRE(m.links == nullptr);
     free_correspondence_map(m);  // must not crash
 }
 
-TEST_CASE("build_correspondence_map links the three tree roots", "[correspondence]") {
+TEST_CASE("build_correspondence_map links the document roots", "[correspondence]") {
     struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", nullptr);
     struct correspondence_map m =
-        build_correspondence_map(lat.original, lat.combined, lat.expanded);
+        build_correspondence_map(lat.original, lat.combined, lat.expanded,
+                                 lat.leftover);
 
     REQUIRE(m.count > 0);
 
-    // One link is emitted per expanded node, so the count matches the number
-    // of nodes reachable from the expanded root.
-    YAMLNodeId exp_root = get_root(lat.expanded);
+    // leftover is what still carries the document root, so that is the node
+    // corresponding to the combined root. (The expanded root is synthesised to
+    // hold the lattice entry and has no counterpart — see below.)
+    YAMLNodeId left_root = get_root(lat.leftover);
 
-    // Find the link for the expanded root and verify it points at the combined
-    // root and at the top-level file's entry in the original tree.
     bool found_root = false;
     for (size_t i = 0; i < m.count; i++) {
-        if (m.links[i].expanded == exp_root) {
+        if (m.links[i].leftover == left_root) {
             found_root = true;
             REQUIRE(m.links[i].combined == get_root(lat.combined));
             // The original tree's first child is the top-level file's contents.
@@ -674,8 +773,9 @@ TEST_CASE("build_correspondence_map links the three tree roots", "[correspondenc
             REQUIRE(is_map(lat.combined, m.links[i].combined));
             REQUIRE(is_map(lat.original, m.links[i].original));
         }
-        // Every emitted link has a valid expanded node.
-        REQUIRE(m.links[i].expanded != YAML_NULL_ID);
+        // A link names a node in exactly one of the two derived trees.
+        REQUIRE((m.links[i].expanded == YAML_NULL_ID) !=
+                (m.links[i].leftover == YAML_NULL_ID));
     }
     REQUIRE(found_root);
 
@@ -683,18 +783,46 @@ TEST_CASE("build_correspondence_map links the three tree roots", "[correspondenc
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
 }
 
-// Helper: navigate root -> PALS -> facility for a given tree.
-static YAMLNodeId facility_of(YAMLTreeHandle t) {
-    YAMLNodeId pals = get_child_by_key(t, get_root(t), "PALS");
-    return get_child_by_key(t, pals, "facility");
+// A definition that expansion substituted into the lattice is a copy: the
+// definition still stands in leftover, so the same combined node reaches both
+// trees.
+TEST_CASE("build_correspondence_map ties the two trees through combined",
+          "[correspondence]") {
+    struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", "lat1");
+    struct correspondence_map m =
+        build_correspondence_map(lat.original, lat.combined, lat.expanded,
+                                 lat.leftover);
+
+    // inj_line is defined at facility level and used by lat1's branches, so it
+    // is expanded into lat1 while its definition stays in leftover.
+    std::map<YAMLNodeId, int> sides;  // combined id -> bitmask of trees reached
+    for (size_t i = 0; i < m.count; i++) {
+        if (m.links[i].combined == YAML_NULL_ID) continue;
+        sides[m.links[i].combined] |=
+            (m.links[i].expanded != YAML_NULL_ID) ? 1 : 2;
+    }
+
+    bool found_both = false;
+    for (const auto& kv : sides)
+        if (kv.second == 3) found_both = true;
+    REQUIRE(found_both);
+
+    free_correspondence_map(m);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    free_lattice_problems(lat.problems);
 }
 
 TEST_CASE("build_correspondence_map connects a node across trees by value",
           "[correspondence]") {
-    // A constant that lives outside the expanded lattice appears, unchanged,
-    // in all three trees; the map must connect the three copies.
+    // A constant that lives outside the expanded lattice is not part of it, so
+    // it lands in leftover; the map must still connect it back to combined and
+    // original.
     const char* path = "tmp_corr.pals.yaml";
     write_tmp(path,
               "PALS:\n"
@@ -716,20 +844,21 @@ TEST_CASE("build_correspondence_map connects a node across trees by value",
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     struct correspondence_map m =
-        build_correspondence_map(lat.original, lat.combined, lat.expanded);
+        build_correspondence_map(lat.original, lat.combined, lat.expanded,
+                                 lat.leftover);
 
-    // Locate a_const in the expanded tree: facility[0] -> constants -> a_const.
-    YAMLNodeId e_const = get_child_by_index(lat.expanded, facility_of(lat.expanded), 0);
-    YAMLNodeId e_a_const =
-        get_child_by_key(lat.expanded,
-                         get_child_by_key(lat.expanded, e_const, "constants"),
+    // Locate a_const in the leftover tree: facility[0] -> constants -> a_const.
+    YAMLNodeId l_const = get_child_by_index(lat.leftover, facility_of(lat.leftover), 0);
+    YAMLNodeId l_a_const =
+        get_child_by_key(lat.leftover,
+                         get_child_by_key(lat.leftover, l_const, "constants"),
                          "a_const");
-    REQUIRE(e_a_const != YAML_NULL_ID);
-    // The expanded tree has its expressions evaluated, so this constant now
-    // holds a number; the combined/original copies (checked below) still carry
-    // the original expression text.
+    REQUIRE(l_a_const != YAML_NULL_ID);
+    // Expressions are evaluated across the whole document before it is split, so
+    // this constant holds a number in leftover too; the combined/original copies
+    // (checked below) still carry the original expression text.
     {
-        char* s = as_string(lat.expanded, e_a_const);
+        char* s = as_string(lat.leftover, l_a_const);
         REQUIRE(s != nullptr);
         double got = std::strtod(s, nullptr);
         yaml_free_string(s);
@@ -742,8 +871,9 @@ TEST_CASE("build_correspondence_map connects a node across trees by value",
     // Find its link and follow it to the combined and original copies.
     bool found = false;
     for (size_t i = 0; i < m.count; i++) {
-        if (m.links[i].expanded != e_a_const) continue;
+        if (m.links[i].leftover != l_a_const) continue;
         found = true;
+        REQUIRE(m.links[i].expanded == YAML_NULL_ID);
         REQUIRE(m.links[i].combined != YAML_NULL_ID);
         REQUIRE(m.links[i].original != YAML_NULL_ID);
         REQUIRE(val_eq(lat.combined, m.links[i].combined, "0.3 * r_electron"));
@@ -755,6 +885,7 @@ TEST_CASE("build_correspondence_map connects a node across trees by value",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
     rm_tmp(path);
 }
 
@@ -786,7 +917,8 @@ TEST_CASE("build_correspondence_map maps one source to many expanded copies",
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     struct correspondence_map m =
-        build_correspondence_map(lat.original, lat.combined, lat.expanded);
+        build_correspondence_map(lat.original, lat.combined, lat.expanded,
+                                 lat.leftover);
 
     // Unrolling `repeat: 3` over a one-element cell produces three keyless `d1`
     // scalars in the expanded line, all copied from the same combined source.
@@ -794,6 +926,8 @@ TEST_CASE("build_correspondence_map maps one source to many expanded copies",
     // nodes point to; a single source must account for at least three copies.
     std::map<YAMLNodeId, int> combined_hits;
     for (size_t i = 0; i < m.count; i++) {
+        // Skip the leftover half of the map: those ids index a different tree.
+        if (m.links[i].expanded == YAML_NULL_ID) continue;
         if (!is_scalar(lat.expanded, m.links[i].expanded)) continue;
         if (!val_eq(lat.expanded, m.links[i].expanded, "d1")) continue;
         REQUIRE(m.links[i].combined != YAML_NULL_ID);  // has a source
@@ -807,6 +941,7 @@ TEST_CASE("build_correspondence_map maps one source to many expanded copies",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
     rm_tmp(path);
 }
 
@@ -904,10 +1039,9 @@ TEST_CASE("Expansion preserves the key order of the source file", "[key_order]")
     REQUIRE(key_eq(lat.combined, c_line, "main_line"));
     REQUIRE(keys_of(lat.combined, c_line) == expected);
 
-    // In the expanded tree the line is inlined under lat1's `branches`.
-    YAMLNodeId lat1 = get_child_by_index(
-        lat.expanded,
-        get_child_by_index(lat.expanded, facility_of(lat.expanded), 2), 0);
+    // The expanded tree is rooted at the lattice entry itself, and the line is
+    // inlined under its `branches`.
+    YAMLNodeId lat1 = get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
     REQUIRE(key_eq(lat.expanded, lat1, "lat1"));
     YAMLNodeId branches = get_child_by_key(lat.expanded, lat1, "branches");
     YAMLNodeId e_line = get_child_by_index(
@@ -928,6 +1062,7 @@ TEST_CASE("Expansion preserves the key order of the source file", "[key_order]")
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
     rm_tmp(path);
 }
 
@@ -1332,6 +1467,23 @@ static double num_val(YAMLTreeHandle t, YAMLNodeId n) {
     return v;
 }
 
+// The first node keyed `key` anywhere in `t`, found depth-first. Used to reach
+// an element that expansion inlined into the lattice, wherever it ended up.
+static YAMLNodeId find_by_key(YAMLTreeHandle t, const char* key) {
+    std::vector<YAMLNodeId> stack{get_root(t)};
+    while (!stack.empty()) {
+        YAMLNodeId n = stack.back();
+        stack.pop_back();
+        char* k = get_node_key(t, n);
+        bool hit = k && std::string(k) == key;
+        yaml_free_string(k);
+        if (hit) return n;
+        for (size_t i = 0; i < get_size(t, n); i++)
+            stack.push_back(get_child_by_index(t, n, i));
+    }
+    return YAML_NULL_ID;
+}
+
 TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
           "[expr][lattices]") {
     const char* path = "tmp_expr.pals.yaml";
@@ -1365,7 +1517,9 @@ TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
 
     const double a_var = 3.75e7 / (2.99792458e8 * 2.99792458e8);
 
-    YAMLNodeId cleo = facility_param(lat.expanded, "cleo");
+    // `cleo` is referenced by main_line, so expansion inlines its definition
+    // into the lattice; this is the copy inside the expanded tree.
+    YAMLNodeId cleo = find_by_key(lat.expanded, "cleo");
     REQUIRE(cleo != YAML_NULL_ID);
 
     // Immediate expression using a user variable.
@@ -1381,13 +1535,17 @@ TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
     YAMLNodeId kn2 = get_child_by_key(lat.expanded, mmp, "Kn2");
     REQUIRE(val_eq(lat.expanded, kn2, "0.01 + 0.003*random_gauss()"));
 
-    // Full-form constant defined via a particle function.
-    YAMLNodeId m_e = facility_param(lat.expanded, "m_e");
-    YAMLNodeId m_e_val = get_child_by_key(lat.expanded, m_e, "value");
-    REQUIRE(close(num_val(lat.expanded, m_e_val), 510998.95069000003));
+    // Expressions are evaluated before the document is split, so a definition
+    // that stayed behind is evaluated in leftover just the same. `m_e` is not
+    // referenced by the lattice, so leftover is the only place it exists.
+    YAMLNodeId m_e = facility_param(lat.leftover, "m_e");
+    REQUIRE(m_e != YAML_NULL_ID);
+    YAMLNodeId m_e_val = get_child_by_key(lat.leftover, m_e, "value");
+    REQUIRE(close(num_val(lat.leftover, m_e_val), 510998.95069000003));
+    REQUIRE(find_by_key(lat.expanded, "m_e") == YAML_NULL_ID);
 
-    // The combined tree keeps the original expression text (only `expanded`
-    // is evaluated).
+    // The combined tree keeps the original expression text (evaluation happens
+    // downstream of it).
     YAMLNodeId c_cleo = facility_param(lat.combined, "cleo");
     YAMLNodeId c_len = get_child_by_key(lat.combined, c_cleo, "length");
     REQUIRE(val_eq(lat.combined, c_len, "0.1*log(abs(b_var))"));
@@ -1395,6 +1553,7 @@ TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
     rm_tmp(path);
 }
 
@@ -1431,19 +1590,23 @@ TEST_CASE("parse_and_expand_PALS resolves map-form constants/variables",
 
     const double a_const = 0.3 * evaluate_pals_expression("r_electron", nullptr);
 
-    YAMLNodeId consts = facility_param(lat.expanded, "constants");
-    REQUIRE(close(num_val(lat.expanded,
-                          get_child_by_key(lat.expanded, consts, "a_const")),
+    // constants/variables blocks are not part of the lattice, so they are
+    // leftover — evaluated all the same.
+    YAMLNodeId consts = facility_param(lat.leftover, "constants");
+    REQUIRE(close(num_val(lat.leftover,
+                          get_child_by_key(lat.leftover, consts, "a_const")),
                   a_const));
 
     // a_var references the map-form constant a_const defined above it.
-    YAMLNodeId vars = facility_param(lat.expanded, "variables");
-    REQUIRE(close(num_val(lat.expanded,
-                          get_child_by_key(lat.expanded, vars, "a_var")),
+    YAMLNodeId vars = facility_param(lat.leftover, "variables");
+    REQUIRE(close(num_val(lat.leftover,
+                          get_child_by_key(lat.leftover, vars, "a_var")),
                   a_const * a_const));
 
-    // An element parameter may reference the map-form definitions too.
-    YAMLNodeId d1 = facility_param(lat.expanded, "d1");
+    // An element parameter may reference the map-form definitions too; this is
+    // d1 as inlined into the expanded lattice.
+    YAMLNodeId d1 = find_by_key(lat.expanded, "d1");
+    REQUIRE(d1 != YAML_NULL_ID);
     REQUIRE(close(num_val(lat.expanded, get_child_by_key(lat.expanded, d1,
                                                          "length")),
                   a_const + 0.45));
@@ -1451,6 +1614,7 @@ TEST_CASE("parse_and_expand_PALS resolves map-form constants/variables",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
     rm_tmp(path);
 }
 
@@ -1486,7 +1650,8 @@ TEST_CASE("parse_and_expand_PALS resolves element-parameter references",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(lat.expanded != nullptr);
 
-    YAMLNodeId dh1a = facility_param(lat.expanded, "DH1A");
+    YAMLNodeId dh1a = find_by_key(lat.expanded, "DH1A");
+    REQUIRE(dh1a != YAML_NULL_ID);
     YAMLNodeId bendp = get_child_by_key(lat.expanded, dh1a, "BendP");
     REQUIRE(close(
         num_val(lat.expanded, get_child_by_key(lat.expanded, bendp, "edge_int2")),
@@ -1499,6 +1664,7 @@ TEST_CASE("parse_and_expand_PALS resolves element-parameter references",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
     rm_tmp(path);
 }
 
@@ -1534,12 +1700,13 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
 
     const double m_3he = 2809413528.3197904;  // mass_of("#3He"), CODATA 2022
 
-    YAMLNodeId consts = facility_param(lat.expanded, "constants");
-    REQUIRE(close(num_val(lat.expanded,
-                          get_child_by_key(lat.expanded, consts, "b_const")),
+    YAMLNodeId consts = facility_param(lat.leftover, "constants");
+    REQUIRE(close(num_val(lat.leftover,
+                          get_child_by_key(lat.leftover, consts, "b_const")),
                   0.45 * m_3he));
 
-    YAMLNodeId dh1a = facility_param(lat.expanded, "DH1A");
+    YAMLNodeId dh1a = find_by_key(lat.expanded, "DH1A");
+    REQUIRE(dh1a != YAML_NULL_ID);
     YAMLNodeId bendp = get_child_by_key(lat.expanded, dh1a, "BendP");
     REQUIRE(close(num_val(lat.expanded,
                           get_child_by_key(lat.expanded, bendp, "e_tot")),
@@ -1553,8 +1720,8 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
                    "#3He"));
 
     // The species constant itself stays as its (string) species name.
-    REQUIRE(val_eq(lat.expanded,
-                   get_child_by_key(lat.expanded, consts, "species"), "#3He"));
+    REQUIRE(val_eq(lat.leftover,
+                   get_child_by_key(lat.leftover, consts, "species"), "#3He"));
 
     // No spurious problems.
     REQUIRE(lat.problems.count == 0);
@@ -1563,6 +1730,7 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
     rm_tmp(path);
 }
 
@@ -1630,6 +1798,7 @@ TEST_CASE("parse_and_expand_PALS reports expansion problems",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
     rm_tmp(path);
 }
 
@@ -1647,10 +1816,18 @@ TEST_CASE("parse_and_expand_PALS reports a missing lattice",
     REQUIRE(lat.problems.count == 1);
     REQUIRE(std::string(lat.problems.items[0]) == "lattice 'not_here' not found");
 
+    // With no lattice to expand, expanded is an empty map and the whole document
+    // is leftover — both handles are still valid.
+    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.leftover != nullptr);
+    REQUIRE(get_size(lat.expanded, get_root(lat.expanded)) == 0);
+    REQUIRE(facility_of(lat.leftover) != YAML_NULL_ID);
+
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
     rm_tmp(path);
 }
 
@@ -1696,53 +1873,55 @@ TEST_CASE("parse_and_expand_PALS evaluates controller expressions",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.leftover != nullptr);
 
     const double cur1 = 0.023;
     const double cur2 = cur1 / 2.99792458e8;
 
+    // Controllers are facility-level, so they are leftover rather than part
+    // of the lattice; their expressions are evaluated all the same.
     // Controller variables are evaluated with the controller's own symbol
     // table: cur2 references the earlier variable cur1 and the constant c_light.
-    YAMLNodeId ps27 = facility_param(lat.expanded, "ps27");
+    YAMLNodeId ps27 = facility_param(lat.leftover, "ps27");
     REQUIRE(ps27 != YAML_NULL_ID);
-    YAMLNodeId vars = get_child_by_key(lat.expanded, ps27, "variables");
-    REQUIRE(close(num_val(lat.expanded, get_child_by_key(lat.expanded, vars,
+    YAMLNodeId vars = get_child_by_key(lat.leftover, ps27, "variables");
+    REQUIRE(close(num_val(lat.leftover, get_child_by_key(lat.leftover, vars,
                                                          "cur2")),
                   cur2));
 
     // Each control `expression` is computed and its value stored in place.
-    YAMLNodeId controls = get_child_by_key(lat.expanded, ps27, "controls");
-    YAMLNodeId c0 = get_child_by_index(lat.expanded, controls, 0);
-    REQUIRE(close(num_val(lat.expanded,
-                          get_child_by_key(lat.expanded, c0, "expression")),
+    YAMLNodeId controls = get_child_by_key(lat.leftover, ps27, "controls");
+    YAMLNodeId c0 = get_child_by_index(lat.leftover, controls, 0);
+    REQUIRE(close(num_val(lat.leftover,
+                          get_child_by_key(lat.leftover, c0, "expression")),
                   0.075 * std::sin(cur1) + 0.3 * cur2));
     // Control expressions may reference lattice constants (my_const = 2).
-    YAMLNodeId c1 = get_child_by_index(lat.expanded, controls, 1);
-    REQUIRE(close(num_val(lat.expanded,
-                          get_child_by_key(lat.expanded, c1, "expression")),
+    YAMLNodeId c1 = get_child_by_index(lat.leftover, controls, 1);
+    REQUIRE(close(num_val(lat.leftover,
+                          get_child_by_key(lat.leftover, c1, "expression")),
                   cur1 * 2.0));
     // random_gauss() stays deferred, exactly as elsewhere.
-    YAMLNodeId c2 = get_child_by_index(lat.expanded, controls, 2);
-    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, c2, "expression"),
+    YAMLNodeId c2 = get_child_by_index(lat.leftover, controls, 2);
+    REQUIRE(val_eq(lat.leftover, get_child_by_key(lat.leftover, c2, "expression"),
                    "0.01 + random_gauss()"));
 
     // The `parameter` target spec and `control_type` are names, left untouched.
-    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, c0, "parameter"),
+    REQUIRE(val_eq(lat.leftover, get_child_by_key(lat.leftover, c0, "parameter"),
                    "Qa.*>MagneticMultipoleP.Ks2L"));
-    REQUIRE(val_eq(lat.expanded,
-                   get_child_by_key(lat.expanded, ps27, "control_type"),
+    REQUIRE(val_eq(lat.leftover,
+                   get_child_by_key(lat.leftover, ps27, "control_type"),
                    "ABSOLUTE"));
 
     // A second controller may reference the first's variables via `name>var`.
-    YAMLNodeId chrom = facility_param(lat.expanded, "chrom_a");
-    YAMLNodeId cvars = get_child_by_key(lat.expanded, chrom, "variables");
-    REQUIRE(close(num_val(lat.expanded, get_child_by_key(lat.expanded, cvars,
+    YAMLNodeId chrom = facility_param(lat.leftover, "chrom_a");
+    YAMLNodeId cvars = get_child_by_key(lat.leftover, chrom, "variables");
+    REQUIRE(close(num_val(lat.leftover, get_child_by_key(lat.leftover, cvars,
                                                          "derived")),
                   cur1 * 2.0));
-    YAMLNodeId ccontrols = get_child_by_key(lat.expanded, chrom, "controls");
-    YAMLNodeId cc0 = get_child_by_index(lat.expanded, ccontrols, 0);
-    REQUIRE(close(num_val(lat.expanded,
-                          get_child_by_key(lat.expanded, cc0, "expression")),
+    YAMLNodeId ccontrols = get_child_by_key(lat.leftover, chrom, "controls");
+    YAMLNodeId cc0 = get_child_by_index(lat.leftover, ccontrols, 0);
+    REQUIRE(close(num_val(lat.leftover,
+                          get_child_by_key(lat.leftover, cc0, "expression")),
                   5.62 * 0.4 + 0.02 * 0.4 * 0.4));
 
     // The combined tree keeps the original controller expression text.
@@ -1756,5 +1935,6 @@ TEST_CASE("parse_and_expand_PALS evaluates controller expressions",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
     rm_tmp(path);
 }


### PR DESCRIPTION
## What

`parse_and_expand_PALS` returned three trees, and `expanded` carried the whole document — the expanded root lattice *plus* every element definition, `use` statement, constant, controller and non-root `Lattice` that came along with it. This splits those apart.

`struct lattices` gains a fourth handle:

- **`expanded`** — the expanded root lattice and nothing else, rooted at the lattice entry with the `PALS:`/`facility:` scaffolding stripped, so it is reached as `expanded["lat1"]` rather than through `["PALS"]["facility"]`.
- **`leftover`** — everything else, keeping that scaffolding.

```yaml
# expanded                      # leftover
lat1:                           PALS:
  kind: Lattice                   facility:
  branches:                         - thingB: {kind: Sextupole, ...}
    - inj_line:                     - lat2:   {kind: Lattice, ...}
        kind: BeamLine              - inj_line: {kind: BeamLine, ...}
        ...                         - use: lat1
```

A definition the lattice references is **copied**, not moved: `inj_line`'s definition stays in `leftover` while its inlined copy lives in `expanded`.

## How

Expansion has to see the whole document at once, so it runs on a throwaway work tree that is then cut in two. Both halves chain their provenance straight back to `combined`, so the work tree can be discarded.

`build_correspondence_map` takes a `leftover` handle and `node_link` gains a `leftover` id. A link names a node in exactly one of the two derived trees; the shared `combined` id ties the halves together, so the inlined copy and the definition left standing belong to one equivalence class.

## A latent bug this surfaced

`handle_fork` writes `fork_pointer` as a **raw node id**, which was only valid because expansion returned the very tree it ran on. Splitting renumbers every node, so that pointer would have silently dangled. It is now remapped as the lattice is cut out, with a test asserting it resolves to the fork's `destination_element`.

## What `leftover` is, exactly

`combined`, with expressions evaluated and the root lattice lifted out. Definitions are otherwise structurally untouched — `inherit:` unmerged, `repeat:` unrolled, no `fork_pointer` — because `expand` duplicates a definition into the lattice rather than mutating it in place.

## Testing

93/93 C++ tests pass. Tests that reached facility-level nodes through `lat.expanded` now read `lat.leftover`; those covering elements inlined into the lattice search `expanded`. New coverage: the shape of each tree, the no-lattice path, the fork-pointer remap, and a combined node reaching both derived trees.

## Downstream

PALSJulia consumes this struct by layout and needs a matching change; its PR follows and its CI builds pals-cpp from this repo's default branch, so this must merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
