### PR TITLE
Review follow-ups: repeat deletion bug, NULL guards, C-visible lattices, constant provenance

### DIFF
--- a/examples/example_rw.cpp
+++ b/examples/example_rw.cpp
@@ -39,9 +39,9 @@ int main(int argc, char* argv[]) {
 
     // add a new sequence element to the facility containing new_map: {apples: 5}
     std::cout << "Adding a new element '-apples: 5' to facility.\n";
-    YAMLNodeId new_map_entry = add_map(tree, facility, NULL, END);
-    YAMLNodeId map = add_map(tree, new_map_entry, "new_map", END);
-    add_scalar(tree, map, "apples", "5", END);
+    YAMLNodeId new_map_entry = add_map(tree, facility, NULL, YAML_END);
+    YAMLNodeId map = add_map(tree, new_map_entry, "new_map", YAML_END);
+    add_scalar(tree, map, "apples", "5", YAML_END);
 
     // add a new sequence element to the facility containing magnets
     std::cout << "Adding a new element\n"
@@ -49,9 +49,10 @@ int main(int argc, char* argv[]) {
               << "        - magnet1\n"
               << "        - magnet2\n"
               << "to facility.\n\n";
-    YAMLNodeId magnets_entry = add_map(tree, facility, NULL, END);
-    YAMLNodeId sequence = add_sequence(tree, magnets_entry, "magnet_list", END);
-    add_scalar(tree, sequence, NULL, "magnet1", END);
+    YAMLNodeId magnets_entry = add_map(tree, facility, NULL, YAML_END);
+    YAMLNodeId sequence =
+        add_sequence(tree, magnets_entry, "magnet_list", YAML_END);
+    add_scalar(tree, sequence, NULL, "magnet1", YAML_END);
     add_scalar(tree, sequence, NULL, "magnet2", 1);
 
     // writing trees to files

--- a/src/pals_expression.cpp
+++ b/src/pals_expression.cpp
@@ -2,12 +2,17 @@
  * @file pals_expression.cpp
  * @brief Recursive-descent evaluator for PALS mathematical expressions.
  *
- * Grammar (standard precedence; `^` is right-associative):
+ * Grammar (`^` is right-associative):
  *   expr    := term (('+' | '-') term)*
- *   term    := power (('*' | '/') power)*
- *   power   := unary ('^' power)?
- *   unary   := ('+' | '-') unary | primary
+ *   term    := unary (('*' | '/') unary)*
+ *   unary   := ('+' | '-') unary | power
+ *   power   := primary ('^' unary)?
  *   primary := number | name | name '(' args ')' | '(' expr ')'
+ *
+ * Note that `unary` sits above `power` rather than below it, so a leading sign
+ * binds looser than `^` while the exponent may itself be signed: -2^2 == -4 and
+ * 2^-1 == 0.5. This is the Fortran/Bmad convention the rest of the ecosystem
+ * uses, and it differs from C-family languages where unary minus binds tighter.
  *
  * The particle functions mass_of / charge_of / anomalous_moment_of take a
  * quoted species name (e.g. `mass_of("#3He")`), not a numeric sub-expression, so
@@ -338,14 +343,20 @@ class Parser {
 
 bool builtin_constant(const std::string& name, double& out) {
   // Physical values come from AtomicAndPhysicalConstantsCLib (APC, CODATA
-  // 2022) so PALS shares the ecosystem's numbers. k_boltzmann and
-  // classical_radius_factor are derived from APC quantities (APC does not
-  // export them directly); pi is exact.
+  // 2022) so PALS shares the ecosystem's numbers; pi is exact.
+  //
+  // classical_radius_factor is the one deliberate exception: apc::
+  // CLASSICAL_RADIUS_FACTOR is r_e*m_e with the mass in MeV, while APC's own
+  // M_ELECTRON is in eV, so the exported constant is 1e6 larger than the value
+  // PALS wants. Deriving it here from APC's own r_electron and M_ELECTRON keeps
+  // it in eV*m and matches Bmad's e^2/(4*pi*eps_0) = 1.44e-9 eV*m. Do not
+  // "simplify" this to apc::CLASSICAL_RADIUS_FACTOR without resolving the units
+  // question upstream first — it would silently introduce a factor of 1e6.
   if (name == "pi") { out = kPi; return true; }
   if (name == "c_light") { out = apc::C_LIGHT; return true; }
   if (name == "h_planck") { out = apc::H_PLANCK; return true; }
   if (name == "hbar") { out = apc::H_BAR; return true; }
-  if (name == "k_boltzmann") { out = 1.380649e-23 / apc::J_PER_EV; return true; }  // eV/K
+  if (name == "k_boltzmann") { out = apc::K_BOLTZMANN; return true; }  // eV/K
   if (name == "r_electron") { out = apc::R_ELECTRON; return true; }
   if (name == "r_proton") { out = apc::R_PROTON; return true; }
   if (name == "e_charge") { out = apc::E_CHARGE; return true; }

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -423,26 +423,34 @@ static void expand(ryml::Tree& t, size_t node,
                     size_t repeat_id =
                         t.find_child(entry, ryml::to_csubstr("repeat"));
                     if (repeat_id != ryml::NONE && t.has_val(repeat_id)) {
-                        int count = 0;
                         std::string cnt_txt(t.val(repeat_id).str,
                                             t.val(repeat_id).len);
+                        std::string target(t.key(entry).str, t.key(entry).len);
+
+                        // stoi stops at the first character it cannot use and
+                        // reports how far it got, so require the whole value to
+                        // be consumed: "3x" is a typo, not a count of 3. A
+                        // negative count is meaningless too. Both land on
+                        // count < 0 and are reported the same way.
+                        int count = -1;
                         try {
-                            count = std::stoi(cnt_txt);
+                            size_t used = 0;
+                            count = std::stoi(cnt_txt, &used);
+                            if (used != cnt_txt.size()) count = -1;
                         } catch (...) {
+                            count = -1;
+                        }
+
+                        if (count < 0) {
                             add_problem(problems, "repeat: invalid count '" +
                                                       cnt_txt + "' for '" +
-                                                      std::string(
-                                                          t.key(entry).str,
-                                                          t.key(entry).len) +
-                                                      "'");
-                        }
-                        std::string target(t.key(entry).str, t.key(entry).len);
-                        // check if the beamline to be repeated has been defined
-                        // in the file
-                        if (!emap.count(target))
+                                                      target + "'");
+                        } else if (!emap.count(target)) {
+                            // check if the beamline to be repeated has been
+                            // defined in the file
                             add_problem(problems, "repeat: beamline '" + target +
                                                       "' is not defined");
-                        if (emap.count(target)) {
+                        } else {
                             size_t def = emap[target];
                             size_t line_id =
                                 t.find_child(def, ryml::to_csubstr("line"));
@@ -475,6 +483,13 @@ static void expand(ryml::Tree& t, size_t node,
                             child = next;
                             continue;
                         }
+                        // Either problem path falls through to leave the entry
+                        // exactly as written. Only a repeat we fully understood
+                        // removes it: dropping an entry on the strength of a
+                        // count we could not read would delete part of the
+                        // lattice, leaving a plausible-looking `line: []` that
+                        // is only explained by a problem the caller may not
+                        // check.
                     }
                 }
             }

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -44,10 +44,10 @@ static void ensure_capacity(ryml::Tree& t, size_t needed = 1) {
     if (t.size() + needed >= t.capacity()) t.reserve(t.capacity() + 64);
 }
 
-// Append or insert a blank child. index=END means append.
+// Append or insert a blank child. index=YAML_END means append.
 static size_t add_child_at(ryml::Tree& t, size_t parent, size_t index) {
     ensure_capacity(t);
-    if (index == END) return t.append_child(parent);
+    if (index == YAML_END) return t.append_child(parent);
     size_t num = t.num_children(parent);
     if (index > num) index = num;
     size_t after = (index > 0) ? t.child(parent, index - 1) : ryml::NONE;
@@ -1989,7 +1989,7 @@ YAML_API void deep_copy_children(YAMLTreeHandle dst_tree, YAMLNodeId dst_node,
     ryml::Tree& dt = GET_TREE(dst_tree);
     const ryml::Tree& st = GET_TREE(src_tree);
     size_t after;
-    if (index == END)
+    if (index == YAML_END)
         after = dt.last_child(dst_node);
     else if (index == 0)
         after = ryml::NONE;

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -1847,7 +1847,7 @@ YAML_API void delete_tree(YAMLTreeHandle tree) {
 
 YAML_API void remove_node(YAMLTreeHandle tree, YAMLNodeId parent,
                           YAMLNodeId child) {
-    if (child == YAML_NULL_ID) return;
+    if (!tree || child == YAML_NULL_ID) return;
     GET_TREE(tree).remove(child);
 }
 
@@ -1859,6 +1859,7 @@ YAML_API YAMLNodeId get_root(YAMLTreeHandle tree) {
 }
 
 YAML_API YAMLNodeId get_parent(YAMLTreeHandle tree, YAMLNodeId node) {
+    if (!tree) return YAML_NULL_ID;
     ryml::Tree& t = GET_TREE(tree);
     if (node == ryml::NONE || !t.has_parent(node)) return YAML_NULL_ID;
     return t.parent(node);
@@ -1866,7 +1867,7 @@ YAML_API YAMLNodeId get_parent(YAMLTreeHandle tree, YAMLNodeId node) {
 
 YAML_API YAMLNodeId get_child_by_key(YAMLTreeHandle tree, YAMLNodeId parent,
                                      const char* key) {
-    if (parent == YAML_NULL_ID) return YAML_NULL_ID;
+    if (!tree || !key || parent == YAML_NULL_ID) return YAML_NULL_ID;
     ryml::Tree& t = GET_TREE(tree);
     if (!t.is_map(parent)) return YAML_NULL_ID;
     size_t child = t.find_child(parent, ryml::to_csubstr(key));
@@ -1875,6 +1876,7 @@ YAML_API YAMLNodeId get_child_by_key(YAMLTreeHandle tree, YAMLNodeId parent,
 
 YAML_API YAMLNodeId get_child_by_index(YAMLTreeHandle tree, YAMLNodeId parent,
                                        size_t index) {
+    if (!tree || parent == YAML_NULL_ID) return YAML_NULL_ID;
     ryml::Tree& t = GET_TREE(tree);
     if (!(t.is_seq(parent) || t.is_map(parent)) ||
         index >= t.num_children(parent))
@@ -1883,12 +1885,12 @@ YAML_API YAMLNodeId get_child_by_index(YAMLTreeHandle tree, YAMLNodeId parent,
 }
 
 YAML_API size_t get_size(YAMLTreeHandle tree, YAMLNodeId node) {
-    if (node == YAML_NULL_ID) return 0;
+    if (!tree || node == YAML_NULL_ID) return 0;
     return GET_TREE(tree).num_children(node);
 }
 
 YAML_API char* get_node_key(YAMLTreeHandle tree, YAMLNodeId node) {
-    if (node == YAML_NULL_ID) return nullptr;
+    if (!tree || node == YAML_NULL_ID) return nullptr;
     ryml::Tree& t = GET_TREE(tree);
     if (!t.has_key(node)) return nullptr;
     ryml::csubstr k = t.key(node);
@@ -1901,24 +1903,24 @@ YAML_API char* get_node_key(YAMLTreeHandle tree, YAMLNodeId node) {
 // --- TYPE CHECKS ---
 
 YAML_API bool is_map(YAMLTreeHandle tree, YAMLNodeId node) {
-    if (node == YAML_NULL_ID) return false;
+    if (!tree || node == YAML_NULL_ID) return false;
     return GET_TREE(tree).is_map(node);
 }
 
 YAML_API bool is_sequence(YAMLTreeHandle tree, YAMLNodeId node) {
-    if (node == YAML_NULL_ID) return false;
+    if (!tree || node == YAML_NULL_ID) return false;
     return GET_TREE(tree).is_seq(node);
 }
 
 YAML_API bool is_scalar(YAMLTreeHandle tree, YAMLNodeId node) {
-    if (node == YAML_NULL_ID) return false;
+    if (!tree || node == YAML_NULL_ID) return false;
     return GET_TREE(tree).is_val(node);
 }
 
 // --- READING VALUES ---
 
 YAML_API char* as_string(YAMLTreeHandle tree, YAMLNodeId node) {
-    if (node == YAML_NULL_ID) return nullptr;
+    if (!tree || node == YAML_NULL_ID) return nullptr;
     ryml::Tree& t = GET_TREE(tree);
     if (!t.has_val(node)) return nullptr;
     ryml::csubstr v = t.val(node);
@@ -1933,7 +1935,7 @@ YAML_API char* as_string(YAMLTreeHandle tree, YAMLNodeId node) {
 YAML_API YAMLNodeId add_scalar(YAMLTreeHandle tree, YAMLNodeId parent,
                                const char* key, const char* value,
                                size_t index) {
-    if (parent == YAML_NULL_ID) return YAML_NULL_ID;
+    if (!tree || !value || parent == YAML_NULL_ID) return YAML_NULL_ID;
     ryml::Tree& t = GET_TREE(tree);
     size_t id = add_child_at(t, parent, index);
     if (t.is_map(parent) && key) {
@@ -1948,7 +1950,7 @@ YAML_API YAMLNodeId add_scalar(YAMLTreeHandle tree, YAMLNodeId parent,
 
 YAML_API YAMLNodeId add_map(YAMLTreeHandle tree, YAMLNodeId parent,
                             const char* key, size_t index) {
-    if (parent == YAML_NULL_ID) return YAML_NULL_ID;
+    if (!tree || parent == YAML_NULL_ID) return YAML_NULL_ID;
     ryml::Tree& t = GET_TREE(tree);
     size_t id = add_child_at(t, parent, index);
     if (t.is_map(parent) && key)
@@ -1960,7 +1962,7 @@ YAML_API YAMLNodeId add_map(YAMLTreeHandle tree, YAMLNodeId parent,
 
 YAML_API YAMLNodeId add_sequence(YAMLTreeHandle tree, YAMLNodeId parent,
                                  const char* key, size_t index) {
-    if (parent == YAML_NULL_ID) return YAML_NULL_ID;
+    if (!tree || parent == YAML_NULL_ID) return YAML_NULL_ID;
     ryml::Tree& t = GET_TREE(tree);
     size_t id = add_child_at(t, parent, index);
     if (t.is_map(parent) && key)
@@ -1972,7 +1974,7 @@ YAML_API YAMLNodeId add_sequence(YAMLTreeHandle tree, YAMLNodeId parent,
 
 YAML_API void set_scalar(YAMLTreeHandle tree, YAMLNodeId node,
                          const char* value) {
-    if (node == YAML_NULL_ID) return;
+    if (!tree || !value || node == YAML_NULL_ID) return;
     ryml::Tree& t = GET_TREE(tree);
     t.ref(node) |= ryml::VAL;
     t.set_val(node, t.to_arena(ryml::to_csubstr(value)));
@@ -1980,7 +1982,7 @@ YAML_API void set_scalar(YAMLTreeHandle tree, YAMLNodeId node,
 
 YAML_API void set_node_key(YAMLTreeHandle tree, YAMLNodeId node,
                            const char* key) {
-    if (node == YAML_NULL_ID) return;
+    if (!tree || !key || node == YAML_NULL_ID) return;
     ryml::Tree& t = GET_TREE(tree);
     t.ref(node) |= ryml::KEY;
     t.set_key(node, t.to_arena(ryml::to_csubstr(key)));
@@ -2017,6 +2019,7 @@ YAML_API void deep_copy_children(YAMLTreeHandle dst_tree, YAMLNodeId dst_node,
 // --- EMITTING & UTILS ---
 
 YAML_API char* node_to_string(YAMLTreeHandle tree, YAMLNodeId node) {
+    if (!tree) return nullptr;
     ryml::Tree& t = GET_TREE(tree);
     if (node == ryml::NONE || node >= t.capacity()) return nullptr;
     std::stringstream ss;
@@ -2032,6 +2035,7 @@ YAML_API char* tree_to_string(YAMLTreeHandle tree) {
 }
 
 YAML_API bool write_file(YAMLTreeHandle tree, const char* filename) {
+    if (!tree || !filename) return false;
     try {
         std::ofstream fout(filename);
         if (!fout) return false;

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -22,8 +22,11 @@ typedef size_t YAMLNodeId;
 // ryml uses (size_t)-1 to represent "not found" or "invalid"
 #define YAML_NULL_ID ((size_t)-1)
 
-// Pass as the index argument to add_* functions to append instead of inserting
-#define END ((size_t)-1)
+// Pass as the index argument to add_* functions to append instead of inserting.
+// Spelled YAML_END rather than END because this is a public header: an
+// unprefixed END would clobber any enumerator, variable or macro of that
+// name in every translation unit that includes us.
+#define YAML_END YAML_NULL_ID
 
 // --- STRING LIST ---
 //
@@ -37,9 +40,11 @@ struct string_list {
     size_t count;
 };
 
-// struct lattices uses std::map so it must be C++ only
-#ifdef __cplusplus
-#include <map>
+// --- LATTICES ---
+//
+// The four trees parse_and_expand_PALS() produces, plus the problems found on
+// the way. Plain C: the handles are opaque pointers, so this is usable from any
+// language that can read the rest of this header.
 struct lattices {
     YAMLTreeHandle original;  // Raw tree mapping each file (including includes)
                               // to its unparsed contents
@@ -56,7 +61,6 @@ struct lattices {
     struct string_list problems;  // Problems found while building `expanded`;
                                   // free with free_lattice_problems()
 };
-#endif
 
 // --- CORRESPONDENCE MAP ---
 //
@@ -433,7 +437,8 @@ YAML_API char* as_string(YAMLTreeHandle tree, YAMLNodeId node);
  * @param parent Node ID of the parent MAP or sequence.
  * @param key    Key string for MAP parents. Pass NULL for sequence elements.
  * @param value  Null-terminated scalar value string.
- * @param index  Insertion position among existing children. Pass END to append.
+ * @param index  Insertion position among existing children. Pass YAML_END
+ * to append.
  * @return Node ID of the newly created child, or YAML_NULL_ID on failure.
  */
 YAML_API YAMLNodeId add_scalar(YAMLTreeHandle tree, YAMLNodeId parent,
@@ -447,7 +452,8 @@ YAML_API YAMLNodeId add_scalar(YAMLTreeHandle tree, YAMLNodeId parent,
  * @param parent Node ID of the parent MAP or sequence.
  * @param key    Key string when parent is a MAP. Pass NULL for sequence
  * elements.
- * @param index  Insertion position among existing children. Pass END to append.
+ * @param index  Insertion position among existing children. Pass YAML_END
+ * to append.
  * @return Node ID of the newly created MAP child, or YAML_NULL_ID on failure.
  */
 YAML_API YAMLNodeId add_map(YAMLTreeHandle tree, YAMLNodeId parent,
@@ -460,7 +466,8 @@ YAML_API YAMLNodeId add_map(YAMLTreeHandle tree, YAMLNodeId parent,
  * @param parent Node ID of the parent MAP or sequence.
  * @param key    Key string when parent is a MAP. Pass NULL for sequence
  * elements.
- * @param index  Insertion position among existing children. Pass END to append.
+ * @param index  Insertion position among existing children. Pass YAML_END
+ * to append.
  * @return Node ID of the newly created sequence child, or YAML_NULL_ID on
  * failure.
  */
@@ -522,7 +529,7 @@ YAML_API void deep_copy_node(YAMLTreeHandle dst_tree, YAMLNodeId dst_node,
  * @param src_tree Handle to the source tree (may be the same as dst_tree).
  * @param src_node Node ID in src_tree whose children are copied.
  * @param index    Insertion position among dst_node's existing children.
- *                 Pass END to append after all existing children, or 0 to
+ *                 Pass YAML_END to append after all existing children, or 0 to
  *                 prepend before all existing children.
  *                 If either handle is NULL or either node is YAML_NULL_ID,
  *                 this call is a no-op.
@@ -565,7 +572,8 @@ YAML_API char* tree_to_string(YAMLTreeHandle tree);
 YAML_API bool write_file(YAMLTreeHandle tree, const char* filename);
 
 /**
- * Frees a string returned by get_node_key(), as_string(), or yaml_to_string().
+ * Frees a string returned by get_node_key(), as_string(), node_to_string() or
+ * tree_to_string(). These are every char*-returning function in this header.
  *
  * Passing NULL is safe and has no effect.
  *

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -359,6 +359,47 @@ TEST_CASE("add_scalar returns YAML_NULL_ID for a null parent", "[modification]")
     delete_tree(tree);
 }
 
+TEST_CASE("a NULL tree handle is rejected, not dereferenced", "[api]") {
+    // Every entry point already refused a null *node*; a null *tree* used to
+    // walk straight into a dereference. Callers across an FFI boundary get
+    // handles from functions that can fail, so this is a reachable mistake and
+    // should be an error return rather than a crash.
+    YAMLTreeHandle t = nullptr;
+
+    REQUIRE(get_root(t) == YAML_NULL_ID);
+    REQUIRE(get_parent(t, 0) == YAML_NULL_ID);
+    REQUIRE(get_child_by_key(t, 0, "k") == YAML_NULL_ID);
+    REQUIRE(get_child_by_index(t, 0, 0) == YAML_NULL_ID);
+    REQUIRE(get_size(t, 0) == 0);
+    REQUIRE(get_node_key(t, 0) == nullptr);
+    REQUIRE(is_map(t, 0) == false);
+    REQUIRE(is_sequence(t, 0) == false);
+    REQUIRE(is_scalar(t, 0) == false);
+    REQUIRE(as_string(t, 0) == nullptr);
+    REQUIRE(add_scalar(t, 0, "k", "v", YAML_END) == YAML_NULL_ID);
+    REQUIRE(add_map(t, 0, "k", YAML_END) == YAML_NULL_ID);
+    REQUIRE(add_sequence(t, 0, "k", YAML_END) == YAML_NULL_ID);
+    REQUIRE(node_to_string(t, 0) == nullptr);
+    REQUIRE(tree_to_string(t) == nullptr);
+    REQUIRE(write_file(t, "should_not_be_created.yaml") == false);
+
+    // Void returns: these just have to not crash.
+    remove_node(t, 0, 0);
+    set_scalar(t, 0, "v");
+    set_node_key(t, 0, "k");
+    deep_copy_node(t, 0, t, 0);
+    deep_copy_children(t, 0, t, 0, YAML_END);
+    delete_tree(t);  // delete on nullptr is a no-op
+
+    // A null key/value/filename is refused the same way.
+    YAMLTreeHandle real = create_empty_tree();
+    REQUIRE(get_child_by_key(real, get_root(real), nullptr) == YAML_NULL_ID);
+    REQUIRE(add_scalar(real, get_root(real), "k", nullptr, YAML_END) ==
+            YAML_NULL_ID);
+    REQUIRE(write_file(real, nullptr) == false);
+    delete_tree(real);
+}
+
 // ============================================================
 // MODIFICATION — set_scalar, set_node_key
 // ============================================================

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1351,9 +1351,17 @@ static double eval_ok(const char* expr) {
     return v;
 }
 
-// True if two doubles agree to a relative/absolute tolerance.
+// True if two doubles agree to a relative/absolute tolerance. The max(1.0, ...)
+// floors the tolerance at 1e-9 absolute, which keeps comparisons against zero
+// workable but makes this useless for values much smaller than 1e-9 — every
+// such comparison passes. Use close_rel for those.
 static bool close(double got, double want) {
     return std::fabs(got - want) <= 1e-9 * std::max(1.0, std::fabs(want));
+}
+
+// Purely relative comparison, for quantities whose magnitude is far from 1.
+static bool close_rel(double got, double want) {
+    return std::fabs(got - want) <= 1e-9 * std::fabs(want);
 }
 
 TEST_CASE("evaluate_pals_expression: arithmetic and precedence", "[expr]") {
@@ -1362,8 +1370,8 @@ TEST_CASE("evaluate_pals_expression: arithmetic and precedence", "[expr]") {
     REQUIRE(eval_ok("2 ^ 3 ^ 2") == 512.0);   // right-associative
     REQUIRE(eval_ok("-2 ^ 2") == -4.0);        // unary minus looser than ^
     REQUIRE(eval_ok("2 ^ -2") == 0.25);
-    REQUIRE(close(eval_ok("3.75e7 / c_light^2"),
-                  3.75e7 / (2.99792458e8 * 2.99792458e8)));
+    REQUIRE(close_rel(eval_ok("3.75e7 / c_light^2"),
+                      3.75e7 / (2.99792458e8 * 2.99792458e8)));
 }
 
 TEST_CASE("evaluate_pals_expression: functions", "[expr]") {
@@ -1383,15 +1391,25 @@ TEST_CASE("evaluate_pals_expression: functions", "[expr]") {
 TEST_CASE("evaluate_pals_expression: built-in constants", "[expr]") {
     REQUIRE(close(eval_ok("pi"), 3.14159265358979323846));
     REQUIRE(eval_ok("c_light") == 2.99792458e8);
-    // classical_radius_factor and k_boltzmann are derived from APC quantities.
-    REQUIRE(close(eval_ok("classical_radius_factor"),
-                  eval_ok("r_electron") * eval_ok("mass_of(\"electron\")")));
+    // Value of apc::K_BOLTZMANN, in eV/K.
+    REQUIRE(eval_ok("k_boltzmann") == 8.617333262e-5);
+
+    // classical_radius_factor is derived rather than taken from APC, because
+    // apc::CLASSICAL_RADIUS_FACTOR is 1e6 larger (its mass is in MeV while
+    // apc::M_ELECTRON is in eV). Pin the exponent explicitly: the relation
+    // below holds under either convention, so on its own it would not notice a
+    // switch to the APC constant silently rescaling every lattice using it.
+    REQUIRE(close_rel(eval_ok("classical_radius_factor"),
+                      eval_ok("r_electron") *
+                          eval_ok("mass_of(\"electron\")")));
+    REQUIRE(close_rel(eval_ok("classical_radius_factor"),
+                      1.4399645468825422e-9));
 
     // epsilon_0 and mu_0 are in the PALS standard's eV units — 1/(eV*m) and
     // eV*sec^2/m respectively, not the SI F/m and N/A^2. In these units the
     // identity eps_0 * mu_0 * c^2 == 1 holds, which pins both values at once.
     REQUIRE(close(eval_ok("epsilon_0"), 5.5263493618e7));
-    REQUIRE(close(eval_ok("mu_0"), 2.013354537e-25));
+    REQUIRE(close_rel(eval_ok("mu_0"), 2.013354537e-25));
     REQUIRE(close(eval_ok("epsilon_0 * mu_0 * c_light^2"), 1.0));
 }
 

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1821,6 +1821,63 @@ TEST_CASE("parse_and_expand_PALS reports expansion problems",
     rm_tmp(path);
 }
 
+TEST_CASE("repeat with an unusable count keeps the entry",
+          "[lattices][problems]") {
+    // A repeat count that cannot be read is reported *and* left alone. It used
+    // to be reported and then unrolled zero times, which removed the entry: the
+    // lattice came back with an empty `line`, silently missing a beamline.
+    auto counts_rejected = [](const char* count) {
+        const char* path = "tmp_repeat_bad.pals.yaml";
+        std::string doc = std::string(
+            "PALS:\n"
+            "  facility:\n"
+            "    - d1:\n"
+            "        kind: Drift\n"
+            "        length: 2.0\n"
+            "    - cell:\n"
+            "        kind: BeamLine\n"
+            "        line:\n"
+            "          - d1\n"
+            "    - main_line:\n"
+            "        kind: BeamLine\n"
+            "        line:\n"
+            "          - cell:\n"
+            "              repeat: ") + count + "\n" +
+            "    - lat1:\n"
+            "        kind: Lattice\n"
+            "        branches:\n"
+            "          - main_line\n"
+            "    - use: \"lat1\"\n";
+        write_tmp(path, doc.c_str());
+
+        struct lattices lat = parse_and_expand_PALS(path, nullptr);
+        REQUIRE(lat.expanded != nullptr);
+
+        bool reported = false;
+        for (size_t i = 0; i < lat.problems.count; ++i)
+            if (std::string(lat.problems.items[i])
+                    .find("repeat: invalid count") != std::string::npos)
+                reported = true;
+
+        // The `line` under main_line must still hold the cell entry rather than
+        // having been emptied.
+        YAMLNodeId line = find_by_key(lat.expanded, "line");
+        bool kept = line != YAML_NULL_ID && get_size(lat.expanded, line) > 0;
+
+        free_lattice_problems(lat.problems);
+        delete_tree(lat.original);
+        delete_tree(lat.combined);
+        delete_tree(lat.expanded);
+        delete_tree(lat.leftover);
+        rm_tmp(path);
+        return reported && kept;
+    };
+
+    REQUIRE(counts_rejected("bogus"));  // not a number at all
+    REQUIRE(counts_rejected("3x"));     // stoi would stop early and return 3
+    REQUIRE(counts_rejected("-1"));     // parses, but meaningless
+}
+
 TEST_CASE("parse_and_expand_PALS reports a missing lattice",
           "[lattices][problems]") {
     const char* path = "tmp_nolattice.pals.yaml";

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -272,7 +272,7 @@ TEST_CASE("add_scalar appends a keyed scalar to a MAP", "[modification]") {
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root = get_root(tree);
 
-    YAMLNodeId node = add_scalar(tree, root, "lang", "C++", END);
+    YAMLNodeId node = add_scalar(tree, root, "lang", "C++", YAML_END);
     REQUIRE(node != YAML_NULL_ID);
     REQUIRE(val_eq(tree, get_child_by_key(tree, root, "lang"), "C++"));
 
@@ -282,10 +282,10 @@ TEST_CASE("add_scalar appends a keyed scalar to a MAP", "[modification]") {
 TEST_CASE("add_scalar appends a keyless scalar to a sequence", "[modification]") {
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root = get_root(tree);
-    YAMLNodeId seq = add_sequence(tree, root, "items", END);
+    YAMLNodeId seq = add_sequence(tree, root, "items", YAML_END);
 
-    add_scalar(tree, seq, nullptr, "x", END);
-    add_scalar(tree, seq, nullptr, "y", END);
+    add_scalar(tree, seq, nullptr, "x", YAML_END);
+    add_scalar(tree, seq, nullptr, "y", YAML_END);
 
     REQUIRE(get_size(tree, seq) == 2);
     REQUIRE(val_eq(tree, get_child_by_index(tree, seq, 0), "x"));
@@ -297,8 +297,8 @@ TEST_CASE("add_scalar appends a keyless scalar to a sequence", "[modification]")
 TEST_CASE("add_scalar inserts at a specific index", "[modification]") {
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root = get_root(tree);
-    add_scalar(tree, root, "first",  "a", END);
-    add_scalar(tree, root, "third",  "c", END);
+    add_scalar(tree, root, "first",  "a", YAML_END);
+    add_scalar(tree, root, "third",  "c", YAML_END);
     add_scalar(tree, root, "second", "b", 1);   // insert between first and third
 
     char* k0 = get_node_key(tree, get_child_by_index(tree, root, 0));
@@ -318,7 +318,7 @@ TEST_CASE("add_scalar inserts at a specific index", "[modification]") {
 TEST_CASE("add_map creates an empty MAP child", "[modification]") {
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root = get_root(tree);
-    YAMLNodeId child = add_map(tree, root, "nested", END);
+    YAMLNodeId child = add_map(tree, root, "nested", YAML_END);
 
     REQUIRE(child != YAML_NULL_ID);
     REQUIRE(is_map(tree, child));
@@ -330,7 +330,7 @@ TEST_CASE("add_map creates an empty MAP child", "[modification]") {
 TEST_CASE("add_sequence creates an empty sequence child", "[modification]") {
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root = get_root(tree);
-    YAMLNodeId seq = add_sequence(tree, root, "list", END);
+    YAMLNodeId seq = add_sequence(tree, root, "list", YAML_END);
 
     REQUIRE(seq != YAML_NULL_ID);
     REQUIRE(is_sequence(tree, seq));
@@ -342,11 +342,12 @@ TEST_CASE("add_sequence creates an empty sequence child", "[modification]") {
 TEST_CASE("add_map inside a sequence creates an anonymous MAP element", "[modification]") {
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root = get_root(tree);
-    YAMLNodeId seq  = add_sequence(tree, root, "records", END);
-    YAMLNodeId elem = add_map(tree, seq, nullptr, END);   // seq element has no key
+    YAMLNodeId seq  = add_sequence(tree, root, "records", YAML_END);
+    // seq element has no key
+    YAMLNodeId elem = add_map(tree, seq, nullptr, YAML_END);
 
     REQUIRE(is_map(tree, elem));
-    add_scalar(tree, elem, "id", "1", END);
+    add_scalar(tree, elem, "id", "1", YAML_END);
     REQUIRE(val_eq(tree, get_child_by_key(tree, elem, "id"), "1"));
 
     delete_tree(tree);
@@ -354,7 +355,7 @@ TEST_CASE("add_map inside a sequence creates an anonymous MAP element", "[modifi
 
 TEST_CASE("add_scalar returns YAML_NULL_ID for a null parent", "[modification]") {
     YAMLTreeHandle tree = create_empty_tree();
-    REQUIRE(add_scalar(tree, YAML_NULL_ID, "k", "v", END) == YAML_NULL_ID);
+    REQUIRE(add_scalar(tree, YAML_NULL_ID, "k", "v", YAML_END) == YAML_NULL_ID);
     delete_tree(tree);
 }
 
@@ -365,7 +366,7 @@ TEST_CASE("add_scalar returns YAML_NULL_ID for a null parent", "[modification]")
 TEST_CASE("set_scalar updates an existing scalar value", "[modification]") {
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root  = get_root(tree);
-    YAMLNodeId child = add_scalar(tree, root, "key", "initial", END);
+    YAMLNodeId child = add_scalar(tree, root, "key", "initial", YAML_END);
 
     set_scalar(tree, child, "updated");
     REQUIRE(val_eq(tree, child, "updated"));
@@ -382,7 +383,7 @@ TEST_CASE("set_scalar on YAML_NULL_ID does not crash", "[modification]") {
 TEST_CASE("set_node_key renames a MAP child", "[modification]") {
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root  = get_root(tree);
-    YAMLNodeId child = add_scalar(tree, root, "old", "val", END);
+    YAMLNodeId child = add_scalar(tree, root, "old", "val", YAML_END);
 
     set_node_key(tree, child, "new");
 
@@ -405,8 +406,8 @@ TEST_CASE("set_node_key on YAML_NULL_ID does not crash", "[modification]") {
 TEST_CASE("remove_node removes a child from a MAP", "[modification]") {
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root = get_root(tree);
-    add_scalar(tree, root, "keep",   "yes", END);
-    add_scalar(tree, root, "remove", "no",  END);
+    add_scalar(tree, root, "keep",   "yes", YAML_END);
+    add_scalar(tree, root, "remove", "no",  YAML_END);
 
     YAMLNodeId to_remove = get_child_by_key(tree, root, "remove");
     remove_node(tree, root, to_remove);
@@ -470,10 +471,10 @@ TEST_CASE("deep_copy_children appends children to dst", "[copy]") {
     YAMLNodeId dst_root = get_root(dst);
 
     // Pre-populate dst with one entry
-    add_scalar(dst, dst_root, "existing", "yes", END);
+    add_scalar(dst, dst_root, "existing", "yes", YAML_END);
     REQUIRE(get_size(dst, dst_root) == 1);
 
-    deep_copy_children(dst, dst_root, src, get_root(src), END);
+    deep_copy_children(dst, dst_root, src, get_root(src), YAML_END);
 
     // Should now have original + 3 copied children
     REQUIRE(get_size(dst, dst_root) == 4);
@@ -487,7 +488,7 @@ TEST_CASE("deep_copy_children appends children to dst", "[copy]") {
 TEST_CASE("deep_copy_children inserts at index 0 (prepend)", "[copy]") {
     YAMLTreeHandle src = parse_string("new: value");
     YAMLTreeHandle dst = create_empty_tree();
-    add_scalar(dst, get_root(dst), "existing", "old", END);
+    add_scalar(dst, get_root(dst), "existing", "old", YAML_END);
 
     deep_copy_children(dst, get_root(dst), src, get_root(src), 0);
 
@@ -507,7 +508,7 @@ TEST_CASE("deep_copy_children inserts at index 0 (prepend)", "[copy]") {
 TEST_CASE("node_to_string emits valid YAML containing expected keys", "[emitting]") {
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root = get_root(tree);
-    add_scalar(tree, root, "greeting", "hello", END);
+    add_scalar(tree, root, "greeting", "hello", YAML_END);
 
     char* str = node_to_string(tree, root);
     REQUIRE(str != nullptr);
@@ -539,8 +540,8 @@ TEST_CASE("write_file writes a tree that can be read back", "[emitting][file]") 
     const char* path = "tmp_write.yaml";
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root = get_root(tree);
-    add_scalar(tree, root, "written", "true", END);
-    add_scalar(tree, root, "count",   "7",    END);
+    add_scalar(tree, root, "written", "true", YAML_END);
+    add_scalar(tree, root, "count",   "7",    YAML_END);
 
     REQUIRE(write_file(tree, path));
     delete_tree(tree);
@@ -574,12 +575,12 @@ TEST_CASE("Nested structure survives a write/read round-trip", "[round_trip]") {
     // Build: { server: { host: localhost, port: 8080 }, tags: [web, api] }
     YAMLTreeHandle tree = create_empty_tree();
     YAMLNodeId root   = get_root(tree);
-    YAMLNodeId server = add_map(tree, root, "server", END);
-    add_scalar(tree, server, "host", "localhost", END);
-    add_scalar(tree, server, "port", "8080",      END);
-    YAMLNodeId tags = add_sequence(tree, root, "tags", END);
-    add_scalar(tree, tags, nullptr, "web", END);
-    add_scalar(tree, tags, nullptr, "api", END);
+    YAMLNodeId server = add_map(tree, root, "server", YAML_END);
+    add_scalar(tree, server, "host", "localhost", YAML_END);
+    add_scalar(tree, server, "port", "8080",      YAML_END);
+    YAMLNodeId tags = add_sequence(tree, root, "tags", YAML_END);
+    add_scalar(tree, tags, nullptr, "web", YAML_END);
+    add_scalar(tree, tags, nullptr, "api", YAML_END);
 
     REQUIRE(write_file(tree, path));
     delete_tree(tree);
@@ -993,7 +994,7 @@ TEST_CASE("Map keys keep their file order through a parse/emit round-trip",
 TEST_CASE("add_scalar inserts at the requested position", "[key_order]") {
     YAMLTreeHandle tree = parse_string("zulu: 1\nalpha: 2");
     YAMLNodeId root = get_root(tree);
-    add_scalar(tree, root, "omega", "3", END);  // append
+    add_scalar(tree, root, "omega", "3", YAML_END);  // append
     add_scalar(tree, root, "first", "0", 0);    // prepend
 
     const std::vector<std::string> expected = {"first", "zulu", "alpha", "omega"};


### PR DESCRIPTION
Follow-ups from the three-repo review. One commit per concern; each builds and passes on its own.

The `classical_radius_factor` units question is deliberately **not** resolved here — the code keeps its current (correct) value and only the misleading comment around it is fixed. See below.

## Keep the repeat entry when its count cannot be read

The one behavior bug. `repeat: bogus` was reported as a problem and then, because `count` stayed at `0`, unrolled zero times and **removed** — the lattice came back with a plausible-looking `line: []`, silently missing a beamline. The only trace was a message in `problems`, which a caller need not read.

Now only a fully-understood count unrolls; anything else is reported and left as written. `stoi` is also made to consume the whole value (it stops at the first character it cannot use, so `repeat: 3x` was silently a count of 3), and negative counts are rejected.

Verified with teeth: the new test fails against the old behavior for all of `bogus`, `3x` and `-1`.

## Reject a NULL tree handle instead of dereferencing it

Every entry point refused a null *node* id, but only `get_root` and the `deep_copy_*` pair checked the *tree* handle — the rest crashed on `GET_TREE(handle)->tree`. Callers reach this API across an FFI boundary holding handles from functions that can fail, so this is a reachable mistake, not a contract violation.

All `YAML_API` functions that dereference a handle are now guarded (verified by a script that parses every `YAML_API` body rather than by eye). Removing a single guard turns the new test into a SEGFAULT, so it has teeth. `tree_to_string(NULL)` crashed inside `node_to_string` before reaching its node check; same guard fixes it.

## Make `struct lattices` reachable from C and prefix the `END` macro

`struct lattices` sat behind `#ifdef __cplusplus` because it "uses std::map". It does not — it is four `void*` and a `struct string_list`. The guard only kept the struct, and therefore `parse_and_expand_PALS` which returns it by value, out of reach of C callers. Unguarded, and the `<map>` include dropped from the public header (both `std::map` users include it directly). Verified by compiling the header as C11 and using the struct by value.

`END` was an unprefixed macro in a public header, clobbering that identifier in every including translation unit. Now `YAML_END`, defined as `YAML_NULL_ID` (the same sentinel). Nothing outside this repo used it — PALSJulia only ever used `YAML_NULL_ID`.

Also: `yaml_free_string`'s docs pointed at a `yaml_to_string()` that does not exist.

## Take `k_boltzmann` from APC and correct the grammar docstring

The grammar docstring described a precedence the parser does not implement (it put `unary` below `power`). Its grammar gives `-2^2 == 4`; the code gives `-4`, which is the Fortran/Bmad convention the tests already assert.

`k_boltzmann` was hand-derived as `1.380649e-23 / apc::J_PER_EV` although APC exports `K_BOLTZMANN`. They agree to 1.7e-11 relative, so this is provenance, not accuracy.

**On `classical_radius_factor`:** the comment claimed APC "does not export" it. APC does — but `apc::CLASSICAL_RADIUS_FACTOR` is **1e6 larger** than what PALS wants, because its mass is in MeV while `apc::M_ELECTRON` is in eV. The comment therefore invited a "simplification" that would silently rescale every lattice using it. The derivation is unchanged and correct (1.44e-9 eV·m, matching Bmad); only the comment now says what is actually going on, and flags that the units divergence is an open upstream question.

While pinning that down: `close()` floors its tolerance at 1e-9 **absolute**, which made every assertion on a value far below 1e-9 vacuous — including the existing `classical_radius_factor` check and `mu_0` at 2e-25. Added `close_rel()` for those. `classical_radius_factor`'s exponent is now pinned explicitly, since the `r_e*m_e` relation holds under either units convention and so could not have caught the 1e6 switch on its own.

## Not addressed

> **Correction (2026-07-17).** The paragraph below is wrong, and is kept only so the record is not silently rewritten. `atomicnumberof` is **a real bug in the CLib**, not an upstream misnomer being mirrored, and it is fixed in [AtomicAndPhysicalConstantsCLib#5](https://github.com/pals-project/AtomicAndPhysicalConstantsCLib/pull/5).
>
> The claim rested on reading `~/.julia/packages/AtomicAndPhysicalConstants/1BLJh` — which is v0.8.2, and is actually *APClite*, where `atomicnumberof(species) = species.iso`. The version the CLib mirrors is the dev checkout pinned by `codegen/Manifest.toml`, **v0.11.1**, where `atomicnumberof` returns the atomic number Z (negated for anti-atoms, an error for non-atoms) and `iso_of` is the separate mass-number accessor.
>
> The bug was also worse than the paragraph suggests: a bare element symbol carries `iso == -1`, so `atomicnumberof(species("Fe"))` returned **-1** rather than 26 for every element given without an explicit isotope.
>
> ~~Original text:~~

~~`atomicnumberof` returns `species.iso` — the mass number, not the atomic number. AAPC.jl defines it identically (`atomicnumberof(species) = species.iso`), so the CLib is faithfully mirroring an upstream misnomer; renaming it here would break the mirror. Worth an upstream issue.~~

## Testing

95/95 pass locally (2 new). Each commit builds and tests clean in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

