### PR TITLE
Drop `kind: BeamLine` from the branches of the expanded tree

### DIFF
--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -557,6 +557,43 @@ static void expand(ryml::Tree& t, size_t node,
 }
 
 /**
+ * Drop `kind: BeamLine` from every branch of the expanded lattice `lat_node`.
+ *
+ * A `branches:` entry is a branch, not a BeamLine. It is instantiated from a
+ * root BeamLine, and a branch carries no `kind` of its own -- its only optional
+ * components are `inherit` and `periodic`. Every route a branch reaches its
+ * contents by copies that root BeamLine's definition in wholesale, and so drags
+ * the definition's `kind: BeamLine` along: name substitution of a bare
+ * `- this_line`, an explicit `inherit: that_ring`, and a Fork building a new
+ * branch out of its `to_line`. Rather than special-case each route, strip the
+ * key once here, after expansion has produced every branch.
+ *
+ * Only branches are stripped. A sub-line nested in a `line:` is still a
+ * BeamLine and keeps its kind.
+ */
+static void strip_branch_kinds(ryml::Tree& t, size_t lat_node,
+                               std::map<size_t, size_t>& prov) {
+    size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
+    if (branches == ryml::NONE || !t.is_seq(branches)) return;
+
+    for (size_t entry = t.first_child(branches); entry != ryml::NONE;
+         entry = t.next_sibling(entry)) {
+        // Both the written form (`- name: {...}`) and a substituted bare name
+        // land as a map wrapping the single keyed branch node.
+        if (!t.is_map(entry)) continue;
+        size_t branch = t.first_child(entry);
+        if (branch == ryml::NONE || !t.is_map(branch)) continue;
+        // Anything other than BeamLine is a branch built from a definition that
+        // is not a beamline at all. That is a mistake in the file, and leaving
+        // the kind in place keeps the evidence of it visible.
+        if (child_val_str(t, branch, "kind") != "BeamLine") continue;
+        size_t kind = t.find_child(branch, ryml::to_csubstr("kind"));
+        erase_prov_subtree(t, kind, prov);
+        t.remove(kind);
+    }
+}
+
+/**
  * Recursive helper for make_combined_from_original. Starting from `node` in the
  * combined tree `t`, replace every "include: filename" element with the
  * contents of that file, sourced from the already-parsed `original` tree so
@@ -1285,6 +1322,10 @@ static void make_expanded_and_leftover(ParsedData* comb,
     } else {
         size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
         expand(t, lat_node, emap, work.provenance, problems, branches);
+
+        // Runs after expand, not inside it: a Fork appends branches as it goes,
+        // so only once expand has returned does `branches` hold them all.
+        strip_branch_kinds(t, lat_node, work.provenance);
 
         // Evaluate every mathematical expression to a number (immediate and
         // expr()-delayed alike). Node ids are unchanged -- only scalar text is

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -126,7 +126,10 @@ extern "C" {
  *           - `expanded`: the selected lattice fully expanded — scalars
  * substituted, repeats unrolled, inherits merged, and forks resolved — and
  * nothing else. Rooted at a map holding the single `name: {kind: Lattice, ...}`
- * entry, stripped of the PALS/facility scaffolding it was defined under.
+ * entry, stripped of the PALS/facility scaffolding it was defined under. Its
+ * `branches` entries are branches, not the BeamLines they were built from, and
+ * so carry no `kind`; a BeamLine nested in a `line:` is a sub-line and keeps
+ * its own.
  *           - `leftover`: the rest of the document, keeping its PALS/facility
  * scaffolding: element and beamline definitions, `use` statements, constants,
  * and any Lattice that was not the one expanded. Definitions substituted into

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1082,14 +1082,18 @@ TEST_CASE("Expansion preserves the key order of the source file", "[key_order]")
     REQUIRE(keys_of(lat.combined, c_line) == expected);
 
     // The expanded tree is rooted at the lattice entry itself, and the line is
-    // inlined under its `branches`.
+    // inlined under its `branches`. Inlining it made it a branch, which drops
+    // the `kind: BeamLine` it had as a definition; the surviving keys keep the
+    // order they were written in.
+    const std::vector<std::string> expected_branch = {"multipass", "length",
+                                                      "zero_point", "line"};
     YAMLNodeId lat1 = get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
     REQUIRE(key_eq(lat.expanded, lat1, "lat1"));
     YAMLNodeId branches = get_child_by_key(lat.expanded, lat1, "branches");
     YAMLNodeId e_line = get_child_by_index(
         lat.expanded, get_child_by_index(lat.expanded, branches, 0), 0);
     REQUIRE(key_eq(lat.expanded, e_line, "main_line"));
-    REQUIRE(keys_of(lat.expanded, e_line) == expected);
+    REQUIRE(keys_of(lat.expanded, e_line) == expected_branch);
 
     // Merging `inherit: thingB` brings the parent's keys in ahead of the
     // child's own, rather than sorting the merged result.
@@ -1542,6 +1546,108 @@ static YAMLNodeId find_by_key(YAMLTreeHandle t, const char* key) {
             stack.push_back(get_child_by_index(t, n, i));
     }
     return YAML_NULL_ID;
+}
+
+TEST_CASE("Expansion drops `kind: BeamLine` from every branch", "[lattices]") {
+    // The three routes a branch gets its contents by, in one file: `main` by
+    // name substitution, `alt` by `inherit`, and `to_dump` built by a Fork out
+    // of `dump_line`. Each copies a BeamLine definition in, and none of the
+    // copies may keep the definition's kind.
+    const char* path = "tmp_branch_kind.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - q1:\n"
+              "        kind: Quadrupole\n"
+              "        length: 0.5\n"
+              "    - dump_begin:\n"
+              "        kind: Marker\n"
+              "    - sub:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - q1\n"
+              "    - dump_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - dump_begin\n"
+              "    - ring:\n"
+              "        kind: BeamLine\n"
+              "        periodic: false\n"
+              "        line:\n"
+              "          - sub\n"
+              "          - f1:\n"
+              "              kind: Fork\n"
+              "              ForkP:\n"
+              "                to_line: dump_line\n"
+              "                destination_element: dump_begin\n"
+              "                new_branch: to_dump\n"
+              "    - main:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - q1\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - main\n"
+              "          - alt:\n"
+              "              inherit: ring\n"
+              "              periodic: true\n"
+              "    - use: lat1\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+
+    YAMLNodeId lat1 = get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
+    YAMLNodeId branches = get_child_by_key(lat.expanded, lat1, "branches");
+    REQUIRE(get_size(lat.expanded, branches) == 3);
+
+    // The lattice itself is not a branch and keeps its kind.
+    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, lat1, "kind"),
+                   "Lattice"));
+
+    const char* names[] = {"main", "alt", "to_dump"};
+    for (size_t i = 0; i < 3; i++) {
+        YAMLNodeId branch = get_child_by_index(
+            lat.expanded, get_child_by_index(lat.expanded, branches, i), 0);
+        REQUIRE(key_eq(lat.expanded, branch, names[i]));
+        REQUIRE(get_child_by_key(lat.expanded, branch, "kind") == YAML_NULL_ID);
+        REQUIRE(get_child_by_key(lat.expanded, branch, "line") != YAML_NULL_ID);
+    }
+
+    // A branch keeps the components that are its own. `periodic: true` also
+    // survives the merge of `ring`'s `periodic: false`, as the branch setting
+    // overrides the root BeamLine's.
+    YAMLNodeId alt = get_child_by_index(
+        lat.expanded, get_child_by_index(lat.expanded, branches, 1), 0);
+    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, alt, "inherit"),
+                   "ring"));
+    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, alt, "periodic"),
+                   "true"));
+
+    // Only branches lose the kind: `sub` sits inside a `line:`, where it is
+    // still a BeamLine.
+    YAMLNodeId sub = get_child_by_index(
+        lat.expanded,
+        get_child_by_index(lat.expanded,
+                           get_child_by_key(lat.expanded, alt, "line"), 0),
+        0);
+    REQUIRE(key_eq(lat.expanded, sub, "sub"));
+    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, sub, "kind"),
+                   "BeamLine"));
+
+    // Expansion copies a definition rather than moving it, and the definition
+    // left standing in leftover is a BeamLine still.
+    YAMLNodeId l_main = facility_param(lat.leftover, "main");
+    REQUIRE(l_main != YAML_NULL_ID);
+    REQUIRE(val_eq(lat.leftover, get_child_by_key(lat.leftover, l_main, "kind"),
+                   "BeamLine"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
 }
 
 TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",


### PR DESCRIPTION
The `expanded` tree carried `kind: BeamLine` on every branch. It should not: a `branches:` entry is a *branch*, not the BeamLine it was instantiated from, and per `lattice-construction.md` a branch has no `kind` of its own — its only optional components are `inherit` and `periodic`.

Expansion reaches a branch by copying the root BeamLine's definition in wholesale, and the definition's `kind: BeamLine` came along for the ride.

### Approach

Three separate routes do that copying:

- name substitution of a bare `- this_line`,
- an explicit `inherit: that_ring`,
- a `Fork` building a new branch out of its `to_line`.

Rather than special-case each, `strip_branch_kinds()` strips the key once, after expansion has produced every branch. It has to run *after* `expand()` rather than inside it: a Fork appends branches as it goes, so only once `expand()` returns does `branches` hold them all.

`expand.pals.yaml` now expands with `inj_line` and the fork-built `this_dump` both free of `kind`, while nested elements keep theirs.

### Deliberate limits

- **Sub-lines keep their kind.** A BeamLine nested in a `line:` is still a BeamLine, not a branch.
- **A non-BeamLine kind is left alone.** A `branches:` entry resolving to, say, a Quadrupole is a mistake in the file; leaving the kind visible keeps the evidence.

Nothing else keyed off this: name matching identifies branches by the presence of a `line:` child, not by `kind`.

### Tests

- **New**: one lattice exercising all three routes to a branch at once, plus checks that the Lattice keeps `kind: Lattice`, a sub-line keeps `kind: BeamLine`, `inherit`/`periodic` survive on the branch, and the definition left in `leftover` is untouched. Verified it fails without the fix.
- **Updated**: the key-order test, which asserted the old shape.

96/96 pass. The `expanded` contract in `yaml_c_wrapper.h` is updated to state the new shape.

Merge before pals-project/PALSJulia.jl#45, which updates a Julia test that asserted the old shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)