### PR TITLE
Report parse errors instead of aborting the process

### DIFF
--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -1460,8 +1460,14 @@ static void add_to_master_tree(ryml::Tree& master, const ryml::Tree& src,
 /**
  * Makes the original lattice. Creates a tree that maps included files to their
  * contents.
+ *
+ * If the top-level file cannot be read or is not valid YAML, `parse_error` is
+ * set to a human-readable description (with the offending line/column for a
+ * syntax error) and the returned tree is an empty MAP. Callers treat a non-empty
+ * `parse_error` as a fatal failure: there is no document to expand.
  */
-static YAMLTreeHandle make_original(const char* filename) {
+static YAMLTreeHandle make_original(const char* filename,
+                                    std::string& parse_error) {
     ParsedData* master = new ParsedData();
     master->tree.rootref() |= ryml::MAP;
     ParsedData* src = static_cast<ParsedData*>(parse_file(filename));
@@ -1475,6 +1481,10 @@ static YAMLTreeHandle make_original(const char* filename) {
                              master->tree.to_arena(ryml::to_csubstr(filename)));
         add_to_master_tree(master->tree, src->tree, src->tree.root_id());
         delete src;
+    } else {
+        // parse_file recorded why on this thread; nothing else has parsed since.
+        parse_error = yaml_last_parse_error();
+        if (parse_error.empty()) parse_error = "parse failed";
     }
     return master;
 }
@@ -1484,16 +1494,27 @@ extern "C" {
 YAML_API struct lattices parse_and_expand_PALS(const char* filename,
                                       const char* root_lattice) {
     struct lattices lat = {};
+    ProblemList problems;
     // Built as a derivation chain so provenance can be recorded at each step:
     //   original --(splice includes)--> combined --(expand, split)--> expanded
     //                                                              \-> leftover
-    lat.original = make_original(filename);
-    lat.combined = make_combined_from_original(
-        static_cast<ParsedData*>(lat.original), filename);
-    ProblemList problems;
-    make_expanded_and_leftover(static_cast<ParsedData*>(lat.combined),
-                               root_lattice, problems, lat.expanded,
-                               lat.leftover);
+    std::string parse_error;
+    lat.original = make_original(filename, parse_error);
+    if (!parse_error.empty()) {
+        // The top-level file is not valid YAML: there is no tree to expand.
+        // Free the empty stand-in, leave all four handles NULL, and report the
+        // location as the single problem so the caller can pinpoint the fault.
+        delete_tree(lat.original);
+        lat.original = nullptr;
+        problems.push_back("could not parse '" + std::string(filename) +
+                           "': " + parse_error);
+    } else {
+        lat.combined = make_combined_from_original(
+            static_cast<ParsedData*>(lat.original), filename);
+        make_expanded_and_leftover(static_cast<ParsedData*>(lat.combined),
+                                   root_lattice, problems, lat.expanded,
+                                   lat.leftover);
+    }
 
     // Hand the problem list to the caller as an owning C string array (freed
     // with free_lattice_problems). The library never prints — the caller

--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -8,11 +8,135 @@
 
 #include <cstring>
 #include <fstream>
+#include <memory>
+#include <mutex>
 #include <ryml.hpp>
 #include <ryml_std.hpp>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
+
+namespace {
+
+// The most recent parse error on this thread, set whenever parse_file() or
+// parse_string() fails and read back through yaml_last_parse_error(). Made
+// thread-local so concurrent parses do not clobber one another's message.
+thread_local std::string g_last_parse_error;
+
+// Thrown by the ryml error callbacks below in place of ryml's default abort(),
+// so a malformed document surfaces as a catchable failure (a NULL handle) that
+// the host — Julia, say — can report, rather than a signal that kills the whole
+// process. Carries ryml's raw message plus the 1-based YAML location, so the
+// caller (which still holds the source buffer) can render a source snippet.
+// `line`/`col` are ryml::npos when unknown.
+struct RymlError : std::runtime_error {
+    size_t line;
+    size_t col;
+    RymlError(ryml::csubstr msg, size_t line_, size_t col_)
+        : std::runtime_error(std::string(msg.str, msg.len)),
+          line(line_),
+          col(col_) {}
+};
+
+// ryml requires its error callbacks never return; each throws instead. The
+// parse callback reports the location within the YAML source (`ymlloc`), which
+// is what pinpoints the offending line for the user.
+[[noreturn]] void ryml_error_parse(ryml::csubstr msg,
+                                   const ryml::ErrorDataParse& err, void*) {
+    throw RymlError(msg, err.ymlloc.line, err.ymlloc.col);
+}
+
+[[noreturn]] void ryml_error_basic(ryml::csubstr msg,
+                                   const ryml::ErrorDataBasic& err, void*) {
+    throw RymlError(msg, err.location.line, err.location.col);
+}
+
+// Return 1-based line `n` of `src` (without its trailing newline), or "" if the
+// source has fewer than `n` lines. ryml filters scalars in place during a parse
+// but never moves the newlines that bound the lines, so scanning the (possibly
+// partly-parsed) buffer still recovers the correct line boundaries.
+std::string source_line(const std::string& src, size_t n) {
+    if (n == 0) return {};
+    size_t start = 0;
+    for (size_t cur = 1; cur < n; ++cur) {
+        size_t nl = src.find('\n', start);
+        if (nl == std::string::npos) return {};
+        start = nl + 1;
+    }
+    size_t nl = src.find('\n', start);
+    std::string line =
+        src.substr(start, nl == std::string::npos ? nl : nl - start);
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    return line;
+}
+
+// Append a source snippet to `out`: the line before the error, the error line,
+// and a caret under the offending column, e.g.
+//
+//       32 |     - cav
+//       33 |         kind: RFCavity
+//                        ^
+//
+// A missing colon is only detectable on the line *after* the omission, so the
+// preceding line is shown too — that is where the real fault usually is. Does
+// nothing when the location is unknown.
+void append_source_context(std::string& out, const std::string& src,
+                           size_t line, size_t col) {
+    if (line == ryml::npos || line == 0) return;
+    const size_t gutter = std::to_string(line).size();
+    auto emit_line = [&](size_t n) {
+        if (n == 0) return;
+        const std::string num = std::to_string(n);
+        out += "\n    ";
+        out.append(gutter - num.size(), ' ');
+        out += num;
+        out += " | ";
+        out += source_line(src, n);
+    };
+    if (line > 1) emit_line(line - 1);
+    emit_line(line);
+    if (col != ryml::npos && col >= 1) {
+        out += "\n    ";
+        out.append(gutter, ' ');
+        out += " | ";
+        out.append(col - 1, ' ');
+        out += '^';
+    }
+}
+
+// Build the full "line L, column C: <msg>" string, followed by the source
+// snippet, from a caught RymlError and the buffer it was parsing.
+std::string build_parse_error(const RymlError& e, const std::string& src) {
+    std::string out;
+    if (e.line != ryml::npos) {
+        out = "line " + std::to_string(e.line);
+        if (e.col != ryml::npos) out += ", column " + std::to_string(e.col);
+        out += ": ";
+    }
+    out += e.what();
+    append_source_context(out, src, e.line, e.col);
+    return out;
+}
+
+// Install the throwing error callbacks, once, so every parse reports errors by
+// exception rather than by aborting. ryml's allocation callbacks are left
+// untouched. This runs lazily on the first parse rather than at load time on
+// purpose: ryml's global callbacks live in a namespace-scope object whose own
+// default (aborting) construction could otherwise run *after* ours in an
+// unspecified static-init order and clobber it. Call it before constructing any
+// Tree, whose callbacks are copied from the global at construction.
+void ensure_throwing_callbacks() {
+    static std::once_flag once;
+    std::call_once(once, [] {
+        ryml::Callbacks cb = ryml::get_callbacks();
+        cb.set_error_parse(&ryml_error_parse);
+        cb.set_error_basic(&ryml_error_basic);
+        ryml::set_callbacks(cb);
+    });
+}
+
+}  // namespace
 
 // Grow node pool if nearly full. ryml does not auto-resize.
 void ensure_capacity(ryml::Tree& t, size_t needed) {
@@ -67,35 +191,69 @@ void deep_copy_recursive(ryml::Tree& dst_t, size_t dst_node,
 extern "C" {
 
 YAML_API YAMLTreeHandle parse_file(const char* filename) {
+    ensure_throwing_callbacks();
+    g_last_parse_error.clear();
+    std::unique_ptr<ParsedData> data(new ParsedData());
     try {
         std::ifstream file(filename, std::ios::binary | std::ios::ate);
-        if (!file) return nullptr;
+        if (!file) {
+            g_last_parse_error =
+                "could not open file: " +
+                std::string(filename ? filename : "(null)");
+            return nullptr;
+        }
         std::streamsize size = file.tellg();
         file.seekg(0, std::ios::beg);
-        ParsedData* data = new ParsedData();
         data->buffer.resize(size);
         file.read(&data->buffer[0], size);
-        data->tree = ryml::parse_in_place(ryml::to_substr(data->buffer));
-        return data;
+        // Parse into data->tree (not the returning overload) so the parser
+        // inherits the tree's callbacks — the global throwing ones set above.
+        // The returning parse_in_place(substr) builds its event handler with
+        // ryml's built-in defaults, which abort() on a syntax error.
+        ryml::parse_in_place(ryml::to_substr(data->buffer), &data->tree);
+        return data.release();
+    } catch (const RymlError& e) {
+        g_last_parse_error = build_parse_error(e, data->buffer);
+        return nullptr;
+    } catch (const std::exception& e) {
+        g_last_parse_error = e.what();
+        return nullptr;
     } catch (...) {
+        g_last_parse_error = "unknown parse error";
         return nullptr;
     }
 }
 
 YAML_API YAMLTreeHandle parse_string(const char* yaml_str) {
+    ensure_throwing_callbacks();
+    g_last_parse_error.clear();
     // Explicit null check prevents the segfault
     if (yaml_str == nullptr) {
+        g_last_parse_error = "null YAML string";
         return nullptr;
     }
 
+    std::unique_ptr<ParsedData> data(new ParsedData());
     try {
-        ParsedData* data = new ParsedData();
         data->buffer = yaml_str;
-        data->tree = ryml::parse_in_place(ryml::to_substr(data->buffer));
-        return data;
+        // Parse into data->tree so the parser uses the tree's (global, throwing)
+        // callbacks rather than ryml's built-in aborting defaults.
+        ryml::parse_in_place(ryml::to_substr(data->buffer), &data->tree);
+        return data.release();
+    } catch (const RymlError& e) {
+        g_last_parse_error = build_parse_error(e, data->buffer);
+        return nullptr;
+    } catch (const std::exception& e) {
+        g_last_parse_error = e.what();
+        return nullptr;
     } catch (...) {
+        g_last_parse_error = "unknown parse error";
         return nullptr;
     }
+}
+
+YAML_API const char* yaml_last_parse_error(void) {
+    return g_last_parse_error.c_str();
 }
 
 YAML_API YAMLTreeHandle create_empty_tree() {

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -454,6 +454,22 @@ YAML_API YAMLTreeHandle parse_file(const char* filename);
 YAML_API YAMLTreeHandle parse_string(const char* yaml_str);
 
 /**
+ * Returns the most recent parse error message on the calling thread.
+ * @ingroup parse
+ *
+ * Whenever parse_file(), parse_string() (and hence parse_and_expand_PALS())
+ * returns NULL because a document is malformed or a file cannot be read, this
+ * holds a human-readable description of why — for a YAML syntax error, prefixed
+ * with the offending "line L, column C:" — so the caller can report exactly what
+ * went wrong instead of a bare failure. It is cleared at the start of each parse
+ * and is empty when the last parse on this thread succeeded.
+ *
+ * @return A null-terminated string owned by the library, valid until the next
+ *         parse call on this thread. Never NULL (empty when there is no error).
+ */
+YAML_API const char* yaml_last_parse_error(void);
+
+/**
  * Creates an empty tree with a MAP root node.
  * @ingroup edit
  *

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -364,3 +364,38 @@ TEST_CASE("parse_and_expand_PALS reports a missing lattice",
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
+
+TEST_CASE("a malformed top-level file is a fatal parse problem, not a crash",
+          "[lattices][problems]") {
+    // A sequence item missing its ':' (here `- cav` followed by an indented
+    // mapping) is a YAML syntax error. ryml would abort the process; instead
+    // parse_and_expand_PALS must return NULL handles and one problem that names
+    // the file and pinpoints the line.
+    const char* path = "tmp_malformed.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - cav\n"
+              "        kind: RFCavity\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+
+    // No usable tree: every handle is NULL.
+    REQUIRE(lat.original == nullptr);
+    REQUIRE(lat.combined == nullptr);
+    REQUIRE(lat.expanded == nullptr);
+    REQUIRE(lat.leftover == nullptr);
+
+    // A single problem, naming the file and the offending line.
+    REQUIRE(lat.problems.count == 1);
+    std::string msg = lat.problems.items[0];
+    REQUIRE(msg.find(path) != std::string::npos);
+    REQUIRE(msg.find("line") != std::string::npos);
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);  // all NULL — delete_tree(NULL) is a safe no-op
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}

--- a/tests/test_yaml_api.cpp
+++ b/tests/test_yaml_api.cpp
@@ -33,6 +33,33 @@ TEST_CASE("parse_file returns nullptr for a missing file", "[parsing][file]") {
     REQUIRE(tree == nullptr);
 }
 
+TEST_CASE("malformed YAML returns nullptr instead of aborting", "[parsing]") {
+    // A sequence item missing its ':' is a syntax error. ryml would abort() by
+    // default; the library installs throwing callbacks so this is catchable.
+    YAMLTreeHandle tree = parse_string("- cav\n    kind: RFCavity\n");
+    REQUIRE(tree == nullptr);
+    // The error message pinpoints where the parse failed...
+    std::string err = yaml_last_parse_error();
+    REQUIRE_FALSE(err.empty());
+    REQUIRE(err.find("line") != std::string::npos);
+    // ...and quotes the source around it — the error line, the line before it
+    // (where a missing ':' actually is), and a caret — so the fault is visible.
+    REQUIRE(err.find("1 | - cav") != std::string::npos);
+    REQUIRE(err.find("kind: RFCavity") != std::string::npos);
+    REQUIRE(err.find('^') != std::string::npos);
+}
+
+TEST_CASE("yaml_last_parse_error is cleared after a successful parse",
+          "[parsing]") {
+    YAMLTreeHandle bad = parse_string(": : :");
+    if (bad) delete_tree(bad);
+    // Whether or not that particular string errors, a clean parse must reset it.
+    YAMLTreeHandle good = parse_string("key: value");
+    REQUIRE(good != nullptr);
+    REQUIRE(std::string(yaml_last_parse_error()).empty());
+    delete_tree(good);
+}
+
 TEST_CASE("create_empty_tree gives an empty MAP root", "[parsing]") {
     YAMLTreeHandle tree = create_empty_tree();
     REQUIRE(tree != nullptr);


### PR DESCRIPTION
## Summary

A YAML syntax error in a lattice file used to **abort the whole process**. rapidyaml's default error handler calls `abort()` (signal 6), which kills any host embedding the library — a Julia REPL, for instance — and a `catch(...)` can't intercept a signal. ryml even knew the error location but printed it to stderr and threw it away.

This makes a malformed document a **catchable failure with a pinpointed message** instead of a crash.

## Changes

- **Throwing error callbacks.** Install ryml error callbacks that throw instead of `abort()`, so `parse_file`/`parse_string` catch the failure and return `NULL`. The install is done lazily on the first parse via `std::call_once`, **not** at load time: ryml's global callbacks live in a namespace-scope object whose own aborting default construction can otherwise run *after* an eager installer in unspecified static-init order and clobber it.
- **Correct callback wiring.** Parse through the `parse_in_place(yaml, &tree)` overload so the parser inherits the tree's (throwing) callbacks. The returning `parse_in_place(substr) -> Tree` overload builds its event handler with ryml's built-in *aborting* defaults and ignores the global callbacks — that was why the first wiring still aborted.
- **`yaml_last_parse_error()`.** New accessor returning the most recent parse error on the calling thread (thread-local). The message carries a `line L, column C` prefix and a quoted **source snippet** — the error line, the line before it (where a missing `:` usually is), and a caret:

  ```
  line 33, column 13: parse error
      32 |     - cav
      33 |         kind: RFCavity
         |             ^
  ```

- **Fatal top-level parse.** A malformed top-level file makes `parse_and_expand_PALS` return NULL handles plus one problem naming the file and line, rather than silently expanding an empty tree.
- **Leak fix.** `parse_file`/`parse_string` previously leaked their `ParsedData` when parsing threw; they now hold it in a `unique_ptr`.

## Tests

`tests/` gains cases (109/109 pass):
- malformed YAML returns `NULL` instead of aborting, and the message quotes the source with a caret;
- `yaml_last_parse_error()` clears after a successful parse;
- a malformed top-level lattice file yields NULL handles + one problem naming the file and line.

## Downstream

PALSJulia depends on this (it calls `yaml_last_parse_error` and relies on the no-abort behavior); its matching PR should land after this. No struct-layout/ABI change — the change is confined to the parse error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
