### PR TITLE
Add get_parameter_value / get_lattice_parameter_value

### DIFF
--- a/docs/src/guide/usage.md
+++ b/docs/src/guide/usage.md
@@ -72,12 +72,35 @@ and `get_size`; inspect nodes with `is_map`, `is_sequence`, `is_scalar`,
 and `deep_copy_children`. Serialize with `node_to_string` / `tree_to_string`, or
 `write_file`. Every one of these is listed in the [API Reference](../api.md).
 
-Two more entry points build on the expanded tree:
+Three more entry points build on the expanded tree:
 
 - `build_correspondence_map` links a node across the four views (their
   provenance is recorded as the trees are derived from one another).
 - `match_names` finds every named construct that a PALS *Name Matching* string
   refers to.
+- `get_parameter_value` looks up a single parameter value by a *Name Matching*
+  string — an element parameter (with a path) or, as a bare name, a constant or
+  variable. It returns a `param_value` tagged as a number, a string, or missing.
+  The value is returned as stored, **not** evaluated: a plain number comes back as
+  `PARAM_VALUE_NUMBER`, while an expression (e.g. `0.3 * 5`), a species name such
+  as `#3He`, or other text comes back verbatim as a string (evaluating is the job
+  of expansion — the `expanded` tree already holds numbers). An unset element
+  parameter yields its default (`0` for now); and a string that identifies no
+  single value — no matching element/constant/variable, a bare element name, a
+  path stopping on a whole group, or matches that disagree — yields
+  `PARAM_VALUE_MISSING`. When the tag is `PARAM_VALUE_STRING`, free the returned
+  `string` with `yaml_free_string`.
+
+  ```c
+  struct param_value v = get_parameter_value(expanded, "lat1>>>B1a>BendP.e1");
+  if (v.kind == PARAM_VALUE_NUMBER) printf("%g\n", v.number);
+  else if (v.kind == PARAM_VALUE_STRING) { puts(v.string); yaml_free_string(v.string); }
+  ```
+- `get_lattice_parameter_value` is the whole-lattice form: pass the `expanded` and
+  `leftover` handles from one `parse_and_expand_PALS()` result and it looks in
+  `expanded` first (element parameters), then `leftover` (constants, variables,
+  and unused definitions) — never in the raw `original`/`combined` trees. Values
+  therefore come back already evaluated.
 
 ## Examples
 

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -1,6 +1,7 @@
 #include "yaml_c_wrapper.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -1589,6 +1590,108 @@ static void free_selector(NameSelector& sel) {
     if (sel.name) pcre2_code_free(sel.name);
 }
 
+// Heap-copy a std::string into a null-terminated C string the caller frees with
+// yaml_free_string() (i.e. allocated with new[], matching that free).
+static char* new_c_string(const std::string& s) {
+    char* result = new char[s.size() + 1];
+    std::memcpy(result, s.c_str(), s.size() + 1);
+    return result;
+}
+
+// Turn a raw scalar value into a param_value, returning it as stored — the value
+// is NOT evaluated. A plain numeric literal (the whole string, bar surrounding
+// whitespace, is a finite number) becomes a number; anything else — an
+// expression like "0.3 * 5", a species name like "#3He", or any other text — is
+// returned verbatim as a string. Evaluation is the job of lattice expansion or
+// evaluate_pals_expression, not of this accessor: on the `expanded` tree values
+// are already numbers, while the raw views keep their expressions.
+static struct param_value value_from_raw(const std::string& raw) {
+    struct param_value v = {PARAM_VALUE_STRING, 0.0, nullptr};
+    const char* s = raw.c_str();
+    char* end = nullptr;
+    double d = std::strtod(s, &end);  // skips leading whitespace itself
+    while (*end == ' ' || *end == '\t' || *end == '\n' || *end == '\r') ++end;
+    if (end != s && *end == '\0' && std::isfinite(d)) {
+        v.kind = PARAM_VALUE_NUMBER;
+        v.number = d;
+    } else {
+        v.string = new_c_string(raw);
+    }
+    return v;
+}
+
+// Resolve one element's parameter into a param_value. `ele` is the element
+// definition map; `path` the dotted parameter path walked from it. A parameter
+// that is not present yields the default (numeric 0 for now); a scalar value is
+// returned as stored (see value_from_raw); a path that stops on a whole
+// parameter group rather than a single value is not a parameter value and yields
+// PARAM_VALUE_MISSING.
+static struct param_value param_value_for_element(
+    const ryml::Tree& t, size_t ele, const std::vector<std::string>& path) {
+    size_t node = resolve_param_path(t, ele, path);
+    if (node == ryml::NONE) {  // element found, parameter unset -> default
+        struct param_value v = {PARAM_VALUE_NUMBER, 0.0, nullptr};
+        return v;
+    }
+    if (!t.has_val(node)) {  // resolved to a group/sequence, not a value
+        struct param_value v = {PARAM_VALUE_MISSING, 0.0, nullptr};
+        return v;
+    }
+    return value_from_raw(std::string(t.val(node).str, t.val(node).len));
+}
+
+// The value of an already-matched node, for a bare-name lookup that resolves to
+// a constant or variable. A compact-form entry (`name: value`) is itself the
+// scalar; a full-form entry (a map with `kind: constant|variable`) carries its
+// value under a `value:` child. Any other node — an element definition or a
+// parameter group — has no single scalar value and yields PARAM_VALUE_MISSING.
+static struct param_value value_of_const_var(const ryml::Tree& t, size_t node) {
+    struct param_value v = {PARAM_VALUE_MISSING, 0.0, nullptr};
+    if (node == ryml::NONE) return v;
+    if (t.has_val(node))  // compact form: the matched node is the value scalar
+        return value_from_raw(std::string(t.val(node).str, t.val(node).len));
+    if (t.is_map(node)) {
+        std::string kind = child_val_str(t, node, "kind");
+        if (kind == "constant" || kind == "variable") {
+            size_t val = t.find_child(node, ryml::to_csubstr("value"));
+            if (val != ryml::NONE && t.has_val(val))
+                return value_from_raw(std::string(t.val(val).str, t.val(val).len));
+        }
+    }
+    return v;
+}
+
+// Whether two param_values carry the same value. Used to collapse several
+// matches into one result: identical values agree, conflicting values leave the
+// parameter unidentified.
+static bool param_value_eq(const struct param_value& a,
+                           const struct param_value& b) {
+    if (a.kind != b.kind) return false;
+    if (a.kind == PARAM_VALUE_NUMBER) return a.number == b.number;
+    if (a.kind == PARAM_VALUE_STRING) return std::strcmp(a.string, b.string) == 0;
+    return true;  // both PARAM_VALUE_MISSING
+}
+
+// Reduce a list of per-match param_values to a single result: the shared value
+// when they all agree (the same element reused, or several that all default),
+// or PARAM_VALUE_MISSING when any two conflict. Consumes `vs`, freeing every
+// owned string except the one handed back.
+static struct param_value reduce_param_values(std::vector<struct param_value>& vs) {
+    struct param_value missing = {PARAM_VALUE_MISSING, 0.0, nullptr};
+    if (vs.empty()) return missing;
+    bool conflict = false;
+    for (size_t i = 1; i < vs.size(); ++i)
+        if (!param_value_eq(vs[0], vs[i])) { conflict = true; break; }
+    if (conflict) {
+        for (struct param_value& v : vs)
+            if (v.string) yaml_free_string(v.string);
+        return missing;
+    }
+    for (size_t i = 1; i < vs.size(); ++i)  // keep vs[0]'s string, free the rest
+        if (vs[i].string) yaml_free_string(vs[i].string);
+    return vs[0];
+}
+
 // True if `re` (null = match any) matches any of `names`.
 static bool any_full_match(pcre2_code* re, const std::vector<std::string>& names) {
     if (!re) return true;
@@ -1674,12 +1777,11 @@ static void collect_const_var(const ryml::Tree& t, size_t named,
 }
 
 // Match a constant/variable name pattern against every constant and variable
-// defined directly under the PALS node or the facility node.
-static void match_const_var(const ryml::Tree& t, pcre2_code* name_re,
-                            std::vector<size_t>& out, std::set<size_t>& seen) {
-    size_t root = t.root_id();
-    if (root == ryml::NONE || !t.is_map(root)) return;
-    size_t pals = t.find_child(root, ryml::to_csubstr("PALS"));
+// defined directly under a single PALS node (or its facility sub-node).
+static void match_const_var_in_pals(const ryml::Tree& t, size_t pals,
+                                    pcre2_code* name_re,
+                                    std::vector<size_t>& out,
+                                    std::set<size_t>& seen) {
     if (pals == ryml::NONE) return;
     for (size_t c = t.first_child(pals); c != ryml::NONE;
          c = t.next_sibling(c)) {
@@ -1693,6 +1795,25 @@ static void match_const_var(const ryml::Tree& t, pcre2_code* name_re,
             collect_const_var(t, c, name_re, out, seen);
         }
     }
+}
+
+// Match constant/variable names across the tree. The PALS node sits at the root
+// in the combined, leftover and expanded views; in the `original` view it is
+// nested one level down under a per-file wrapper keyed by filename, and there
+// may be several (one per included file). Look in both places so a constant is
+// found in whichever tree actually holds it. The `seen` set keeps the root-level
+// PALS node from being scanned twice.
+static void match_const_var(const ryml::Tree& t, pcre2_code* name_re,
+                            std::vector<size_t>& out, std::set<size_t>& seen) {
+    size_t root = t.root_id();
+    if (root == ryml::NONE || !t.is_map(root)) return;
+
+    match_const_var_in_pals(t, t.find_child(root, ryml::to_csubstr("PALS")),
+                            name_re, out, seen);
+    for (size_t c = t.first_child(root); c != ryml::NONE; c = t.next_sibling(c))
+        if (t.is_map(c))
+            match_const_var_in_pals(
+                t, t.find_child(c, ryml::to_csubstr("PALS")), name_re, out, seen);
 }
 
 // ============================================================
@@ -1840,6 +1961,63 @@ YAML_API struct name_matches match_names(YAMLTreeHandle tree,
 
 YAML_API void free_name_matches(struct name_matches matches) {
     delete[] matches.nodes;
+}
+
+YAML_API struct param_value get_parameter_value(YAMLTreeHandle tree,
+                                                const char* match_string) {
+    struct param_value out = {PARAM_VALUE_MISSING, 0.0, nullptr};
+    if (!tree || !match_string) return out;
+    ryml::Tree& t = GET_TREE(tree);
+
+    NameSelector sel = parse_selector(std::string(match_string));
+    if (!sel.valid) {  // a bad pattern identifies nothing
+        free_selector(sel);
+        return out;
+    }
+
+    std::vector<struct param_value> values;
+
+    if (sel.has_param) {
+        // An element parameter. Find the matching element(s) ignoring the
+        // parameter path — with has_param cleared, match_elements yields the
+        // element definition maps themselves — then walk the path down from
+        // each, so an element that exists but does not set the parameter still
+        // yields its default.
+        std::vector<std::string> path = sel.path;
+        sel.has_param = false;
+        std::vector<size_t> eles;
+        std::set<size_t> seen;
+        match_elements(t, t.root_id(), "", {}, sel, eles, seen);
+        free_selector(sel);
+        if (eles.empty()) return out;  // no such element -> missing
+        for (size_t ele : eles)
+            values.push_back(param_value_for_element(t, ele, path));
+    } else {
+        // No parameter path. A bare name — no lattice/branch/kind qualifier —
+        // resolves to a constant or variable, mirroring match_names. A
+        // qualified name with no path identifies an element, which has no
+        // scalar value, so it stays missing.
+        bool bare = !sel.lattice_present && !sel.branch_present && !sel.has_kind;
+        std::vector<size_t> nodes;
+        std::set<size_t> seen;
+        if (bare) match_const_var(t, sel.name, nodes, seen);
+        free_selector(sel);
+        if (nodes.empty()) return out;  // no such constant/variable -> missing
+        for (size_t node : nodes)
+            values.push_back(value_of_const_var(t, node));
+    }
+
+    return reduce_param_values(values);
+}
+
+YAML_API struct param_value get_lattice_parameter_value(
+    YAMLTreeHandle expanded, YAMLTreeHandle leftover, const char* match_string) {
+    // Element parameters live in the expanded lattice; look there first.
+    struct param_value v = get_parameter_value(expanded, match_string);
+    if (v.kind != PARAM_VALUE_MISSING) return v;
+    // Constants, variables and unused definitions live in the facility
+    // scaffolding kept by the leftover tree.
+    return get_parameter_value(leftover, match_string);
 }
 
 // --- PARSING & MEMORY ---

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -262,6 +262,96 @@ YAML_API struct name_matches match_names(YAMLTreeHandle tree,
  */
 YAML_API void free_name_matches(struct name_matches matches);
 
+// --- PARAMETER VALUES ---
+//
+// The three outcomes of get_parameter_value(). PARAM_VALUE_NUMBER also covers
+// the "parameter identified but not set" case, which returns the parameter's
+// default value (0 for every parameter, for now — real per-parameter defaults
+// come later).
+enum param_value_kind {
+    PARAM_VALUE_MISSING = 0,  // the match string did not identify a parameter
+    PARAM_VALUE_NUMBER = 1,   // numeric value, in `number`
+    PARAM_VALUE_STRING = 2,   // non-numeric string value, in `string`
+};
+
+// The result of get_parameter_value(). When `kind` is PARAM_VALUE_STRING,
+// `string` is a heap-allocated null-terminated copy the caller must release
+// with yaml_free_string(); it is NULL for the other two kinds, which need no
+// freeing.
+struct param_value {
+    int kind;       // one of enum param_value_kind
+    double number;  // valid when kind == PARAM_VALUE_NUMBER
+    char* string;   // valid when kind == PARAM_VALUE_STRING; NULL otherwise
+};
+
+/**
+ * Looks up the value of a single lattice parameter named by a PALS
+ * name-matching string.
+ *
+ * `match_string` uses the same syntax as match_names(). It names either an
+ * element parameter (with a `>{group}.{sub}. ... .{param}` path) or, as a bare
+ * name (no lattice/branch/kind qualifier and no path), a constant or variable —
+ * the same constructs match_names() resolves. Run an element-parameter query on
+ * the `expanded` tree of a parse_and_expand_PALS() result, where constants and
+ * variables referenced by a value have already been substituted; constants and
+ * variables themselves live in the facility scaffolding, so look them up in any
+ * view that keeps it — `original`, `combined`, or `leftover` — but not
+ * `expanded`, which drops it (exactly as with match_names()).
+ *
+ * The value is returned as stored; it is NOT evaluated. A plain numeric literal
+ * comes back as a number (PARAM_VALUE_NUMBER); anything else — an expression such
+ * as "0.3 * 5", a species name like "#3He", or any other text — comes back
+ * verbatim as a string (PARAM_VALUE_STRING). Evaluation is the job of lattice
+ * expansion (the `expanded` tree already holds numbers) or
+ * evaluate_pals_expression, not of this accessor.
+ *
+ * Resolution, and the resulting `kind`:
+ *   - Element parameter, set: its stored value — a number, or a string for an
+ *     expression or other non-numeric text.
+ *   - Element parameter, not set: the default value is returned
+ *     (PARAM_VALUE_NUMBER with number 0, for now).
+ *   - Constant or variable (bare name): its stored value, the same way.
+ *   - Nothing is identified: PARAM_VALUE_MISSING. That covers no matching
+ *     element, no matching constant/variable, a bare element name (an element
+ *     has no single scalar value), a path that stops on a whole parameter group,
+ *     and several matches that carry conflicting values. (Matches that agree —
+ *     the same element reused, or several that all take the default — collapse
+ *     to the one shared value.)
+ *
+ * @param tree         Handle to the tree to search.
+ * @param match_string Null-terminated name-matching string.
+ * @return A param_value. If `kind` is PARAM_VALUE_STRING the caller must free
+ *         `string` with yaml_free_string().
+ */
+YAML_API struct param_value get_parameter_value(YAMLTreeHandle tree,
+                                                const char* match_string);
+
+/**
+ * Looks up a parameter value across the two trees of an expanded lattice that
+ * carry live values: the `expanded` lattice (element parameters, already
+ * evaluated) and the `leftover` facility scaffolding (constants, variables, and
+ * any element/beamline definitions not spliced into the lattice).
+ *
+ * This is the whole-lattice form of get_parameter_value(): the caller passes the
+ * two relevant handles from a parse_and_expand_PALS() result instead of picking a
+ * tree by hand. `expanded` is consulted first; only if it does not identify the
+ * parameter is `leftover` tried. The `original` and `combined` trees are
+ * deliberately not consulted — they hold raw, pre-expansion text, so a value read
+ * from them would be unevaluated and, for reused definitions, duplicated.
+ *
+ * Either handle may be NULL (treated as "no match" for that tree). The value's
+ * `kind`, string ownership, and the number/string/missing rules are exactly
+ * those of get_parameter_value().
+ *
+ * @param expanded     Handle to the `expanded` tree (element parameters).
+ * @param leftover     Handle to the `leftover` tree (constants/variables).
+ * @param match_string Null-terminated name-matching string.
+ * @return A param_value. If `kind` is PARAM_VALUE_STRING the caller must free
+ *         `string` with yaml_free_string().
+ */
+YAML_API struct param_value get_lattice_parameter_value(
+    YAMLTreeHandle expanded, YAMLTreeHandle leftover, const char* match_string);
+
 // --- PARSING & MEMORY ---
 
 /**

--- a/tests/test_yaml_c_wrapper.cpp
+++ b/tests/test_yaml_c_wrapper.cpp
@@ -1,4 +1,5 @@
 #define CATCH_CONFIG_MAIN
+#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <algorithm>
 #include <cmath>
@@ -1381,6 +1382,206 @@ TEST_CASE("a malformed pattern yields an empty result, not a crash",
     struct name_matches m = match_names(t, "(unclosed");
     REQUIRE(m.count == 0);
     free_name_matches(m);
+    delete_tree(t);
+}
+
+// ============================================================
+// PARAMETER VALUES
+// ============================================================
+
+TEST_CASE("get_parameter_value returns a set numeric value", "[param]") {
+    YAMLTreeHandle t = parse_string(MATCH_YAML);
+    // lat1>>> disambiguates the two B1a's.
+    struct param_value v = get_parameter_value(t, "lat1>>>B1a>length");
+    REQUIRE(v.kind == PARAM_VALUE_NUMBER);
+    REQUIRE(v.number == Catch::Approx(1.2));
+
+    v = get_parameter_value(t, "lat1>>>B1a>BendP.e1");
+    REQUIRE(v.kind == PARAM_VALUE_NUMBER);
+    REQUIRE(v.number == Catch::Approx(0.1));
+    delete_tree(t);
+}
+
+TEST_CASE("get_parameter_value returns the default for an unset parameter",
+          "[param]") {
+    YAMLTreeHandle t = parse_string(MATCH_YAML);
+    // Q1 exists but has no BendP.g; the default (0, for now) comes back.
+    struct param_value v = get_parameter_value(t, "Q1>BendP.g");
+    REQUIRE(v.kind == PARAM_VALUE_NUMBER);
+    REQUIRE(v.number == 0.0);
+
+    // A name that is not a real parameter is indistinguishable from an unset one
+    // without a schema, so it also takes the default.
+    v = get_parameter_value(t, "Q1>not_a_param");
+    REQUIRE(v.kind == PARAM_VALUE_NUMBER);
+    REQUIRE(v.number == 0.0);
+    delete_tree(t);
+}
+
+TEST_CASE("get_parameter_value returns a non-numeric value as a string",
+          "[param]") {
+    YAMLTreeHandle t = parse_string(
+        "PALS:\n"
+        "  facility:\n"
+        "    - lat:\n"
+        "        kind: Lattice\n"
+        "        branches:\n"
+        "          - bl:\n"
+        "              kind: BeamLine\n"
+        "              line:\n"
+        "                - fl:\n"
+        "                    kind: Foil\n"
+        "                    length: 2 * 0.5\n"
+        "                    ReferenceP:\n"
+        "                      species_ref: \"#3He\"\n");
+    // A species name is not numeric: returned as a string.
+    struct param_value v = get_parameter_value(t, "fl>ReferenceP.species_ref");
+    REQUIRE(v.kind == PARAM_VALUE_STRING);
+    REQUIRE(v.string != nullptr);
+    REQUIRE(std::string(v.string) == "#3He");
+    yaml_free_string(v.string);
+
+    // An element parameter whose value is an expression: returned verbatim,
+    // not evaluated.
+    v = get_parameter_value(t, "fl>length");
+    REQUIRE(v.kind == PARAM_VALUE_STRING);
+    REQUIRE(std::string(v.string) == "2 * 0.5");
+    yaml_free_string(v.string);
+    delete_tree(t);
+}
+
+TEST_CASE("get_parameter_value returns missing when nothing is identified",
+          "[param]") {
+    YAMLTreeHandle t = parse_string(MATCH_YAML);
+
+    // No such element.
+    REQUIRE(get_parameter_value(t, "nosuch>length").kind == PARAM_VALUE_MISSING);
+    // No parameter path — a bare element names no parameter.
+    REQUIRE(get_parameter_value(t, "B1a").kind == PARAM_VALUE_MISSING);
+    // The path resolves to a whole parameter group, not a single value.
+    REQUIRE(get_parameter_value(t, "lat1>>>B1a>BendP").kind ==
+            PARAM_VALUE_MISSING);
+    // Malformed pattern.
+    REQUIRE(get_parameter_value(t, "(unclosed>length").kind ==
+            PARAM_VALUE_MISSING);
+    // Null args.
+    REQUIRE(get_parameter_value(nullptr, "B1a>length").kind ==
+            PARAM_VALUE_MISSING);
+    REQUIRE(get_parameter_value(t, nullptr).kind == PARAM_VALUE_MISSING);
+    delete_tree(t);
+}
+
+TEST_CASE("get_parameter_value reads a constant or variable by bare name",
+          "[param]") {
+    YAMLTreeHandle t = parse_string(MATCH_YAML);
+
+    // Compact-form constant with a plain numeric value.
+    struct param_value v = get_parameter_value(t, "a_two");
+    REQUIRE(v.kind == PARAM_VALUE_NUMBER);
+    REQUIRE(v.number == Catch::Approx(5.0));
+
+    // Its value is an expression, returned verbatim (not evaluated).
+    v = get_parameter_value(t, "a_const");
+    REQUIRE(v.kind == PARAM_VALUE_STRING);
+    REQUIRE(std::string(v.string) == "0.3 * r_electron");
+    yaml_free_string(v.string);
+
+    // Full-form variable: the value lives under a `value:` child.
+    v = get_parameter_value(t, "my_var");
+    REQUIRE(v.kind == PARAM_VALUE_NUMBER);
+    REQUIRE(v.number == Catch::Approx(37.0));
+
+    // A pattern matching two differently-valued constants is a conflict.
+    REQUIRE(get_parameter_value(t, "a_.*").kind == PARAM_VALUE_MISSING);
+
+    // A bare element name is not a value.
+    REQUIRE(get_parameter_value(t, "Q1").kind == PARAM_VALUE_MISSING);
+    delete_tree(t);
+}
+
+TEST_CASE("constants are found under the original tree's per-file wrapper",
+          "[param][matching]") {
+    // The `original` view nests the whole document one level down, under a map
+    // keyed by filename. Both match_names and get_parameter_value must reach the
+    // PALS node there, not only when it sits at the root.
+    YAMLTreeHandle t = parse_string(
+        "\"/path/to/lat.pals.yaml\":\n"
+        "  PALS:\n"
+        "    facility:\n"
+        "      - constants:\n"
+        "          - a_const: 0.3 * 5\n");
+
+    struct name_matches m = match_names(t, "a_const");
+    REQUIRE(m.count == 1);
+    free_name_matches(m);
+
+    // The value is an expression, returned verbatim (the raw view keeps it).
+    struct param_value v = get_parameter_value(t, "a_const");
+    REQUIRE(v.kind == PARAM_VALUE_STRING);
+    REQUIRE(std::string(v.string) == "0.3 * 5");
+    yaml_free_string(v.string);
+    delete_tree(t);
+}
+
+TEST_CASE("get_lattice_parameter_value tries expanded, then leftover",
+          "[param]") {
+    // Stand-ins for the two live trees of a parse_and_expand_PALS() result: the
+    // expanded lattice carries element parameters; the leftover facility carries
+    // constants and variables.
+    YAMLTreeHandle expanded = parse_string(
+        "fodo:\n"
+        "  kind: Lattice\n"
+        "  branches:\n"
+        "    - main:\n"
+        "        line:\n"
+        "          - Q1: {kind: Quadrupole, length: 0.5}\n");
+    YAMLTreeHandle leftover = parse_string(
+        "PALS:\n"
+        "  facility:\n"
+        "    - constants:\n"
+        "        - a_two: 5\n");
+
+    // An element parameter is found in the expanded tree.
+    struct param_value v =
+        get_lattice_parameter_value(expanded, leftover, "Q1>length");
+    REQUIRE(v.kind == PARAM_VALUE_NUMBER);
+    REQUIRE(v.number == Catch::Approx(0.5));
+
+    // A constant is not in expanded, so leftover is consulted.
+    v = get_lattice_parameter_value(expanded, leftover, "a_two");
+    REQUIRE(v.kind == PARAM_VALUE_NUMBER);
+    REQUIRE(v.number == Catch::Approx(5.0));
+
+    // Found in neither -> missing.
+    REQUIRE(get_lattice_parameter_value(expanded, leftover, "nope>x").kind ==
+            PARAM_VALUE_MISSING);
+
+    // Either handle may be NULL.
+    REQUIRE(get_lattice_parameter_value(nullptr, leftover, "a_two").kind ==
+            PARAM_VALUE_NUMBER);
+    REQUIRE(get_lattice_parameter_value(expanded, nullptr, "Q1>length").kind ==
+            PARAM_VALUE_NUMBER);
+    REQUIRE(get_lattice_parameter_value(expanded, nullptr, "a_two").kind ==
+            PARAM_VALUE_MISSING);
+
+    delete_tree(expanded);
+    delete_tree(leftover);
+}
+
+TEST_CASE("get_parameter_value collapses agreeing matches, rejects conflicts",
+          "[param]") {
+    YAMLTreeHandle t = parse_string(MATCH_YAML);
+
+    // B1a matches in both lattices with different lengths (1.2 vs 9.9): a
+    // conflict leaves the parameter unidentified.
+    REQUIRE(get_parameter_value(t, "B1a>length").kind == PARAM_VALUE_MISSING);
+
+    // B1a and B1b both live in lat1 and are both Bends; their equal `kind`
+    // collapses to a single string value.
+    struct param_value v = get_parameter_value(t, "lat1>>>B1.>kind");
+    REQUIRE(v.kind == PARAM_VALUE_STRING);
+    REQUIRE(std::string(v.string) == "Bend");
+    yaml_free_string(v.string);
     delete_tree(t);
 }
 


### PR DESCRIPTION
## What

Adds a way to look up a single lattice parameter's value by a PALS *Name Matching* string, returning a `param_value` tagged union (`PARAM_VALUE_NUMBER` / `PARAM_VALUE_STRING` / `PARAM_VALUE_MISSING`).

### `get_parameter_value(tree, match_string)` — the primitive
Resolves an element parameter (via a `>group.….param` path) or, for a *bare* name, a constant/variable — the same constructs `match_names` resolves.

- **Value as stored, not evaluated.** A plain numeric literal → `PARAM_VALUE_NUMBER`; anything else (an expression like `0.3 * 5`, a species name like `#3He`, other text) → `PARAM_VALUE_STRING`, verbatim. Evaluation is the job of expansion / `evaluate_pals_expression`, not this accessor.
- **Unset element parameter** → its default (`0` for every parameter, for now).
- **Nothing identified** → `PARAM_VALUE_MISSING`: no match, a bare element name, a path stopping on a whole group, or matches that disagree. Matches that *agree* collapse to the one shared value.

Constant/variable lookup descends one level so the per-file wrapper in the `original` tree is handled too.

### `get_lattice_parameter_value(expanded, leftover, match_string)` — whole-lattice form
Pass the two live-value handles from a `parse_and_expand_PALS()` result. Searches `expanded` first (element parameters, already evaluated), then `leftover` (constants, variables, unused definitions) — never the raw `original`/`combined` trees. Either handle may be `NULL`.

## Memory

`PARAM_VALUE_STRING` returns a heap-allocated string the caller frees with `yaml_free_string`; the other kinds need no freeing.

## Tests & docs

- Adds `[param]` tests covering set/unset/default, string values, missing cases, constant/variable by bare name (incl. the per-file-wrapper regression), collapse vs. conflict, and the expanded-then-leftover fallthrough with NULL handling. **104/104** pass.
- Documents both functions in `docs/src/guide/usage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
