### PR TITLE
Fix CMake target ordering and default the build type to Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,17 @@
 cmake_minimum_required(VERSION 3.16)
 project(YAMLWrapper)
 
+# Default to Release when no build type is given. This is not just about
+# optimization: an empty build type leaves NDEBUG undefined, and c4core (vendored
+# by rapidyaml) then compiles a debugbreak path calling __builtin_debugtrap,
+# which is clang-only and fails to build under GCC. Multi-config generators
+# ignore CMAKE_BUILD_TYPE, so skip them rather than set a variable they discard.
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
+               STRINGS Debug Release RelWithDebInfo MinSizeRel)
+endif()
+
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
 
@@ -14,7 +25,7 @@ include(FetchContent)
 FetchContent_Declare(
   rapidyaml
   GIT_REPOSITORY https://github.com/biojppm/rapidyaml.git
-  GIT_TAG v0.11.1 
+  GIT_TAG v0.11.1
   GIT_SHALLOW FALSE
 )
 
@@ -60,8 +71,6 @@ FetchContent_MakeAvailable(Catch2)
 FetchContent_MakeAvailable(pcre2)
 FetchContent_MakeAvailable(apc)
 
-add_subdirectory(tests)
-
 file(COPY ${CMAKE_SOURCE_DIR}/lattice_files/
      DESTINATION ${CMAKE_BINARY_DIR}/lattice_files/)
 
@@ -75,3 +84,6 @@ target_link_libraries(example_rw yaml_c_wrapper ryml)
 
 add_executable(print_lattices examples/print_lattices.cpp)
 target_link_libraries(print_lattices yaml_c_wrapper ryml)
+
+# Must come after yaml_c_wrapper is defined: tests/CMakeLists.txt links it.
+add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,5 +10,5 @@ target_link_libraries(tests
 )
 
 include(Catch)
-Catch_discover_tests(tests)
+catch_discover_tests(tests)
 target_compile_features(tests PRIVATE cxx_std_17)


### PR DESCRIPTION
Follow-up cleanup to `CMakeLists.txt`. Four changes, no behaviour change to the library itself.

## Target ordering

`add_subdirectory(tests)` ran *before* `add_library(yaml_c_wrapper ...)`, so `tests/CMakeLists.txt` linked a target that did not exist yet. CMake resolves target names at generate time, so this worked — but only by luck, and it would break the moment anyone touched it. Moved below the library definition, with a comment saying why it has to stay there.

## Build-type guard

A fresh `cmake -S . -B build` with MacPorts g++ 15.2 failed:

```
debugbreak.h:150:9: error: '__builtin_debugtrap' was not declared in this scope
```

The trigger is the **build type**, not the compiler. An empty `CMAKE_BUILD_TYPE` leaves `NDEBUG` undefined, and c4core (vendored by rapidyaml) then compiles a debugbreak path calling `__builtin_debugtrap`, which is clang-only. CI passes `-DCMAKE_BUILD_TYPE=Release` explicitly, which is why it never surfaced here — but anyone cloning fresh and running a plain `cmake` hit it.

Now defaults to `Release` when nothing is specified, skipping multi-config generators since they ignore the variable.

## Verification

| Configure | Before | After |
|---|---|---|
| g++, no build type | ❌ debugtrap | ✅ 93/93 |
| g++, `Release` (what CI does) | ✅ | ✅ |
| g++, `Debug` | ❌ | ❌ upstream |
| AppleClang | ✅ | ✅ 93/93 |

Explicit `-DCMAKE_BUILD_TYPE=Debug` under GCC still fails. That is an upstream c4core bug; fixing it here would mean patching a vendored dep or forcing `NDEBUG` into Debug builds, which defeats the point of Debug. Out of scope.

## Cosmetic

`Catch_discover_tests` → `catch_discover_tests`, plus stray trailing whitespace and a missing final newline.

Note for downstream: PALSJulia's CI builds this repo with a bare `cmake ..`, so its pals-cpp build becomes Release-optimized. No struct or API changes, so no layout coupling risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
