### PR TITLE
Show first non-blank preceding line in parse errors

### DIFF
--- a/src/yaml_c_wrapper.cpp
+++ b/src/yaml_c_wrapper.cpp
@@ -71,7 +71,12 @@ std::string source_line(const std::string& src, size_t n) {
     return line;
 }
 
-// Append a source snippet to `out`: the line before the error, the error line,
+// True when a source line has no non-whitespace content.
+bool is_blank_line(const std::string& line) {
+    return line.find_first_not_of(" \t") == std::string::npos;
+}
+
+// Append a source snippet to `out`: the preceding context, the error line,
 // and a caret under the offending column, e.g.
 //
 //       32 |     - cav
@@ -79,8 +84,17 @@ std::string source_line(const std::string& src, size_t n) {
 //                        ^
 //
 // A missing colon is only detectable on the line *after* the omission, so the
-// preceding line is shown too — that is where the real fault usually is. Does
-// nothing when the location is unknown.
+// preceding line is shown too — that is where the real fault usually is. When
+// that preceding line is blank it is no help, so the scan walks further back to
+// the first non-blank line and shows every line from there down to the error,
+// e.g. a missing dash reported on line 68 whose real fault is on line 66:
+//
+//       66 |     - use: "lat1"
+//       67 |
+//       68 |     ext_line:
+//              ^
+//
+// Does nothing when the location is unknown.
 void append_source_context(std::string& out, const std::string& src,
                            size_t line, size_t col) {
     if (line == ryml::npos || line == 0) return;
@@ -94,7 +108,13 @@ void append_source_context(std::string& out, const std::string& src,
         out += " | ";
         out += source_line(src, n);
     };
-    if (line > 1) emit_line(line - 1);
+    if (line > 1) {
+        // Walk back over blank preceding lines to the first non-blank one, then
+        // show that line and everything between it and the error.
+        size_t first = line - 1;
+        while (first > 1 && is_blank_line(source_line(src, first))) --first;
+        for (size_t n = first; n < line; ++n) emit_line(n);
+    }
     emit_line(line);
     if (col != ryml::npos && col >= 1) {
         out += "\n    ";

--- a/tests/test_yaml_api.cpp
+++ b/tests/test_yaml_api.cpp
@@ -49,6 +49,21 @@ TEST_CASE("malformed YAML returns nullptr instead of aborting", "[parsing]") {
     REQUIRE(err.find('^') != std::string::npos);
 }
 
+TEST_CASE("parse error skips blank preceding lines to the first non-blank one",
+          "[parsing]") {
+    // The error is on line 4; line 3 is blank, so an unhelpful blank previous
+    // line would be shown. Instead the snippet walks back to line 2 (the real
+    // fault, a map entry missing its dash) and shows every line down to 4.
+    YAMLTreeHandle tree =
+        parse_string("seq:\n  - a: 1\n\n  b: 2\n");
+    REQUIRE(tree == nullptr);
+    std::string err = yaml_last_parse_error();
+    REQUIRE(err.find("2 | ") != std::string::npos);   // first non-blank line
+    REQUIRE(err.find("3 | ") != std::string::npos);   // the blank line
+    REQUIRE(err.find("4 | ") != std::string::npos);   // the error line
+    REQUIRE(err.find('^') != std::string::npos);
+}
+
 TEST_CASE("yaml_last_parse_error is cleared after a successful parse",
           "[parsing]") {
     YAMLTreeHandle bad = parse_string(": : :");


### PR DESCRIPTION
## Problem

When a YAML parse error is reported, the source snippet shows the error line and the single line immediately before it. A missing dash (or colon) is only detectable on the line *after* the omission, so the preceding line is the useful one — but when that preceding line is **blank**, the snippet gives no help at all.

For example, `test.pals.yaml` line 68 (missing `- `) previously reported:

```
line 68, column 5: parse error
    67 |
    68 |     ext_line:
       |     ^
```

## Change

`append_source_context()` now walks back over blank preceding lines to the first non-blank line, and shows every line from there down to the error line:

```
line 68, column 5: parse error
    66 |     - use: "lat1"
    67 |
    68 |     ext_line:
       |     ^
```

Line 66 — where the real fault is — is now visible.

Added an `is_blank_line()` helper and a Catch2 test covering the blank-skipping case. The existing non-blank-preceding-line test is unchanged and still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
