### PR TITLE
Add the element bookkeeper: reference, floor, s-position, dependents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,8 @@ add_library(yaml_c_wrapper SHARED
   src/pals_expand.cpp
   src/pals_match.cpp
   src/pals_util.cpp
-  src/pals_expression.cpp)
+  src/pals_expression.cpp
+  src/pals_floor.cpp)
 target_link_libraries(yaml_c_wrapper PUBLIC ryml PRIVATE pcre2-8-static apc)
 
 add_executable(example_rw examples/example_rw.cpp)

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -8,8 +8,12 @@
 #include "yaml_c_wrapper.h"
 #include "yaml_tree.h"
 #include "pals_util.h"
+#include "pals_floor.h"
+
+#include "apc/apc.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -1314,6 +1318,797 @@ static void evaluate_expressions(ryml::Tree& t, ProblemList& problems) {
     substitute_values(t, t.root_id(), *resolve, species, problems);
 }
 
+// ============================================================
+// ELEMENT BOOKKEEPING
+// ============================================================
+//
+// Once every expression has been reduced to a number, each branch is walked
+// element-by-element from its BeginningEle to compute the output parameters that
+// depend on where an element sits in the branch: the reference parameters
+// (species / energy / momentum / time), the floor placement, the s-position,
+// and the field-dependent parameters (normalized <-> unnormalized multipole and
+// bend strengths). See the "Lattice Expansion" step in
+// pals/source/lattice-construction.md; the floor math (Eqs. wws etc.) lives in
+// pals_floor.cpp.
+//
+// All ReferenceP / FloorP values describe the *upstream* end of their element.
+// The bookkeeper persists each element's results into the tree before moving on,
+// so _element_bookkeeper reads the previous element's stored parameters and
+// "propagates" them onto the current one, exactly as the standard describes.
+
+// Parse the whole of `s` (bar surrounding whitespace) as a finite double. Values
+// in the expanded tree are already evaluated to plain numbers by this point.
+static bool parse_num(const std::string& s, double& out) {
+    const char* p = s.c_str();
+    char* end = nullptr;
+    double d = std::strtod(p, &end);
+    while (*end == ' ' || *end == '\t' || *end == '\n' || *end == '\r') ++end;
+    if (end != p && *end == '\0' && std::isfinite(d)) {
+        out = d;
+        return true;
+    }
+    return false;
+}
+
+// Numeric value of a keyed child, if present and numeric.
+static bool get_num_child(const ryml::Tree& t, size_t parent, const char* key,
+                          double& out) {
+    if (parent == ryml::NONE) return false;
+    size_t c = t.find_child(parent, ryml::to_csubstr(key));
+    if (c == ryml::NONE || !t.has_val(c)) return false;
+    return parse_num(std::string(t.val(c).str, t.val(c).len), out);
+}
+
+// String value of a keyed child, trimmed and with any surrounding quotes
+// stripped; false (and `out` untouched) if absent or empty.
+static bool get_str_child(const ryml::Tree& t, size_t parent, const char* key,
+                          std::string& out) {
+    if (parent == ryml::NONE) return false;
+    size_t c = t.find_child(parent, ryml::to_csubstr(key));
+    if (c == ryml::NONE || !t.has_val(c)) return false;
+    std::string v(t.val(c).str, t.val(c).len);
+    size_t a = v.find_first_not_of(" \t\r\n");
+    size_t b = v.find_last_not_of(" \t\r\n");
+    if (a == std::string::npos) return false;
+    v = v.substr(a, b - a + 1);
+    if (v.size() >= 2 && (v.front() == '"' || v.front() == '\'') &&
+        v.back() == v.front())
+        v = v.substr(1, v.size() - 2);
+    if (v.empty()) return false;
+    out = v;
+    return true;
+}
+
+// A keyed map child of `parent`, created (empty) if absent. An existing scalar
+// placeholder of the same key is converted to a map in place.
+static size_t find_or_add_map_child(ryml::Tree& t, size_t parent,
+                                    const char* key) {
+    size_t c = t.find_child(parent, ryml::to_csubstr(key));
+    if (c != ryml::NONE) {
+        if (!t.is_map(c)) {
+            t.change_type(c, ryml::KEYMAP);
+            t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+        }
+        return c;
+    }
+    ensure_capacity(t, 2);
+    c = t.append_child(parent);
+    t.ref(c) |= ryml::KEY | ryml::MAP;
+    t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+    return c;
+}
+
+// Set (or create) a keyed scalar child to the shortest round-tripping decimal.
+static void set_num_child(ryml::Tree& t, size_t parent, const char* key,
+                          double v) {
+    size_t c = t.find_child(parent, ryml::to_csubstr(key));
+    if (c == ryml::NONE) {
+        ensure_capacity(t, 2);
+        c = t.append_child(parent);
+        t.ref(c) |= ryml::KEY | ryml::VAL;
+        t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+    }
+    t.set_val(c, t.to_arena(ryml::to_csubstr(format_double(v))));
+}
+
+// Set (or create) a keyed scalar child to a string. Double-quoted so a leading
+// '#' in a species name survives YAML's comment rule on re-emit.
+static void set_str_child(ryml::Tree& t, size_t parent, const char* key,
+                          const std::string& v) {
+    size_t c = t.find_child(parent, ryml::to_csubstr(key));
+    if (c == ryml::NONE) {
+        ensure_capacity(t, 2);
+        c = t.append_child(parent);
+        t.ref(c) |= ryml::KEY | ryml::VAL;
+        t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+    }
+    t.set_val(c, t.to_arena(ryml::to_csubstr(v)));
+    t.set_val_style(c, ryml::VAL_DQUO);
+}
+
+// Set (or create) a keyed scalar child to a bare (unquoted) token. Used for
+// enum and boolean defaults (e.g. `cavity_type: STANDING_WAVE`, `direction:
+// FORWARDS`, `aperture_active: true`), which are plain YAML scalars, not strings.
+static void set_plain_child(ryml::Tree& t, size_t parent, const char* key,
+                            const char* v) {
+    size_t c = t.find_child(parent, ryml::to_csubstr(key));
+    if (c == ryml::NONE) {
+        ensure_capacity(t, 2);
+        c = t.append_child(parent);
+        t.ref(c) |= ryml::KEY | ryml::VAL;
+        t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+    }
+    t.set_val(c, t.to_arena(ryml::to_csubstr(v)));
+}
+
+// Reference parameters at one end of an element (ReferenceP). Energy and
+// momentum are related through the reference mass; a flag records which of them
+// is known so complete_energy() can fill the other.
+struct RefState {
+    std::string species;
+    double E_tot = 0.0;  // [eV] total energy
+    double pc = 0.0;     // [eV] momentum * c
+    double time = 0.0;   // [s]
+    bool has_species = false;
+    bool has_E = false;
+    bool has_pc = false;
+};
+
+// Fill in whichever of E_tot / pc is missing from the other, using the reference
+// species mass (E^2 = (pc)^2 + (m c^2)^2, all in eV). A no-op if the species is
+// unknown, both are set, or neither is.
+static void complete_energy(RefState& r) {
+    if (!r.has_species) return;
+    double m;
+    try {
+        m = apc::mass_of(r.species);
+    } catch (...) {
+        return;  // unknown species name; leave energy/momentum as-is
+    }
+    if (r.has_E && !r.has_pc) {
+        double v = r.E_tot * r.E_tot - m * m;
+        if (v >= 0.0) {
+            r.pc = std::sqrt(v);
+            r.has_pc = true;
+        }
+    } else if (r.has_pc && !r.has_E) {
+        r.E_tot = std::sqrt(r.pc * r.pc + m * m);
+        r.has_E = true;
+    }
+}
+
+// Read the ReferenceP group of an element into a RefState (its upstream values).
+static RefState read_ref(const ryml::Tree& t, size_t ele) {
+    RefState r;
+    size_t rp = t.find_child(ele, ryml::to_csubstr("ReferenceP"));
+    if (rp == ryml::NONE) return r;
+    r.has_species = get_str_child(t, rp, "species_ref", r.species);
+    r.has_E = get_num_child(t, rp, "E_tot_ref", r.E_tot);
+    r.has_pc = get_num_child(t, rp, "pc_ref", r.pc);
+    get_num_child(t, rp, "time_ref", r.time);  // defaults to 0
+    return r;
+}
+
+// Write a RefState back into an element's ReferenceP group (creating it).
+static void write_ref(ryml::Tree& t, size_t ele, const RefState& r) {
+    size_t rp = find_or_add_map_child(t, ele, "ReferenceP");
+    if (r.has_species) set_str_child(t, rp, "species_ref", r.species);
+    if (r.has_E) set_num_child(t, rp, "E_tot_ref", r.E_tot);
+    if (r.has_pc) set_num_child(t, rp, "pc_ref", r.pc);
+    set_num_child(t, rp, "time_ref", r.time);
+}
+
+// Apply a ReferenceChange element's ReferenceChangeP adjustments to a RefState
+// (see referencechange.md): a species, an absolute or delta energy/momentum, and
+// an absolute or delta reference time. Clearing has_E/has_pc lets the subsequent
+// complete_energy() recompute the partner quantity with the new mass/energy.
+static void apply_ref_change(const ryml::Tree& t, size_t ele, RefState& r) {
+    size_t rc = t.find_child(ele, ryml::to_csubstr("ReferenceChangeP"));
+    if (rc == ryml::NONE) return;
+
+    std::string sp;
+    if (get_str_child(t, rc, "species_ref", sp)) {
+        r.species = sp;
+        r.has_species = true;
+        r.has_pc = false;  // recompute momentum for the new mass
+    }
+    double v;
+    if (get_num_child(t, rc, "E_tot_ref", v)) {
+        r.E_tot = v;
+        r.has_E = true;
+        r.has_pc = false;
+    } else if (get_num_child(t, rc, "pc_ref", v)) {
+        r.pc = v;
+        r.has_pc = true;
+        r.has_E = false;
+    } else if (get_num_child(t, rc, "dE_ref", v)) {
+        if (r.has_E) {
+            r.E_tot += v;
+            r.has_pc = false;
+        }
+    } else if (get_num_child(t, rc, "dpc_ref", v)) {
+        if (r.has_pc) {
+            r.pc += v;
+            r.has_E = false;
+        }
+    }
+    if (get_num_child(t, rc, "time_ref", v))
+        r.time = v;
+    else if (get_num_child(t, rc, "dtime_ref", v))
+        r.time += v;
+}
+
+// Reference parameters at the downstream end of an element, given its completed
+// upstream parameters. Species and energy carry through unchanged for most
+// kinds; an RFCavity shifts the energy by RFP.dE_ref and a ReferenceChange
+// applies its ReferenceChangeP. The reference time advances by the transit time
+// (reference.md).
+static RefState downstream_ref(const ryml::Tree& t, size_t ele,
+                               const std::string& kind, const RefState& up,
+                               double length, ProblemList& problems) {
+    RefState down = up;
+
+    if (kind == "RFCavity") {
+        size_t rfp = t.find_child(ele, ryml::to_csubstr("RFP"));
+        double dE;
+        if (get_num_child(t, rfp, "dE_ref", dE) && down.has_E) {
+            down.E_tot = up.E_tot + dE;
+            down.has_pc = false;  // recompute momentum for the new energy
+        }
+    } else if (kind == "ReferenceChange") {
+        apply_ref_change(t, ele, down);
+    } else if (kind == "Foil") {
+        // A Foil can strip electrons, changing the downstream species (and hence
+        // energy). The stripping model is not defined by the standard, so the
+        // downstream species is left equal to the upstream one and the omission
+        // is flagged rather than guessed at.
+        std::string ename = t.has_key(ele) ? std::string(t.key(ele).str,
+                                                          t.key(ele).len)
+                                           : "<foil>";
+        add_problem(problems, "Foil element '" + ename +
+                                  "': downstream species change is not computed");
+    }
+
+    complete_energy(down);  // refill whichever of E/pc a change above cleared
+
+    // Reference transit time: length * (E_up + E_down) / (c * (pc_up + pc_down)).
+    if (up.has_E && down.has_E && up.has_pc && down.has_pc) {
+        double denom = apc::C_LIGHT * (up.pc + down.pc);
+        if (denom != 0.0)
+            down.time = up.time + length * (up.E_tot + down.E_tot) / denom;
+    }
+    return down;
+}
+
+// Read an element's FloorP group into a FloorState. Missing components default
+// to zero (origin / identity orientation). Returns false if the group is absent.
+static bool read_floor(const ryml::Tree& t, size_t ele, pals::FloorState& s) {
+    size_t fp = t.find_child(ele, ryml::to_csubstr("FloorP"));
+    if (fp == ryml::NONE) return false;
+    double x = 0, y = 0, z = 0, th = 0, ph = 0, ps = 0;
+    get_num_child(t, fp, "x", x);
+    get_num_child(t, fp, "y", y);
+    get_num_child(t, fp, "z", z);
+    get_num_child(t, fp, "theta", th);
+    get_num_child(t, fp, "phi", ph);
+    get_num_child(t, fp, "psi", ps);
+    s.r = pals::Vec3{x, y, z};
+    s.q = pals::quat_from_floor_angles(pals::FloorAngles{th, ph, ps});
+    return true;
+}
+
+// Write a FloorState back into an element's FloorP group (creating it),
+// converting the orientation quaternion to (theta, phi, psi).
+static void write_floor(ryml::Tree& t, size_t ele, const pals::FloorState& s) {
+    size_t fp = find_or_add_map_child(t, ele, "FloorP");
+    set_num_child(t, fp, "x", s.r.x);
+    set_num_child(t, fp, "y", s.r.y);
+    set_num_child(t, fp, "z", s.r.z);
+    pals::FloorAngles a = pals::floor_angles_from_quat(s.q);
+    set_num_child(t, fp, "theta", a.theta);
+    set_num_child(t, fp, "phi", a.phi);
+    set_num_child(t, fp, "psi", a.psi);
+}
+
+// Build the floor displacement L and coordinate rotation S for an element's
+// reference curve, dispatched on kind: bends use their BendP angle/tilt, patches
+// their PatchP offsets/rotations, everything else is a straight segment of the
+// element length. (FloorShift, which also redirects the reference curve, is not
+// yet handled and is treated as straight.)
+static void element_LS(const ryml::Tree& t, size_t ele, const std::string& kind,
+                       double length, pals::Vec3& L, pals::Quat& S) {
+    if (kind == "Bend") {
+        size_t bp = t.find_child(ele, ryml::to_csubstr("BendP"));
+        double angle = 0.0;
+        if (!get_num_child(t, bp, "angle_ref", angle)) {
+            double g = 0.0;
+            if (get_num_child(t, bp, "g_ref", g)) angle = g * length;
+        }
+        double tilt = 0.0;
+        get_num_child(t, bp, "tilt_ref", tilt);
+        pals::bend_LS(length, angle, tilt, L, S);
+    } else if (kind == "Patch") {
+        size_t pp = t.find_child(ele, ryml::to_csubstr("PatchP"));
+        double xo = 0, yo = 0, zo = 0, xr = 0, yr = 0, zr = 0;
+        get_num_child(t, pp, "x_offset", xo);
+        get_num_child(t, pp, "y_offset", yo);
+        get_num_child(t, pp, "z_offset", zo);
+        get_num_child(t, pp, "x_rot", xr);
+        get_num_child(t, pp, "y_rot", yr);
+        get_num_child(t, pp, "z_rot", zr);
+        pals::patch_LS(xo, yo, zo, xr, yr, zr, L, S);
+    } else {
+        pals::straight_LS(length, L, S);
+    }
+}
+
+// The name of an element (its map key), or a placeholder for the unkeyed case.
+static std::string ele_name(const ryml::Tree& t, size_t ele) {
+    return t.has_key(ele) ? std::string(t.key(ele).str, t.key(ele).len)
+                          : "<element>";
+}
+
+// Two numbers agree "to high accuracy" (rf.md): equal within a relative
+// tolerance, with both-zero counted as equal.
+static bool approx_eq(double a, double b) {
+    double scale = std::max(std::fabs(a), std::fabs(b));
+    return scale == 0.0 || std::fabs(a - b) <= 1e-9 * scale;
+}
+
+// ---------------------------------------------------------------------------
+// DEPENDENT PARAMETERS
+//
+// Many parameters within a group are not independent: one is a fixed multiple
+// (or the reciprocal) of another. The expanded lattice holds every non-zero
+// parameter, so when the author sets one member of such a relation the parser
+// derives the rest. When the author sets more than one, the parser instead
+// verifies they agree to high accuracy and flags an inconsistency (rather than
+// silently overwriting). link_pair / reciprocal_link are the two primitives;
+// the per-group resolvers below wire them up per the parameter docs.
+// ---------------------------------------------------------------------------
+
+// Relate two proportional parameters of a group, `b_key = factor * a_key`.
+//  - both present  -> verify agreement, flag an inconsistency if not.
+//  - only `a`      -> derive b = factor*a (unless the result is zero: a zero
+//                     parameter is not "held").
+//  - only `b`      -> derive a = b/factor (needs an invertible, non-zero factor).
+// Returns true if it wrote a value, so callers can iterate to a fixed point.
+static bool link_pair(ryml::Tree& t, size_t group, const char* a_key,
+                      const char* b_key, double factor, const std::string& ctx,
+                      ProblemList& problems) {
+    double a, b;
+    bool has_a = get_num_child(t, group, a_key, a);
+    bool has_b = get_num_child(t, group, b_key, b);
+    if (has_a && has_b) {
+        double expect = factor * a;
+        if (!approx_eq(b, expect)) {
+            std::ostringstream m;
+            m << ctx << ": '" << b_key << "' and '" << a_key
+              << "' are inconsistent (" << b_key << " = " << format_double(b)
+              << ", but " << format_double(factor) << " * " << a_key << " = "
+              << format_double(expect) << ").";
+            add_problem(problems, m.str());
+        }
+        return false;
+    }
+    if (has_a && factor * a != 0.0) {
+        set_num_child(t, group, b_key, factor * a);
+        return true;
+    }
+    if (has_b && factor != 0.0 && b / factor != 0.0) {
+        set_num_child(t, group, a_key, b / factor);
+        return true;
+    }
+    return false;
+}
+
+// Relate two reciprocal parameters of a group, `b_key = 1 / a_key` (e.g.
+// `rho_ref = 1 / g_ref`). A zero value has no finite reciprocal, so it is
+// neither a source nor a target. Consistency (a*b == 1) is only meaningful when
+// both are non-zero. Returns true if it wrote a value.
+static bool reciprocal_link(ryml::Tree& t, size_t group, const char* a_key,
+                            const char* b_key, const std::string& ctx,
+                            ProblemList& problems) {
+    double a, b;
+    bool has_a = get_num_child(t, group, a_key, a);
+    bool has_b = get_num_child(t, group, b_key, b);
+    if (has_a && has_b) {
+        if (a != 0.0 && b != 0.0 && !approx_eq(a * b, 1.0)) {
+            std::ostringstream m;
+            m << ctx << ": '" << a_key << "' and '" << b_key
+              << "' are inconsistent (" << a_key << " * " << b_key << " = "
+              << format_double(a * b) << ", expected 1).";
+            add_problem(problems, m.str());
+        }
+        return false;
+    }
+    if (has_a && a != 0.0) {
+        set_num_child(t, group, b_key, 1.0 / a);
+        return true;
+    }
+    if (has_b && b != 0.0) {
+        set_num_child(t, group, a_key, 1.0 / b);
+        return true;
+    }
+    return false;
+}
+
+// Resolve the BendP dependent parameters (bend.md). The reference bend strength
+// has four equivalent forms tied together by the element length and the
+// reference momentum:
+//   angle_ref     = length * g_ref
+//   rho_ref       = 1 / g_ref
+//   g_ref         = factor * bend_field_ref     (factor = q*c/pc)
+// and the "actual" output pair g_actual = factor * bend_field_actual. The
+// geometric relations need no momentum; only the field<->strength legs do, so
+// they run only when `has_factor`. Iterated to a fixed point so a value given in
+// any one form fills the others.
+static void resolve_bend(ryml::Tree& t, size_t ele, double length,
+                         bool has_factor, double factor,
+                         const std::string& ename, ProblemList& problems) {
+    size_t bp = t.find_child(ele, ryml::to_csubstr("BendP"));
+    if (bp == ryml::NONE) return;
+    std::string ctx = "element '" + ename + "' BendP";
+
+    reciprocal_link(t, bp, "g_ref", "rho_ref", ctx, problems);
+    for (int pass = 0; pass < 4; ++pass) {
+        bool changed = false;
+        changed |= link_pair(t, bp, "g_ref", "angle_ref", length, ctx, problems);
+        if (has_factor)
+            changed |= link_pair(t, bp, "bend_field_ref", "g_ref", factor, ctx,
+                                 problems);
+        if (!changed) break;
+    }
+    // g_ref may have been derived above; fill rho_ref from it now.
+    reciprocal_link(t, bp, "g_ref", "rho_ref", ctx, problems);
+    if (has_factor)
+        link_pair(t, bp, "bend_field_actual", "g_actual", factor, ctx, problems);
+}
+
+// Split a multipole component key into its (normal/skew char, order digits),
+// e.g. "Bn2L" -> ('n', "2"). `prefixes` is the pair of accepted leading tokens
+// (magnetic "Bn"/"Bs"/"Kn"/"Ks" collapse to the field forms here; electric
+// "En"/"Es"). Returns false for taper keys (an underscore) and anything that is
+// not <prefix><digits>[L].
+static bool parse_multipole_key(const std::string& k, char first,
+                                char& ns_out, std::string& order_out) {
+    if (k.size() < 3 || k[0] != first) return false;
+    if (k[1] != 'n' && k[1] != 's') return false;
+    if (k.find('_') != std::string::npos) return false;  // *_taper etc.
+    std::string rest = k.substr(2);
+    if (!rest.empty() && rest.back() == 'L') rest.pop_back();
+    if (rest.empty()) return false;
+    for (char c : rest)
+        if (!std::isdigit(static_cast<unsigned char>(c))) return false;
+    ns_out = k[1];
+    order_out = rest;
+    return true;
+}
+
+// Collect the set of (normal/skew, order) components present in a multipole
+// group, judged by the field-form prefix `first` ('B' magnetic, 'E' electric)
+// and its normalized partner `norm` ('K', or '\0' when there is none).
+static std::set<std::pair<char, std::string>> multipole_components(
+    const ryml::Tree& t, size_t group, char first, char norm) {
+    std::set<std::pair<char, std::string>> comps;
+    for (size_t c = t.first_child(group); c != ryml::NONE;
+         c = t.next_sibling(c)) {
+        if (!t.has_key(c)) continue;
+        std::string k(t.key(c).str, t.key(c).len);
+        char ns;
+        std::string order;
+        if (parse_multipole_key(k, first, ns, order) ||
+            (norm && parse_multipole_key(k, norm, ns, order)))
+            comps.emplace(ns, order);
+    }
+    return comps;
+}
+
+// Resolve MagneticMultipoleP components (magneticmultipole.md). Each component
+// of order N has four equivalent forms tied by length and reference momentum:
+//   BnNL = length * BnN,   KnN = factor * BnN,   KnNL = factor * length * BnN
+// (and likewise for the skew "s" forms). Length-integration needs no momentum;
+// the field<->normalized legs run only when `has_factor`. Iterated to a fixed
+// point so a value given in any one form fills the rest.
+static void resolve_magnetic_multipoles(ryml::Tree& t, size_t ele, double length,
+                                        bool has_factor, double factor,
+                                        const std::string& ename,
+                                        ProblemList& problems) {
+    size_t mp = t.find_child(ele, ryml::to_csubstr("MagneticMultipoleP"));
+    if (mp == ryml::NONE) return;
+    std::string ctx = "element '" + ename + "' MagneticMultipoleP";
+
+    for (const auto& comp : multipole_components(t, mp, 'B', 'K')) {
+        std::string B = std::string("B") + comp.first + comp.second;
+        std::string BL = B + "L";
+        std::string K = std::string("K") + comp.first + comp.second;
+        std::string KL = K + "L";
+        for (int pass = 0; pass < 4; ++pass) {
+            bool changed = false;
+            changed |= link_pair(t, mp, B.c_str(), BL.c_str(), length, ctx,
+                                 problems);
+            changed |= link_pair(t, mp, K.c_str(), KL.c_str(), length, ctx,
+                                 problems);
+            if (has_factor) {
+                changed |= link_pair(t, mp, B.c_str(), K.c_str(), factor, ctx,
+                                     problems);
+                changed |= link_pair(t, mp, BL.c_str(), KL.c_str(), factor, ctx,
+                                     problems);
+            }
+            if (!changed) break;
+        }
+    }
+}
+
+// Resolve ElectricMultipoleP components (electricmultipole.md). Electric
+// multipoles have no normalized form, so a component of order N is only tied by
+// length-integration: EnNL = length * EnN (and the skew "s" forms). No momentum
+// is needed.
+static void resolve_electric_multipoles(ryml::Tree& t, size_t ele, double length,
+                                        const std::string& ename,
+                                        ProblemList& problems) {
+    size_t ep = t.find_child(ele, ryml::to_csubstr("ElectricMultipoleP"));
+    if (ep == ryml::NONE) return;
+    std::string ctx = "element '" + ename + "' ElectricMultipoleP";
+
+    for (const auto& comp : multipole_components(t, ep, 'E', '\0')) {
+        std::string E = std::string("E") + comp.first + comp.second;
+        std::string EL = E + "L";
+        link_pair(t, ep, E.c_str(), EL.c_str(), length, ctx, problems);
+    }
+}
+
+// Compute the field-dependent output parameters of an element. Uses the
+// element's *upstream* reference (parameters are referenced to the upstream
+// end). The reference momentum sets the field<->normalized conversion factor
+// K = factor * B; when the species/momentum is unknown the momentum-dependent
+// legs are skipped, but the purely geometric relations (bend angle/radius,
+// multipole length-integration) still run.
+static void compute_dependent(ryml::Tree& t, size_t ele, const std::string& kind,
+                              const RefState& up, double length,
+                              ProblemList& problems) {
+    bool has_factor = false;
+    double factor = 0.0;
+    if (up.has_species && up.has_pc && up.pc > 0.0) {
+        try {
+            factor = apc::charge_of(up.species) * apc::C_LIGHT / up.pc;
+            has_factor = true;
+        } catch (...) {
+            has_factor = false;
+        }
+    }
+
+    std::string ename = ele_name(t, ele);
+    if (kind == "Bend")
+        resolve_bend(t, ele, length, has_factor, factor, ename, problems);
+    resolve_magnetic_multipoles(t, ele, length, has_factor, factor, ename,
+                                problems);
+    resolve_electric_multipoles(t, ele, length, ename, problems);
+}
+
+// Resolve the RFP dependent parameters (rf.md). The active length `L_active`
+// defaults to the element length `L`; it is materialized when non-zero. The RF
+// voltage and gradient are then tied by `voltage = gradient * L_active`: one is
+// derived from the other, or an inconsistency is flagged when both are set.
+// (frequency <-> harmon is *not* resolved here: it needs the change in reference
+// time across the whole branch, which is not known element-by-element.) Any
+// element carrying an RFP group is handled, keyed on the group's presence.
+static void compute_rf_dependent(ryml::Tree& t, size_t ele, double length,
+                                 ProblemList& problems) {
+    size_t rfp = t.find_child(ele, ryml::to_csubstr("RFP"));
+    if (rfp == ryml::NONE) return;
+
+    // L_active defaults to the element length; hold it when non-zero.
+    double L_active = 0.0;
+    if (!get_num_child(t, rfp, "L_active", L_active)) {
+        L_active = length;
+        if (L_active != 0.0) set_num_child(t, rfp, "L_active", L_active);
+    }
+
+    std::string ctx = "element '" + ele_name(t, ele) + "' RFP";
+    link_pair(t, rfp, "gradient", "voltage", L_active, ctx, problems);
+}
+
+// Parameters with a non-zero (or enum/boolean) default, filled in for any group
+// that is *present* in the element. The expanded lattice holds every non-zero
+// parameter, so an author who writes a group but omits these gets the defaults
+// made explicit. A group absent from the element is left untouched -- only
+// ReferenceP and FloorP are added by the parser. Parameters whose default is
+// zero/null/false are not listed: they are not "held".
+struct GroupDefault {
+    const char* group;
+    const char* key;
+    const char* value;
+};
+static const GroupDefault kGroupDefaults[] = {
+    {"RFP", "cavity_type", "STANDING_WAVE"},
+    {"RFP", "zero_phase", "ACCELERATING"},
+    {"BendP", "ref_geometry", "arc"},
+    {"BendP", "multipole_geometry", "follows_ref_geometry"},
+    {"ApertureP", "shape", "ELLIPTICAL"},
+    {"ApertureP", "location", "ENTRANCE_END"},
+    {"ApertureP", "aperture_active", "true"},
+    {"ForkP", "direction", "FORWARDS"},
+    {"ForkP", "propagate_reference", "true"},
+};
+
+// Write the non-zero/enum defaults (kGroupDefaults) into every group the element
+// already carries, leaving any value the author set in place.
+static void materialize_group_defaults(ryml::Tree& t, size_t ele) {
+    for (const GroupDefault& d : kGroupDefaults) {
+        size_t g = t.find_child(ele, ryml::to_csubstr(d.group));
+        if (g == ryml::NONE || !t.is_map(g)) continue;
+        if (t.find_child(g, ryml::to_csubstr(d.key)) == ryml::NONE)
+            set_plain_child(t, g, d.key, d.value);
+    }
+}
+
+// The per-element bookkeeper. Given the previous element in the branch (NONE for
+// the first, the BeginningEle) and the current element, compute and store the
+// current element's upstream reference parameters, floor placement, s-position,
+// and field-dependent parameters. Order matters: the reference momentum is
+// needed for the dependent-parameter conversions, so reference comes first.
+//
+// `seed_fork` names the Fork element that instantiated this branch, or NONE. It
+// is set only for the first element of a branch created by a Fork whose
+// `propagate_reference` is true: that beginning (destination) element then
+// inherits the Fork's reference species/energy and floor placement instead of
+// starting from the branch's own (usually empty) inputs (fork.md, s:forking).
+static void _element_bookkeeper(ryml::Tree& t, size_t prev, size_t ele,
+                                ProblemList& problems,
+                                size_t seed_fork = ryml::NONE) {
+    std::string kind = child_val_str(t, ele, "kind");
+
+    RefState up;
+    pals::FloorState floor;
+    double s_pos = 0.0;
+
+    if (prev == ryml::NONE && seed_fork != ryml::NONE) {
+        // Beginning element of a forked branch with propagate_reference: inherit
+        // the Fork element's reference and floor. A Fork has zero length and a
+        // unit transfer map, so its stored (upstream) reference and floor are
+        // also its values at the connection point. The new branch's s-coordinate
+        // still starts at zero.
+        up = read_ref(t, seed_fork);
+        complete_energy(up);
+        read_floor(t, seed_fork, floor);
+    } else if (prev == ryml::NONE) {
+        // First element of the branch (BeginningEle): reference, floor and
+        // s-position are user inputs. Complete the reference (fill pc from E or
+        // vice versa) and normalize the floor placement; both default sensibly
+        // when unset (zero energy/momentum, origin, identity orientation, s = 0).
+        up = read_ref(t, ele);
+        complete_energy(up);
+        read_floor(t, ele, floor);  // leaves the origin/identity default if absent
+        get_num_child(t, ele, "s_position", s_pos);
+    } else {
+        // Any later element: its upstream parameters are the previous element's
+        // downstream parameters, propagated through the previous element.
+        std::string pkind = child_val_str(t, prev, "kind");
+        double plen = 0.0;
+        get_num_child(t, prev, "length", plen);
+
+        RefState pup = read_ref(t, prev);
+        complete_energy(pup);
+        up = downstream_ref(t, prev, pkind, pup, plen, problems);
+
+        pals::FloorState pfloor;
+        read_floor(t, prev, pfloor);
+        pals::Vec3 L;
+        pals::Quat S;
+        element_LS(t, prev, pkind, plen, L, S);
+        floor = pals::floor_propagate(pfloor, L, S);
+
+        double ps = 0.0;
+        get_num_child(t, prev, "s_position", ps);
+        s_pos = ps + plen;
+    }
+
+    // Store the outputs. Reference before dependent: the latter reads pc_ref.
+    write_ref(t, ele, up);
+    write_floor(t, ele, floor);
+    set_num_child(t, ele, "s_position", s_pos);
+
+    // Fill in dependent parameters and non-zero/enum defaults of the groups the
+    // element carries. The expanded lattice holds every non-zero parameter.
+    double length = 0.0;
+    get_num_child(t, ele, "length", length);
+    materialize_group_defaults(t, ele);
+    compute_dependent(t, ele, kind, up, length, problems);
+    compute_rf_dependent(t, ele, length, problems);
+}
+
+// Append a zero-length `Placeholder` element named `branch_end` to a branch's
+// `line` and return its definition node. This is the marker that holds the
+// branch's final floor placement and reference parameters; the bookkeeper fills
+// those in by treating it like any other element (its upstream parameters are
+// the downstream end of the last real element).
+static size_t append_branch_end(ryml::Tree& t, size_t line) {
+    ensure_capacity(t, 4);
+    size_t wrapper = t.append_child(line);  // the anonymous seq-entry map
+    t.ref(wrapper) |= ryml::MAP;
+    size_t def = t.append_child(wrapper);  // the keyed element definition
+    t.ref(def) |= ryml::KEY | ryml::MAP;
+    t.set_key(def, t.to_arena(ryml::to_csubstr("branch_end")));
+    size_t kind = t.append_child(def);
+    t.ref(kind) |= ryml::KEY | ryml::VAL;
+    t.set_key(kind, t.to_arena(ryml::to_csubstr("kind")));
+    t.set_val(kind, t.to_arena(ryml::to_csubstr("Placeholder")));
+    return def;
+}
+
+// Walk every branch of the expanded lattice and run _element_bookkeeper on each
+// element in order, threading each element's results (persisted in the tree)
+// into the next. After the branch's elements, a `branch_end` Placeholder is
+// appended and bookkept to hold the branch's final floor placement and reference
+// parameters (the downstream end of the last element).
+//
+// A Fork whose `propagate_reference` is true seeds its destination branch's
+// beginning element from its own reference/floor. Branches are visited in order
+// and a new branch is always appended after the Fork that creates it, so by the
+// time a forked branch is reached its Fork has been bookkept: `fork_seed` maps
+// the destination element (by node id, matching the raw `fork_pointer`) to that
+// Fork. `fork_pointer` still holds the work-tree node id here; it is remapped to
+// the split-out tree only later.
+static void run_element_bookkeeper(ryml::Tree& t, size_t lat_node,
+                                   ProblemList& problems) {
+    size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
+    if (branches == ryml::NONE || !t.is_seq(branches)) return;
+
+    std::map<size_t, size_t> fork_seed;  // destination element -> its Fork
+
+    for (size_t entry = t.first_child(branches); entry != ryml::NONE;
+         entry = t.next_sibling(entry)) {
+        if (!t.is_map(entry)) continue;
+        size_t branch = t.first_child(entry);
+        if (branch == ryml::NONE || !t.is_map(branch)) continue;
+        size_t line = t.find_child(branch, ryml::to_csubstr("line"));
+        if (line == ryml::NONE || !t.is_seq(line)) continue;
+
+        size_t prev = ryml::NONE;
+        for (size_t le = t.first_child(line); le != ryml::NONE;
+             le = t.next_sibling(le)) {
+            // A line entry is a wrapper map whose first child is the keyed
+            // element definition; bare unresolved references have no parameters.
+            if (!t.is_map(le)) continue;
+            size_t def = t.first_child(le);
+            if (def == ryml::NONE || !t.has_key(def)) continue;
+
+            size_t seed = ryml::NONE;
+            if (prev == ryml::NONE) {
+                auto it = fork_seed.find(def);
+                if (it != fork_seed.end()) seed = it->second;
+            }
+            _element_bookkeeper(t, prev, def, problems, seed);
+
+            // Record where a Fork propagates its reference/floor to. The default
+            // (materialized above) is propagate_reference: true; only an explicit
+            // false opts out.
+            if (child_val_str(t, def, "kind") == "Fork") {
+                size_t forkp = t.find_child(def, ryml::to_csubstr("ForkP"));
+                std::string prop =
+                    forkp != ryml::NONE
+                        ? child_val_str(t, forkp, "propagate_reference")
+                        : "";
+                std::string ptr = child_val_str(t, def, "fork_pointer");
+                if (prop != "false" && !ptr.empty()) {
+                    try {
+                        fork_seed[static_cast<size_t>(std::stoull(ptr))] = def;
+                    } catch (...) {
+                    }
+                }
+            }
+            prev = def;
+        }
+
+        // An empty branch has no final state to record; otherwise cap it with a
+        // `branch_end` Placeholder carrying the downstream end of the last
+        // element.
+        if (prev != ryml::NONE)
+            _element_bookkeeper(t, prev, append_branch_end(t, line), problems);
+    }
+}
+
 // Rewrite the `fork_pointer` scalars of a freshly split-out tree. handle_fork
 // stores the raw node id of the fork's destination element, but it runs while
 // expansion is still on the work tree; cutting the lattice out into its own tree
@@ -1410,6 +2205,13 @@ static void make_expanded_and_leftover(ParsedData* comb,
         // expr()-delayed alike). Node ids are unchanged -- only scalar text is
         // rewritten -- so provenance stays valid.
         evaluate_expressions(t, problems);
+
+        // With every input now a plain number, walk each branch element-by-
+        // element to fill in the reference, floor, s-position, and field-
+        // dependent output parameters. This adds new ReferenceP/FloorP nodes,
+        // which carry no provenance (like fork_pointer) and so simply do not
+        // appear in the correspondence map.
+        run_element_bookkeeper(t, lat_node, problems);
 
         size_t wrapper = t.parent(lat_node);
         skip = (wrapper != ryml::NONE && !t.is_root(wrapper) &&

--- a/src/pals_floor.cpp
+++ b/src/pals_floor.cpp
@@ -1,0 +1,138 @@
+// Low-level floor (global) coordinate geometry for lattice expansion. See
+// pals_floor.h for the interface and the mapping onto the PALS "Floor
+// Coordinates" / "Lattice Element Positioning" sections. Orientations are
+// carried as unit quaternions rather than 3x3 rotation matrices; the only place
+// a matrix appears is the internal angle<->quaternion conversion, which needs
+// three specific matrix entries.
+
+#include "pals_floor.h"
+
+#include <cmath>
+
+namespace pals {
+
+Quat quat_mul(const Quat& a, const Quat& b) {
+    return Quat{
+        a.w * b.w - a.x * b.x - a.y * b.y - a.z * b.z,
+        a.w * b.x + a.x * b.w + a.y * b.z - a.z * b.y,
+        a.w * b.y - a.x * b.z + a.y * b.w + a.z * b.x,
+        a.w * b.z + a.x * b.y - a.y * b.x + a.z * b.w,
+    };
+}
+
+Quat quat_normalize(const Quat& q) {
+    double n = std::sqrt(q.w * q.w + q.x * q.x + q.y * q.y + q.z * q.z);
+    if (n <= 0.0) return Quat{1.0, 0.0, 0.0, 0.0};
+    return Quat{q.w / n, q.x / n, q.y / n, q.z / n};
+}
+
+Vec3 quat_rotate(const Quat& q, const Vec3& v) {
+    // v' = q * (0,v) * conj(q), expanded. Equivalent to W*v where W is the
+    // matrix form of q.
+    double ww = q.w, xx = q.x, yy = q.y, zz = q.z;
+    double r00 = 1 - 2 * (yy * yy + zz * zz);
+    double r01 = 2 * (xx * yy - ww * zz);
+    double r02 = 2 * (xx * zz + ww * yy);
+    double r10 = 2 * (xx * yy + ww * zz);
+    double r11 = 1 - 2 * (xx * xx + zz * zz);
+    double r12 = 2 * (yy * zz - ww * xx);
+    double r20 = 2 * (xx * zz - ww * yy);
+    double r21 = 2 * (yy * zz + ww * xx);
+    double r22 = 1 - 2 * (xx * xx + yy * yy);
+    return Vec3{
+        r00 * v.x + r01 * v.y + r02 * v.z,
+        r10 * v.x + r11 * v.y + r12 * v.z,
+        r20 * v.x + r21 * v.y + r22 * v.z,
+    };
+}
+
+Quat quat_from_axis_angle(const Vec3& axis, double angle) {
+    double n = std::sqrt(axis.x * axis.x + axis.y * axis.y + axis.z * axis.z);
+    if (n <= 0.0) return Quat{1.0, 0.0, 0.0, 0.0};
+    double h = 0.5 * angle;
+    double s = std::sin(h) / n;
+    return Quat{std::cos(h), axis.x * s, axis.y * s, axis.z * s};
+}
+
+Quat quat_rot_x(double angle) { return quat_from_axis_angle(Vec3{1, 0, 0}, angle); }
+Quat quat_rot_y(double angle) { return quat_from_axis_angle(Vec3{0, 1, 0}, angle); }
+Quat quat_rot_z(double angle) { return quat_from_axis_angle(Vec3{0, 0, 1}, angle); }
+
+Quat quat_from_floor_angles(const FloorAngles& a) {
+    // W = R_y(theta) * R_x(phi) * R_z(psi); the quaternion product mirrors that
+    // matrix product order.
+    return quat_normalize(
+        quat_mul(quat_rot_y(a.theta), quat_mul(quat_rot_x(a.phi), quat_rot_z(a.psi))));
+}
+
+FloorAngles floor_angles_from_quat(const Quat& q) {
+    Quat u = quat_normalize(q);
+    double ww = u.w, xx = u.x, yy = u.y, zz = u.z;
+
+    // Only the entries used to invert Eq. www are formed. The z-axis column of W
+    // is (sin(theta)cos(phi), -sin(phi), cos(theta)cos(phi)); row 2 is
+    // (cos(phi)sin(psi), cos(phi)cos(psi), -sin(phi)).
+    double r02 = 2 * (xx * zz + ww * yy);
+    double r12 = 2 * (yy * zz - ww * xx);
+    double r22 = 1 - 2 * (xx * xx + yy * yy);
+    double r10 = 2 * (xx * yy + ww * zz);
+    double r11 = 1 - 2 * (xx * xx + zz * zz);
+
+    FloorAngles a;
+    double cos_phi = std::sqrt(r02 * r02 + r22 * r22);
+    a.phi = std::atan2(-r12, cos_phi);
+    if (cos_phi > 1e-12) {
+        a.theta = std::atan2(r02, r22);
+        a.psi = std::atan2(r10, r11);
+    } else {
+        // Gimbal lock (phi = +-pi/2): theta and psi share an axis. Pin psi = 0
+        // and let theta carry the whole rotation. With psi = 0, W row 0 reduces
+        // to (cos(theta), *, *) and W[0][0] = r00, W[2][0] = r20.
+        double r00 = 1 - 2 * (yy * yy + zz * zz);
+        double r20 = 2 * (xx * zz - ww * yy);
+        a.theta = std::atan2(-r20, r00);
+        a.psi = 0.0;
+    }
+    return a;
+}
+
+FloorState floor_propagate(const FloorState& s0, const Vec3& L, const Quat& S) {
+    Vec3 dr = quat_rotate(s0.q, L);
+    FloorState s1;
+    s1.r = Vec3{s0.r.x + dr.x, s0.r.y + dr.y, s0.r.z + dr.z};
+    s1.q = quat_normalize(quat_mul(s0.q, S));
+    return s1;
+}
+
+void straight_LS(double length, Vec3& L, Quat& S) {
+    L = Vec3{0.0, 0.0, length};
+    S = Quat{1.0, 0.0, 0.0, 0.0};
+}
+
+void bend_LS(double length, double angle, double tilt_ref, Vec3& L, Quat& S) {
+    // A bend with no angle bends nothing: fall back to a straight segment so a
+    // zero-curvature "bend" (or a numerically tiny angle) stays well defined.
+    if (std::fabs(angle) < 1e-12) {
+        straight_LS(length, L, S);
+        return;
+    }
+    double rho = length / angle;  // rho = length / angle_ref
+    // Displacement in the un-tilted bend plane (Eq. lrztt, L~) then rotated by
+    // tilt_ref about z.
+    Vec3 L_tilde{rho * (std::cos(angle) - 1.0), 0.0, rho * std::sin(angle)};
+    L = quat_rotate(quat_rot_z(tilt_ref), L_tilde);
+    // Rotation axis u = (-sin(tilt_ref), -cos(tilt_ref), 0), angle = angle_ref
+    // (Eq. ustt). u is a unit vector.
+    S = quat_from_axis_angle(Vec3{-std::sin(tilt_ref), -std::cos(tilt_ref), 0.0},
+                             angle);
+}
+
+void patch_LS(double x_offset, double y_offset, double z_offset, double x_rot,
+              double y_rot, double z_rot, Vec3& L, Quat& S) {
+    L = Vec3{x_offset, y_offset, z_offset};
+    // S = R_y(y_rot) * R_x(x_rot) * R_z(z_rot)  (Eq. lxyz).
+    S = quat_normalize(
+        quat_mul(quat_rot_y(y_rot), quat_mul(quat_rot_x(x_rot), quat_rot_z(z_rot))));
+}
+
+}  // namespace pals

--- a/src/pals_floor.h
+++ b/src/pals_floor.h
@@ -1,0 +1,122 @@
+#ifndef PALS_FLOOR_H
+#define PALS_FLOOR_H
+
+/**
+ * @file pals_floor.h
+ * @brief Low-level floor (global) coordinate geometry for lattice expansion.
+ *
+ * Implements the "Floor Coordinates" and "Lattice Element Positioning" sections
+ * of the PALS standard (pals/source/coordinates.md). A floor placement is the
+ * position and orientation of the branch coordinate system at one point along
+ * the reference curve; the standard writes the orientation as the 3x3 rotation
+ * matrix W (Eq. www), but here it is carried as a unit quaternion instead. Only
+ * the boundary conversions to/from the FloorP orientation angles
+ * (theta, phi, psi) touch the matrix form at all.
+ *
+ * The element-by-element construction (the branch bookkeeper in
+ * pals_expand.cpp) walks the reference curve using floor_propagate():
+ * given the placement at the upstream end of an element and the element's local
+ * displacement L and coordinate rotation S, it returns the placement at the
+ * downstream end (Eq. wws). straight_LS / bend_LS / patch_LS build the (L, S)
+ * pair for the three reference-curve geometries PALS defines.
+ */
+
+namespace pals {
+
+// A vector in floor (global) Cartesian coordinates, or a displacement expressed
+// in a local branch frame.
+struct Vec3 {
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+};
+
+// A unit quaternion (w + x i + y j + z k) representing a rotation. Used in place
+// of the 3x3 orientation matrix W: the branch x, y, z axes are the columns of
+// the matrix this quaternion encodes.
+struct Quat {
+    double w = 1.0;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+};
+
+// A floor placement: the origin position r of the branch coordinate system and
+// its orientation q (the quaternion form of the W matrix), at one point on the
+// reference curve.
+struct FloorState {
+    Vec3 r;
+    Quat q;
+};
+
+// The three FloorP orientation angles (radians), as defined in the Floor
+// Coordinates section: theta (azimuth), phi (pitch), psi (roll).
+struct FloorAngles {
+    double theta = 0.0;
+    double phi = 0.0;
+    double psi = 0.0;
+};
+
+// --- Quaternion primitives ---
+
+// Hamilton product a*b. With quat_rotate below this composes rotations so that
+// quat_mul(a, b) applies b first, then a (matrix product A*B).
+Quat quat_mul(const Quat& a, const Quat& b);
+
+// Return a copy scaled to unit norm (identity if the input is ~zero). Repeated
+// products accumulate rounding, so placements are renormalized as they are
+// carried along the branch.
+Quat quat_normalize(const Quat& q);
+
+// Rotate vector v by the rotation q encodes, i.e. compute W*v where W is the
+// matrix form of q.
+Vec3 quat_rotate(const Quat& q, const Vec3& v);
+
+// Quaternion for a rotation of `angle` radians about `axis` (need not be
+// normalized; a ~zero axis yields the identity).
+Quat quat_from_axis_angle(const Vec3& axis, double angle);
+
+// Quaternions for the elementary rotations R_x, R_y, R_z of the standard
+// (Eq. wtt0t), about the branch x, y, z axes respectively.
+Quat quat_rot_x(double angle);
+Quat quat_rot_y(double angle);
+Quat quat_rot_z(double angle);
+
+// --- FloorP angle <-> quaternion (Eq. www) ---
+
+// Build the orientation quaternion from FloorP angles:
+//   W = R_y(theta) * R_x(phi) * R_z(psi).
+Quat quat_from_floor_angles(const FloorAngles& a);
+
+// Recover the FloorP angles from an orientation quaternion (inverse of
+// quat_from_floor_angles). At the phi = +-pi/2 gimbal singularity psi is taken
+// to be zero and theta absorbs the remaining rotation.
+FloorAngles floor_angles_from_quat(const Quat& q);
+
+// --- Reference-curve propagation ---
+
+// Placement at the downstream end of an element given the placement s0 at its
+// upstream end, the element's displacement vector L (in the upstream branch
+// frame), and its coordinate rotation S:
+//   r1 = r0 + W0*L,   W1 = W0*S     (Eq. wws).
+FloorState floor_propagate(const FloorState& s0, const Vec3& L, const Quat& S);
+
+// --- (L, S) builders for the three reference-curve geometries ---
+
+// Straight element (Drift, Quadrupole, ...) of the given length: L = (0,0,L),
+// S = identity (Eq. l00l).
+void straight_LS(double length, Vec3& L, Quat& S);
+
+// Bend with arc length `length`, reference bend angle `angle` (radians), and
+// `tilt_ref` (radians). Uses Eqs. ustt / lrztt. A ~zero angle degenerates to a
+// straight element of that length.
+void bend_LS(double length, double angle, double tilt_ref, Vec3& L, Quat& S);
+
+// Patch element (Eq. lxyz): L = (x_offset, y_offset, z_offset),
+// S = R_y(y_rot) * R_x(x_rot) * R_z(z_rot).
+void patch_LS(double x_offset, double y_offset, double z_offset, double x_rot,
+              double y_rot, double z_rot, Vec3& L, Quat& S);
+
+}  // namespace pals
+
+#endif  // PALS_FLOOR_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(tests
   test_expressions.cpp
   test_multipass.cpp
   test_controllers.cpp
+  test_bookkeeper.cpp
 )
 
 target_link_libraries(tests

--- a/tests/test_bookkeeper.cpp
+++ b/tests/test_bookkeeper.cpp
@@ -1,0 +1,533 @@
+#include "test_helpers.h"
+
+#include <cmath>
+
+// ============================================================
+// ELEMENT BOOKKEEPER
+// ============================================================
+//
+// The element bookkeeper (run_element_bookkeeper in pals_expand.cpp) walks each
+// branch after expression evaluation and fills in the position-dependent output
+// parameters: reference (species / energy / momentum / time), floor placement,
+// s_position, and the field-dependent multipole / bend strengths. The floor math
+// lives in the quaternion module pals_floor.cpp. These tests pin the values it
+// produces for a small branch with a drift, a quadrupole, and a bend.
+
+namespace {
+
+// A branch: BeginningEle (1 GeV electrons) -> 2 m drift -> 0.5 m quad with a
+// normal quadrupole field -> 1.5 m bend of 0.15 rad -> 1 m drift -> Marker.
+const char* BOOKKEEPER_YAML =
+    "PALS:\n"
+    "  facility:\n"
+    "    - test_line:\n"
+    "        kind: BeamLine\n"
+    "        line:\n"
+    "          - begin:\n"
+    "              kind: BeginningEle\n"
+    "              ReferenceP:\n"
+    "                species_ref: \"electron\"\n"
+    "                E_tot_ref: 1.0e9\n"
+    "          - d1:\n"
+    "              kind: Drift\n"
+    "              length: 2.0\n"
+    "          - q1:\n"
+    "              kind: Quadrupole\n"
+    "              length: 0.5\n"
+    "              MagneticMultipoleP:\n"
+    "                Bn1: 1.2\n"
+    "          - b1:\n"
+    "              kind: Bend\n"
+    "              length: 1.5\n"
+    "              BendP:\n"
+    "                angle_ref: 0.15\n"
+    "          - d2:\n"
+    "              kind: Drift\n"
+    "              length: 1.0\n"
+    "          - end:\n"
+    "              kind: Marker\n"
+    "    - lat:\n"
+    "        kind: Lattice\n"
+    "        branches:\n"
+    "          - test_line\n"
+    "    - use: lat\n";
+
+// Value of ele>group.param in the expanded tree, as a double.
+double param_num(YAMLTreeHandle t, const char* ele, const char* group,
+                 const char* param) {
+    YAMLNodeId e = find_by_key(t, ele);
+    YAMLNodeId g = group ? get_child_by_key(t, e, group) : e;
+    return num_val(t, get_child_by_key(t, g, param));
+}
+
+// Expand BOOKKEEPER_YAML from a temp file (the only expansion entry point takes
+// a filename). The caller frees the returned trees and problem list.
+struct lattices expand_bookkeeper() {
+    const char* path = "tmp_bookkeeper.pals.yaml";
+    write_tmp(path, BOOKKEEPER_YAML);
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    rm_tmp(path);
+    return lat;
+}
+
+}  // namespace
+
+TEST_CASE("Bookkeeper fills reference energy, momentum, and time",
+          "[bookkeeper]") {
+    struct lattices lat = expand_bookkeeper();
+    YAMLTreeHandle t = lat.expanded;
+
+    // pc = sqrt(E^2 - m^2) with the electron rest energy ~0.511 MeV; every
+    // element downstream carries the same species and (drifts don't change it)
+    // energy/momentum.
+    const double m_e = 510998.95;  // eV, apc electron rest energy
+    const double pc = std::sqrt(1.0e9 * 1.0e9 - m_e * m_e);
+    for (const char* ele : {"begin", "d1", "q1", "b1", "d2", "end"}) {
+        REQUIRE(close_rel(param_num(t, ele, "ReferenceP", "pc_ref"), pc));
+        REQUIRE(close_rel(param_num(t, ele, "ReferenceP", "E_tot_ref"), 1.0e9));
+    }
+
+    // Reference time is zero at the start and grows by length / (beta c) across
+    // each element. beta = pc / E.
+    const double c = 2.99792458e8;
+    const double beta = pc / 1.0e9;
+    REQUIRE(close(param_num(t, "begin", "ReferenceP", "time_ref"), 0.0));
+    REQUIRE(close_rel(param_num(t, "q1", "ReferenceP", "time_ref"),
+                      2.0 / (beta * c)));               // after the 2 m drift
+    REQUIRE(close_rel(param_num(t, "end", "ReferenceP", "time_ref"),
+                      5.0 / (beta * c)));               // total path length 5 m
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper accumulates s_position from element lengths",
+          "[bookkeeper]") {
+    struct lattices lat = expand_bookkeeper();
+    YAMLTreeHandle t = lat.expanded;
+
+    // s_position is the upstream end of each element: 0, then the running sum of
+    // the preceding element lengths (0, 2, 0.5, 1.5, 1).
+    REQUIRE(close(param_num(t, "begin", nullptr, "s_position"), 0.0));
+    REQUIRE(close(param_num(t, "d1", nullptr, "s_position"), 0.0));
+    REQUIRE(close(param_num(t, "q1", nullptr, "s_position"), 2.0));
+    REQUIRE(close(param_num(t, "b1", nullptr, "s_position"), 2.5));
+    REQUIRE(close(param_num(t, "d2", nullptr, "s_position"), 4.0));
+    REQUIRE(close(param_num(t, "end", nullptr, "s_position"), 5.0));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper derives the normalized multipole strength", "[bookkeeper]") {
+    struct lattices lat = expand_bookkeeper();
+    YAMLTreeHandle t = lat.expanded;
+
+    // Kn1 = (q / P0) Bn1 = (charge * c_light / pc) * Bn1, with charge = -1 for
+    // the electron, referenced to q1's upstream momentum.
+    const double m_e = 510998.95;
+    const double pc = std::sqrt(1.0e9 * 1.0e9 - m_e * m_e);
+    const double factor = -1.0 * 2.99792458e8 / pc;
+    REQUIRE(close_rel(param_num(t, "q1", "MagneticMultipoleP", "Kn1"),
+                      factor * 1.2));
+    // The user-supplied field value is left as written.
+    REQUIRE(close(param_num(t, "q1", "MagneticMultipoleP", "Bn1"), 1.2));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper caps each branch with a branch_end Placeholder",
+          "[bookkeeper]") {
+    struct lattices lat = expand_bookkeeper();
+    YAMLTreeHandle t = lat.expanded;
+
+    // The branch gains a trailing element named `branch_end` of kind Placeholder.
+    YAMLNodeId be = find_by_key(t, "branch_end");
+    REQUIRE(be != YAML_NULL_ID);
+    REQUIRE(val_eq(t, get_child_by_key(t, be, "kind"), "Placeholder"));
+
+    // It holds the branch's final state: the downstream end of the last element.
+    // Here the last real element is the zero-length Marker `end`, so branch_end's
+    // placement, reference, and s-position match it exactly.
+    REQUIRE(close(param_num(t, "branch_end", nullptr, "s_position"),
+                  param_num(t, "end", nullptr, "s_position")));
+    REQUIRE(close(param_num(t, "branch_end", "FloorP", "z"),
+                  param_num(t, "end", "FloorP", "z")));
+    REQUIRE(close(param_num(t, "branch_end", "FloorP", "theta"), -0.15));
+
+    const double m_e = 510998.95;
+    const double pc = std::sqrt(1.0e9 * 1.0e9 - m_e * m_e);
+    REQUIRE(close_rel(param_num(t, "branch_end", "ReferenceP", "pc_ref"), pc));
+    REQUIRE(val_eq(t, get_child_by_key(t, get_child_by_key(t, be, "ReferenceP"),
+                                       "species_ref"),
+                   "electron"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+// A branch with a single RFCavity, whose RFP body is spliced in from `rfp_body`
+// (raw YAML at 16-space indentation). Lets each RF test set voltage/gradient/
+// L_active as it likes.
+static std::string rf_yaml(const std::string& rfp_body) {
+    return std::string(
+               "PALS:\n"
+               "  facility:\n"
+               "    - test_line:\n"
+               "        kind: BeamLine\n"
+               "        line:\n"
+               "          - begin:\n"
+               "              kind: BeginningEle\n"
+               "              ReferenceP:\n"
+               "                species_ref: \"electron\"\n"
+               "                E_tot_ref: 1.0e9\n"
+               "          - cav:\n"
+               "              kind: RFCavity\n"
+               "              length: 0.4\n"
+               "              RFP:\n") +
+           rfp_body +
+           "    - lat:\n"
+           "        kind: Lattice\n"
+           "        branches:\n"
+           "          - test_line\n"
+           "    - use: lat\n";
+}
+
+static struct lattices expand_rf(const std::string& rfp_body) {
+    const char* path = "tmp_rf.pals.yaml";
+    write_tmp(path, rf_yaml(rfp_body));
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    rm_tmp(path);
+    return lat;
+}
+
+static bool any_problem_contains(struct lattices& lat, const char* needle) {
+    for (size_t i = 0; i < lat.problems.count; ++i)
+        if (std::string(lat.problems.items[i]).find(needle) != std::string::npos)
+            return true;
+    return false;
+}
+
+// A branch: BeginningEle (1 GeV electrons) followed by a single element whose
+// definition is spliced in from `ele_body` (raw YAML at 10-space indentation,
+// e.g. "          - el:\n              kind: Bend\n ..."). Lets a test drive one
+// element's dependent parameters in isolation.
+static std::string one_ele_yaml(const std::string& ele_body) {
+    return std::string(
+               "PALS:\n"
+               "  facility:\n"
+               "    - test_line:\n"
+               "        kind: BeamLine\n"
+               "        line:\n"
+               "          - begin:\n"
+               "              kind: BeginningEle\n"
+               "              ReferenceP:\n"
+               "                species_ref: \"electron\"\n"
+               "                E_tot_ref: 1.0e9\n") +
+           ele_body +
+           "    - lat:\n"
+           "        kind: Lattice\n"
+           "        branches:\n"
+           "          - test_line\n"
+           "    - use: lat\n";
+}
+
+static struct lattices expand_src(const std::string& src) {
+    const char* path = "tmp_dep.pals.yaml";
+    write_tmp(path, src);
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    rm_tmp(path);
+    return lat;
+}
+
+// The reference momentum and the field<->normalized conversion factor for a
+// 1 GeV electron (charge -1), shared by the multipole / bend-field tests.
+static double electron_pc() {
+    const double m_e = 510998.95;  // eV, apc electron rest energy
+    return std::sqrt(1.0e9 * 1.0e9 - m_e * m_e);
+}
+static double electron_factor() { return -1.0 * 2.99792458e8 / electron_pc(); }
+
+TEST_CASE("Bookkeeper derives RF voltage from gradient and active length",
+          "[bookkeeper]") {
+    // Only the gradient is given; L_active defaults to the element length 0.4, so
+    // voltage = gradient * L_active = 1e8 * 0.4 = 4e7. No inconsistency reported.
+    struct lattices lat = expand_rf("                gradient: 1.0e8\n");
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(close_rel(param_num(t, "cav", "RFP", "voltage"), 4.0e7));
+    REQUIRE(close(param_num(t, "cav", "RFP", "gradient"), 1.0e8));
+    REQUIRE_FALSE(any_problem_contains(lat, "inconsistent"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper derives RF gradient from voltage and active length",
+          "[bookkeeper]") {
+    // Only the voltage is given; gradient = voltage / L_active = 8e6 / 0.4 = 2e7.
+    struct lattices lat = expand_rf("                voltage: 8.0e6\n");
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(close_rel(param_num(t, "cav", "RFP", "gradient"), 2.0e7));
+    REQUIRE(close(param_num(t, "cav", "RFP", "voltage"), 8.0e6));
+    REQUIRE_FALSE(any_problem_contains(lat, "inconsistent"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper accepts consistent RF voltage and gradient",
+          "[bookkeeper]") {
+    // Both set and agreeing (2e7 * 0.4 = 8e6): no problem, values untouched.
+    struct lattices lat =
+        expand_rf("                gradient: 2.0e7\n"
+                  "                voltage: 8.0e6\n");
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(close(param_num(t, "cav", "RFP", "gradient"), 2.0e7));
+    REQUIRE(close(param_num(t, "cav", "RFP", "voltage"), 8.0e6));
+    REQUIRE_FALSE(any_problem_contains(lat, "inconsistent"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper flags inconsistent RF voltage and gradient",
+          "[bookkeeper]") {
+    // The PALSJulia/alocal case: gradient 1e8 with L_active 0.4 implies voltage
+    // 4e7, but voltage is set to 45. That must be reported as inconsistent.
+    struct lattices lat =
+        expand_rf("                gradient: 1.0e8\n"
+                  "                voltage: 45\n");
+
+    REQUIRE(any_problem_contains(lat, "inconsistent"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper honors an explicit L_active for RF derivation",
+          "[bookkeeper]") {
+    // L_active (0.25) differs from the element length (0.4); the derived voltage
+    // follows the active length: 1e8 * 0.25 = 2.5e7.
+    struct lattices lat =
+        expand_rf("                gradient: 1.0e8\n"
+                  "                L_active: 0.25\n");
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(close_rel(param_num(t, "cav", "RFP", "voltage"), 2.5e7));
+    REQUIRE_FALSE(any_problem_contains(lat, "inconsistent"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper propagates floor coordinates through a bend",
+          "[bookkeeper]") {
+    struct lattices lat = expand_bookkeeper();
+    YAMLTreeHandle t = lat.expanded;
+
+    // Everything up to the bend lies along +Z at the origin, unrotated.
+    REQUIRE(close(param_num(t, "b1", "FloorP", "z"), 2.5));
+    REQUIRE(close(param_num(t, "b1", "FloorP", "x"), 0.0));
+    REQUIRE(close(param_num(t, "b1", "FloorP", "theta"), 0.0));
+
+    // The bend has arc length 1.5 and angle 0.15, so rho = 10. Its downstream
+    // frame (= d2's upstream frame) is displaced by (rho(cos a - 1), 0,
+    // rho sin a) from the bend entrance at z = 2.5, and a positive bend angle
+    // decreases theta.
+    const double rho = 1.5 / 0.15;
+    REQUIRE(close(param_num(t, "d2", "FloorP", "x"), rho * (std::cos(0.15) - 1.0)));
+    REQUIRE(close(param_num(t, "d2", "FloorP", "z"), 2.5 + rho * std::sin(0.15)));
+    REQUIRE(close(param_num(t, "d2", "FloorP", "theta"), -0.15));
+
+    // The final 1 m drift advances along the rotated z-axis (azimuth -0.15).
+    REQUIRE(close(param_num(t, "end", "FloorP", "theta"), -0.15));
+    REQUIRE(close(param_num(t, "end", "FloorP", "x"),
+                  param_num(t, "d2", "FloorP", "x") + 1.0 * std::sin(-0.15)));
+    REQUIRE(close(param_num(t, "end", "FloorP", "z"),
+                  param_num(t, "d2", "FloorP", "z") + 1.0 * std::cos(-0.15)));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper derives all bend strength forms from the angle",
+          "[bookkeeper]") {
+    // b1 gives only angle_ref 0.15 over length 1.5. The expanded lattice holds
+    // every equivalent form: g_ref = angle/length = 0.1, rho_ref = 1/g_ref = 10,
+    // and bend_field_ref = g_ref / factor (factor = -c/pc for the electron).
+    struct lattices lat = expand_bookkeeper();
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(close(param_num(t, "b1", "BendP", "angle_ref"), 0.15));
+    REQUIRE(close(param_num(t, "b1", "BendP", "g_ref"), 0.1));
+    REQUIRE(close(param_num(t, "b1", "BendP", "rho_ref"), 10.0));
+    REQUIRE(close_rel(param_num(t, "b1", "BendP", "bend_field_ref"),
+                      0.1 / electron_factor()));
+
+    // The non-zero enum defaults of the present BendP group are made explicit.
+    YAMLNodeId bp = get_child_by_key(t, find_by_key(t, "b1"), "BendP");
+    REQUIRE(val_eq(t, get_child_by_key(t, bp, "ref_geometry"), "arc"));
+    REQUIRE(val_eq(t, get_child_by_key(t, bp, "multipole_geometry"),
+                   "follows_ref_geometry"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper derives integrated and normalized multipole forms",
+          "[bookkeeper]") {
+    // q1 gives only Bn1 1.2 over length 0.5. The expanded lattice holds all four
+    // equivalent forms: the field (Bn1), its length integral (Bn1L = L*Bn1), the
+    // normalized value (Kn1 = factor*Bn1), and the normalized integral (Kn1L).
+    struct lattices lat = expand_bookkeeper();
+    YAMLTreeHandle t = lat.expanded;
+    const double f = electron_factor();
+
+    REQUIRE(close(param_num(t, "q1", "MagneticMultipoleP", "Bn1"), 1.2));
+    REQUIRE(close(param_num(t, "q1", "MagneticMultipoleP", "Bn1L"), 0.6));
+    REQUIRE(close_rel(param_num(t, "q1", "MagneticMultipoleP", "Kn1"), f * 1.2));
+    REQUIRE(close_rel(param_num(t, "q1", "MagneticMultipoleP", "Kn1L"), f * 0.6));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper derives the integrated electric multipole", "[bookkeeper]") {
+    // Electric multipoles have no normalized form; only length-integration ties
+    // En2 to En2L = length * En2 = 0.5 * 5 = 2.5.
+    struct lattices lat = expand_src(one_ele_yaml(
+        "          - em:\n"
+        "              kind: Sextupole\n"
+        "              length: 0.5\n"
+        "              ElectricMultipoleP:\n"
+        "                En2: 5.0\n"));
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(close(param_num(t, "em", "ElectricMultipoleP", "En2"), 5.0));
+    REQUIRE(close(param_num(t, "em", "ElectricMultipoleP", "En2L"), 2.5));
+    REQUIRE_FALSE(any_problem_contains(lat, "inconsistent"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper flags an inconsistent bend strength", "[bookkeeper]") {
+    // angle_ref 0.15 over length 1.5 implies g_ref 0.1, but g_ref is set to 0.2.
+    struct lattices lat = expand_src(one_ele_yaml(
+        "          - bnd:\n"
+        "              kind: Bend\n"
+        "              length: 1.5\n"
+        "              BendP:\n"
+        "                angle_ref: 0.15\n"
+        "                g_ref: 0.2\n"));
+
+    REQUIRE(any_problem_contains(lat, "inconsistent"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper flags an inconsistent multipole component",
+          "[bookkeeper]") {
+    // Bn1 1.2 over length 0.5 implies Bn1L 0.6, but Bn1L is set to 0.5.
+    struct lattices lat = expand_src(one_ele_yaml(
+        "          - sx:\n"
+        "              kind: Sextupole\n"
+        "              length: 0.5\n"
+        "              MagneticMultipoleP:\n"
+        "                Bn1: 1.2\n"
+        "                Bn1L: 0.5\n"));
+
+    REQUIRE(any_problem_contains(lat, "inconsistent"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper materializes RF enum defaults and L_active",
+          "[bookkeeper]") {
+    // A present RFP group gains its non-zero enum defaults and an explicit
+    // L_active (= element length 0.4), alongside the derived voltage.
+    struct lattices lat = expand_rf("                gradient: 1.0e8\n");
+    YAMLTreeHandle t = lat.expanded;
+
+    YAMLNodeId rfp = get_child_by_key(t, find_by_key(t, "cav"), "RFP");
+    REQUIRE(val_eq(t, get_child_by_key(t, rfp, "cavity_type"), "STANDING_WAVE"));
+    REQUIRE(val_eq(t, get_child_by_key(t, rfp, "zero_phase"), "ACCELERATING"));
+    REQUIRE(close(param_num(t, "cav", "RFP", "L_active"), 0.4));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper leaves absent parameter groups alone", "[bookkeeper]") {
+    // Groups not present in the file are not materialized: a plain drift gains no
+    // BendP/RFP/multipole groups. Only ReferenceP and FloorP are parser-added.
+    struct lattices lat = expand_bookkeeper();
+    YAMLTreeHandle t = lat.expanded;
+    YAMLNodeId d1 = find_by_key(t, "d1");
+
+    REQUIRE(get_child_by_key(t, d1, "BendP") == YAML_NULL_ID);
+    REQUIRE(get_child_by_key(t, d1, "RFP") == YAML_NULL_ID);
+    REQUIRE(get_child_by_key(t, d1, "MagneticMultipoleP") == YAML_NULL_ID);
+    REQUIRE(get_child_by_key(t, d1, "ReferenceP") != YAML_NULL_ID);
+    REQUIRE(get_child_by_key(t, d1, "FloorP") != YAML_NULL_ID);
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -465,6 +465,143 @@ TEST_CASE("a Fork needs only to_line; destination_element and new_branch default
     rm_tmp(path);
 }
 
+// Helper: the keyed element definition of a branch's first line element.
+// expanded -> lat1(0) -> branches -> branch entry(idx) -> branch map(0) ->
+// line -> line entry(0) -> element def(0).
+static YAMLNodeId first_element_of_branch(YAMLTreeHandle t, size_t branch_idx) {
+    YAMLNodeId lat1 = get_child_by_index(t, get_root(t), 0);
+    YAMLNodeId branches = get_child_by_key(t, lat1, "branches");
+    YAMLNodeId branch = get_child_by_index(
+        t, get_child_by_index(t, branches, branch_idx), 0);
+    YAMLNodeId line = get_child_by_key(t, branch, "line");
+    YAMLNodeId entry = get_child_by_index(t, line, 0);
+    return get_child_by_index(t, entry, 0);
+}
+
+TEST_CASE("a Fork propagates reference and floor into its new branch",
+          "[lattices]") {
+    // propagate_reference is true by default, so the destination branch's
+    // beginning element inherits the Fork element's reference species/energy and
+    // floor placement (fork.md), even when the forked-to line has no BeginningEle
+    // of its own.
+    const char* path = "tmp_fork_propagate.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - begin:\n"
+              "        kind: BeginningEle\n"
+              "        FloorP:\n"
+              "          x: 1.5\n"
+              "        ReferenceP:\n"
+              "          species_ref: proton\n"
+              "          E_tot_ref: 1.0e9\n"
+              "    - m1:\n"
+              "        kind: Marker\n"
+              "    - ext_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - m1\n"
+              "    - ring:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - begin\n"
+              "          - f1:\n"
+              "              kind: Fork\n"
+              "              ForkP:\n"
+              "                to_line: ext_line\n"
+              "                new_branch: extraction\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - ring\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+
+    // Branch 1 is `extraction`; its first (destination) element is `m1`.
+    YAMLNodeId dest = first_element_of_branch(lat.expanded, 1);
+    REQUIRE(key_eq(lat.expanded, dest, "m1"));
+
+    YAMLNodeId refp = get_child_by_key(lat.expanded, dest, "ReferenceP");
+    REQUIRE(refp != YAML_NULL_ID);
+    REQUIRE(val_eq(lat.expanded,
+                   get_child_by_key(lat.expanded, refp, "species_ref"),
+                   "proton"));
+    // Energy carried through the zero-length Fork unchanged, and completion
+    // filled in the momentum from it.
+    REQUIRE(val_eq(lat.expanded,
+                   get_child_by_key(lat.expanded, refp, "E_tot_ref"), "1e+09"));
+    REQUIRE(get_child_by_key(lat.expanded, refp, "pc_ref") != YAML_NULL_ID);
+
+    // Floor placement of the source (x = 1.5) reaches the destination too.
+    YAMLNodeId floorp = get_child_by_key(lat.expanded, dest, "FloorP");
+    REQUIRE(floorp != YAML_NULL_ID);
+    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, floorp, "x"),
+                   "1.5"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}
+
+TEST_CASE("propagate_reference: false leaves the new branch's reference unset",
+          "[lattices]") {
+    // With propagate_reference explicitly false, nothing is carried across the
+    // Fork: the destination element keeps only its own (here empty) reference.
+    const char* path = "tmp_fork_noprop.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - begin:\n"
+              "        kind: BeginningEle\n"
+              "        ReferenceP:\n"
+              "          species_ref: proton\n"
+              "          E_tot_ref: 1.0e9\n"
+              "    - m1:\n"
+              "        kind: Marker\n"
+              "    - ext_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - m1\n"
+              "    - ring:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - begin\n"
+              "          - f1:\n"
+              "              kind: Fork\n"
+              "              ForkP:\n"
+              "                to_line: ext_line\n"
+              "                new_branch: extraction\n"
+              "                propagate_reference: false\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - ring\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+
+    YAMLNodeId dest = first_element_of_branch(lat.expanded, 1);
+    REQUIRE(key_eq(lat.expanded, dest, "m1"));
+
+    YAMLNodeId refp = get_child_by_key(lat.expanded, dest, "ReferenceP");
+    // A ReferenceP is still written (time_ref), but no species/energy propagated.
+    REQUIRE(get_child_by_key(lat.expanded, refp, "species_ref") == YAML_NULL_ID);
+    REQUIRE(get_child_by_key(lat.expanded, refp, "E_tot_ref") == YAML_NULL_ID);
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}
+
 TEST_CASE("a malformed top-level file is a fatal parse problem, not a crash",
           "[lattices][problems]") {
     // A sequence item missing its ':' (here `- cav` followed by an indented

--- a/tests/test_key_order.cpp
+++ b/tests/test_key_order.cpp
@@ -111,13 +111,16 @@ TEST_CASE("Expansion preserves the key order of the source file", "[key_order]")
     // Merging `inherit: thingB` brings the parent's keys in ahead of the
     // child's own, rather than sorting the merged result. `main_line` is a
     // `multipass` root line, so its one element also picks up a trailing
-    // `multipass_index`, appended after the inherited keys.
+    // `multipass_index`, appended after the inherited keys. Finally, the element
+    // bookkeeper appends its computed output groups (`ReferenceP`, `FloorP`) and
+    // `s_position`, in that order, after everything the file supplied.
     YAMLNodeId line_seq = get_child_by_key(lat.expanded, e_line, "line");
     YAMLNodeId thingZ = get_child_by_index(
         lat.expanded, get_child_by_index(lat.expanded, line_seq, 0), 0);
     REQUIRE(key_eq(lat.expanded, thingZ, "thingZ"));
-    const std::vector<std::string> inherited = {"kind", "length", "inherit",
-                                                "multipass_index"};
+    const std::vector<std::string> inherited = {
+        "kind",           "length",     "inherit", "multipass_index",
+        "ReferenceP",     "FloorP",     "s_position"};
     REQUIRE(keys_of(lat.expanded, thingZ) == inherited);
     REQUIRE(val_eq(lat.expanded,
                    get_child_by_key(lat.expanded, thingZ, "multipass_index"),

--- a/tests/test_multipass.cpp
+++ b/tests/test_multipass.cpp
@@ -52,14 +52,15 @@ TEST_CASE("Multipass sub-lines are numbered with a multipass_index",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(lat.expanded != nullptr);
 
-    // Flat line: mark, cavA, cavA, cavA, cavA (5 elements).
+    // Flat line: mark, cavA, cavA, cavA, cavA (5 elements), plus the appended
+    // `branch_end` Placeholder the bookkeeper caps every branch with (6 total).
     YAMLNodeId lat1 = get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
     YAMLNodeId branch = get_child_by_index(
         lat.expanded,
         get_child_by_index(lat.expanded,
                            get_child_by_key(lat.expanded, lat1, "branches"), 0),
         0);
-    REQUIRE(get_size(lat.expanded, get_child_by_key(lat.expanded, branch, "line")) == 5);
+    REQUIRE(get_size(lat.expanded, get_child_by_key(lat.expanded, branch, "line")) == 6);
 
     // mark, from the non-multipass inj, carries no index.
     REQUIRE(mp_index_at(lat.expanded, 0) == YAML_NULL_ID);


### PR DESCRIPTION
## What

Adds the **element bookkeeper**: the lattice-expansion stage that, once every
expression has been reduced to a number, walks each branch element-by-element
from its `BeginningEle` and fills in the parameters that depend on an element's
position in the branch.

Per element it computes and stores:

- **Reference parameters** — species, total energy, momentum, and time.
  `E_tot`/`pc` are completed from the reference mass; time advances by the
  transit time; `RFCavity` shifts the energy and `ReferenceChange` applies its
  `ReferenceChangeP`.
- **Floor placement** — propagated along the reference curve for straight,
  bend, and patch geometries, using the new `pals_floor.{h,cpp}` quaternion
  geometry.
- **s-position** — accumulated from element lengths.
- **Field-dependent parameters** — normalized ⇄ unnormalized multipole and bend
  strengths — plus the non-zero/enum defaults of each group the element carries.

Each branch is capped with a zero-length `branch_end` `Placeholder` holding the
branch's final floor placement and reference parameters.

### Fork reference/floor propagation

A `Fork` with `propagate_reference: true` (the default) seeds its destination
branch's beginning element from the Fork's own reference and floor. This fixes
the case where a forked line has no `BeginningEle` of its own: previously such a
branch started from zero energy and the origin; now it correctly inherits the
species/energy and floor position at the fork point (fork.md, s:forking). An
explicit `propagate_reference: false` opts out.

## New files

- `src/pals_floor.{h,cpp}` — floor (global) coordinate geometry: quaternion
  algebra, `FloorP` angle ↔ quaternion conversion, and `floor_propagate` /
  `straight_LS` / `bend_LS` / `patch_LS` implementing the standard's
  "Floor Coordinates" / "Lattice Element Positioning" sections.
- `tests/test_bookkeeper.cpp` — reference/floor/s propagation and dependent-
  parameter conversions.

## Tests

`tests/test_expansion.cpp` adds fork reference/floor propagation cases;
`test_key_order` and `test_multipass` are updated for the appended
`ReferenceP`/`FloorP`/`s_position` groups and the `branch_end` Placeholder.

Full suite: **705 assertions in 131 test cases, all passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
