### PR TITLE
Reject a Fork destination of a kind that cannot be forked to

### DIFF
--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -240,7 +240,8 @@ static size_t find_in_line(const ryml::Tree& t, size_t line,
 //     `to_line`; the literal `null` instead points into an existing branch and
 //     creates nothing.
 //  3. Names the new branch (after `to_line` for SELF, else after `new_branch`).
-//  4. Creates a fork_pointer in the element pointing at "destination_element" in
+//  4. Checks the destination is a kind that may be forked to.
+//  5. Creates a fork_pointer in the element pointing at "destination_element" in
 //     the destination branch, and resolves ForkP.new_branch to the name of the
 //     branch that was made (or `null` when none was).
 static void handle_fork(ryml::Tree& t, size_t fork_node, size_t branches,
@@ -369,6 +370,28 @@ static void handle_fork(ryml::Tree& t, size_t fork_node, size_t branches,
             add_problem(problems, "Fork element '" + fork_name +
                                       "': destination_element '" + to_element +
                                       "' not found in '" + to_line + "'");
+            return;
+        }
+    }
+
+    // A Fork has zero length and a unit transfer map, so to keep the connection
+    // unambiguous the destination has to be an element with those same
+    // properties: only a Marker, a BeginningEle, or another Fork may be forked
+    // to (lattice-construction.md, s:fork). A bare entry that never resolved
+    // carries no kind to judge, and is reported as a dangling reference in its
+    // own right.
+    if (t.is_map(target)) {
+        std::string dest_kind = child_val_str(t, target, "kind");
+        if (dest_kind != "Marker" && dest_kind != "BeginningEle" &&
+            dest_kind != "Fork") {
+            std::string dest_name(t.key(target).str, t.key(target).len);
+            add_problem(problems,
+                        "Fork element '" + fork_name +
+                            "': destination element '" + dest_name + "' in '" +
+                            to_line + "' has kind '" +
+                            (dest_kind.empty() ? "<none>" : dest_kind) +
+                            "'; a Fork destination must be a Marker, a "
+                            "BeginningEle, or a Fork");
             return;
         }
     }

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -688,6 +688,70 @@ TEST_CASE("new_branch: null forks into an existing branch, creating none",
     rm_tmp(path);
 }
 
+TEST_CASE("a destination of a kind that cannot be forked to is reported",
+          "[lattices][problems]") {
+    // Only a Marker, a BeginningEle, or another Fork may be forked to
+    // (lattice-construction.md, s:fork): the destination has to share the Fork's
+    // zero length and unit transfer map. `dump_line` begins with a Drift, so
+    // both the defaulted destination and one named outright are rejected, and
+    // neither Fork is linked.
+    const char* path = "tmp_fork_bad_kind.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - d1:\n"
+              "        kind: Drift\n"
+              "        length: 1\n"
+              "    - dump_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - d1\n"
+              "    - ring:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - f1:\n"
+              "              kind: Fork\n"
+              "              ForkP:\n"
+              "                to_line: dump_line\n"
+              "          - f2:\n"
+              "              kind: Fork\n"
+              "              ForkP:\n"
+              "                to_line: dump_line\n"
+              "                new_branch: null\n"
+              "                destination_element: d1\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - ring\n"
+              "          - dump_line\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+
+    int reported = 0;
+    for (size_t i = 0; i < lat.problems.count; ++i) {
+        std::string p(lat.problems.items[i]);
+        if (p.find("must be a Marker") != std::string::npos) {
+            REQUIRE(p.find("'d1'") != std::string::npos);
+            REQUIRE(p.find("'Drift'") != std::string::npos);
+            reported++;
+        }
+    }
+    REQUIRE(reported == 2);
+
+    // Neither Fork resolved, so nothing was linked in either direction.
+    REQUIRE(find_by_key(lat.expanded, "fork_pointer") == YAML_NULL_ID);
+    REQUIRE(find_by_key(lat.expanded, "ForkFromP") == YAML_NULL_ID);
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}
+
 TEST_CASE("a fork destination lists its incoming Forks in ForkFromP",
           "[lattices]") {
     // ForkFromP (forkfrom.md, s:fork.from.params) is the reverse link of ForkP:


### PR DESCRIPTION
A `Fork` has zero length and a unit transfer map, so to keep the connection unambiguous the standard restricts what it may point at: only a `Marker`, a `BeginningEle`, or another `Fork` may be forked to (`lattice-construction.md`, s:fork — [pals#272](https://github.com/pals-project/pals/pull/272) drops `FloorShift` from that list).

Nothing enforced it. A Fork onto a `Drift` resolved silently and got a `fork_pointer` and a `ForkFromP` link like any other.

`handle_fork` now checks the destination's kind and reports a problem instead:

```
Fork element 'a_fork': destination element 'dft' in 'a_line' has kind 'Drift';
a Fork destination must be a Marker, a BeginningEle, or a Fork
```

It covers both the destination defaulted to the line's first element and one named outright by `destination_element`. The Fork is left unlinked — no `fork_pointer`, no `ForkFromP` entry — as it already is when `destination_element` names an element that is not in the line. A line entry that never resolved carries no kind to judge and is skipped; it is reported as a dangling reference in its own right.

## Tests

One new case in `tests/test_expansion.cpp` exercising both the defaulted and the explicitly named destination, asserting two problems and that neither link was made. 147/147 ctest pass; the PALSJulia suite passes against the rebuilt library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
