### PR TITLE
docs: add GitHub repository backlink to the sidebar

### DIFF
--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -48,5 +48,20 @@ html_theme_options = {
     'source_directory': 'docs/src/',
     'navigation_with_keys': True,
     'sidebar_hide_name': False,
+    # GitHub backlink shown at the bottom of the sidebar (Furo has no topbar;
+    # footer_icons is its designated spot for a repository link).
+    'footer_icons': [
+        {
+            'name': 'GitHub',
+            'url': 'https://github.com/pals-project/pals-cpp',
+            'html': """
+                <svg stroke="currentColor" fill="currentColor" stroke-width="0"
+                     viewBox="0 0 16 16">
+                    <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+                </svg>
+            """,
+            'class': '',
+        },
+    ],
 }
 html_title = 'pals-cpp'


### PR DESCRIPTION
## Summary

Adds a GitHub backlink to the documentation so readers can jump to the source repo.

The docs use the **Furo** theme, which has no top navigation bar — its designated
spot for a repository link is `footer_icons`, rendering a GitHub icon at the
bottom of the sidebar. This adds one pointing at `pals-project/pals-cpp`.

## Change

- `docs/src/conf.py`: add a `footer_icons` entry (GitHub octicon SVG + repo URL)
  to `html_theme_options`.

## Notes

- Furo places this at the sidebar footer rather than a topbar. If you specifically
  want it visually pinned to the top of the page, that needs a custom template /
  CSS override — happy to do that as a follow-up if preferred.
- The CI `Build Documentation` job (`python docs/build.py`) will render and
  validate the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)