### PR TITLE
Spell-check element kinds and parameter group names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,8 @@ add_library(yaml_c_wrapper SHARED
   src/pals_match.cpp
   src/pals_util.cpp
   src/pals_expression.cpp
-  src/pals_floor.cpp)
+  src/pals_floor.cpp
+  src/pals_check.cpp)
 target_link_libraries(yaml_c_wrapper PUBLIC ryml PRIVATE pcre2-8-static apc)
 
 add_executable(example_rw examples/example_rw.cpp)

--- a/src/pals_check.cpp
+++ b/src/pals_check.cpp
@@ -1,0 +1,213 @@
+#include "pals_check.h"
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "pals_util.h"
+
+namespace {
+
+// Every element kind PALS defines (lattice-element-kinds.md, s:ele.kinds),
+// followed by the kinds that name something other than a lattice element: the
+// two structural kinds (beamlines.md, lattice-construction.md) and the three
+// definition kinds -- `constant` (fundamentals.md, s:constants), and `variable`
+// and `Controller` (pals#240, pals#237).
+const std::set<std::string>& known_kinds() {
+    static const std::set<std::string> k = {
+        "ACKicker",   "BeamBeam",  "BeginningEle",    "Bend",
+        "Converter",  "CrabCavity", "Drift",          "EGun",
+        "Feedback",   "Fiducial",  "FloorShift",      "Foil",
+        "Fork",       "Girder",    "Instrument",      "Kicker",
+        "Marker",     "Mask",      "Match",           "Multipole",
+        "Octupole",   "Patch",     "Placeholder",     "Quadrupole",
+        "ReferenceChange", "RFCavity", "Sextupole",   "Solenoid",
+        "Taylor",     "UnionEle",  "Wiggler",
+        // Not lattice elements:
+        "BeamLine",   "Lattice",   "Controller",      "constant",
+        "variable"};
+    return k;
+}
+
+// Every parameter group PALS defines (lattice-element-parameter-groups.md, and
+// one file each under source/parameters). ForkFromP is pals#272.
+const std::set<std::string>& known_groups() {
+    static const std::set<std::string> g = {
+        "ACKickerP",         "ApertureP",   "BeamBeamP",   "BendP",
+        "BodyShiftP",        "ConverterP",  "ElectricMultipoleP",
+        "FloorP",            "FloorShiftP", "FoilP",       "ForkFromP",
+        "ForkP",             "GirderP",     "MagneticMultipoleP",
+        "MetaP",             "ParticleP",   "PatchP",      "ReferenceChangeP",
+        "ReferenceP",        "RFP",         "SolenoidP",   "TaylorP",
+        "TrackingP",         "TwissP"};
+    return g;
+}
+
+// A parameter group is named in strict CamelCase and ends in `P`; every other
+// key of an element is a plain lower-case parameter (`length`, `s_position`,
+// `to_line`). So a key of this shape that is not a group PALS knows is a group
+// name spelled wrong -- which is the point of the convention.
+//
+// Letters only: a digit or an underscore (`L20_BLW_P`) is a naming style PALS
+// never uses for a group, and marks the key as something outside the standard.
+bool looks_like_group(const std::string& key) {
+    if (key.size() < 2 || key.back() != 'P' || key[0] < 'A' || key[0] > 'Z')
+        return false;
+    for (char c : key)
+        if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'))) return false;
+    return true;
+}
+
+// The names registered under `PALS: extension_labels` (extensions.md,
+// s:extension-syntax). A key or enum value matching one of these introduces
+// extension data, which is outside the standard and so outside these checks.
+struct Extensions {
+    std::set<std::string> names, prefixes, suffixes;
+
+    bool marks(const std::string& s) const {
+        if (names.count(s)) return true;
+        for (const std::string& p : prefixes)
+            if (s.size() >= p.size() && s.compare(0, p.size(), p) == 0)
+                return true;
+        for (const std::string& x : suffixes)
+            if (s.size() >= x.size() &&
+                s.compare(s.size() - x.size(), x.size(), x) == 0)
+                return true;
+        return false;
+    }
+};
+
+void collect_label_keys(const ryml::Tree& t, size_t parent, const char* key,
+                        std::set<std::string>& out) {
+    size_t m = t.find_child(parent, ryml::to_csubstr(key));
+    if (m == ryml::NONE || !t.is_map(m)) return;
+    for (size_t c = t.first_child(m); c != ryml::NONE; c = t.next_sibling(c))
+        if (t.has_key(c)) out.insert(std::string(t.key(c).str, t.key(c).len));
+}
+
+Extensions collect_extensions(const ryml::Tree& t) {
+    Extensions ext;
+    // `extension_labels` must be a child of the `PALS` root node.
+    size_t pals = t.find_child(t.root_id(), ryml::to_csubstr("PALS"));
+    if (pals == ryml::NONE || !t.is_map(pals)) return ext;
+    size_t labels = t.find_child(pals, ryml::to_csubstr("extension_labels"));
+    if (labels == ryml::NONE || !t.is_map(labels)) return ext;
+    collect_label_keys(t, labels, "names", ext.names);
+    collect_label_keys(t, labels, "prefixes", ext.prefixes);
+    collect_label_keys(t, labels, "suffixes", ext.suffixes);
+    return ext;
+}
+
+// Levenshtein distance, abandoned once every cell of a row exceeds `cap`. Only
+// small distances are of interest, so the cap keeps a comparison against a long
+// unrelated name cheap.
+int edit_distance(const std::string& a, const std::string& b, int cap) {
+    std::vector<int> prev(b.size() + 1), cur(b.size() + 1);
+    for (size_t j = 0; j <= b.size(); ++j) prev[j] = static_cast<int>(j);
+    for (size_t i = 1; i <= a.size(); ++i) {
+        cur[0] = static_cast<int>(i);
+        int row_min = cur[0];
+        for (size_t j = 1; j <= b.size(); ++j) {
+            int sub = prev[j - 1] + (a[i - 1] == b[j - 1] ? 0 : 1);
+            cur[j] = std::min(sub, std::min(prev[j] + 1, cur[j - 1] + 1));
+            row_min = std::min(row_min, cur[j]);
+        }
+        if (row_min > cap) return cap + 1;
+        prev.swap(cur);
+    }
+    return prev[b.size()];
+}
+
+std::string lowered(const std::string& s) {
+    std::string out = s;
+    for (char& c : out)
+        if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
+    return out;
+}
+
+// The known name `bad` was most likely meant to be, or "" if nothing is close.
+// A name that differs only in case is the answer outright -- `marker` for
+// `Marker` -- since that is the mistake the CamelCase convention invites.
+std::string suggest(const std::string& bad, const std::set<std::string>& known) {
+    std::string low = lowered(bad);
+    for (const std::string& k : known)
+        if (lowered(k) == low) return k;
+
+    // Otherwise the nearest name within a couple of edits, and never more than
+    // a third of the name's length, so short names are not matched to anything
+    // and everything.
+    int cap = std::min(2, std::max(1, static_cast<int>(bad.size()) / 3));
+    std::string best;
+    int best_d = cap + 1;
+    for (const std::string& k : known) {
+        int d = edit_distance(low, lowered(k), cap);
+        if (d < best_d) {
+            best_d = d;
+            best = k;
+        } else if (d == best_d) {
+            best.clear();  // ambiguous: offer nothing rather than a coin toss
+        }
+    }
+    return best_d <= cap ? best : std::string();
+}
+
+// Append a problem, skipping exact duplicates (mirrors expansion's add_problem).
+void add(std::vector<std::string>& problems, const std::string& msg) {
+    for (const std::string& p : problems)
+        if (p == msg) return;
+    problems.push_back(msg);
+}
+
+// "element 'q1': " when the map is keyed, "" when it is not.
+std::string where(const ryml::Tree& t, size_t node) {
+    if (!t.has_key(node)) return "";
+    return "element '" + std::string(t.key(node).str, t.key(node).len) + "': ";
+}
+
+void report(std::vector<std::string>& problems, const ryml::Tree& t,
+            size_t node, const std::string& what, const std::string& bad,
+            const std::set<std::string>& known) {
+    std::string msg = where(t, node) + "unknown " + what + " '" + bad + "'";
+    std::string fix = suggest(bad, known);
+    if (!fix.empty()) msg += "; did you mean '" + fix + "'?";
+    add(problems, msg);
+}
+
+void walk(const ryml::Tree& t, size_t node, const Extensions& ext,
+          std::vector<std::string>& problems) {
+    if (node == ryml::NONE) return;
+
+    if (t.is_map(node)) {
+        // An `extension` key hands the rest of this dictionary to an extension
+        // schema, which PALS explicitly does not validate.
+        if (t.find_child(node, ryml::to_csubstr("extension")) != ryml::NONE)
+            return;
+
+        size_t kind = t.find_child(node, ryml::to_csubstr("kind"));
+        if (kind != ryml::NONE && t.has_val(kind)) {
+            std::string v(t.val(kind).str, t.val(kind).len);
+            if (!v.empty() && !known_kinds().count(v) && !ext.marks(v))
+                report(problems, t, node, "kind", v, known_kinds());
+        }
+    }
+
+    for (size_t c = t.first_child(node); c != ryml::NONE;
+         c = t.next_sibling(c)) {
+        if (t.has_key(c)) {
+            std::string k(t.key(c).str, t.key(c).len);
+            if (ext.marks(k)) continue;  // registered extension data
+            if (k == "extension_labels") continue;
+            if (looks_like_group(k) && !known_groups().count(k))
+                report(problems, t, node, "parameter group", k,
+                       known_groups());
+        }
+        walk(t, c, ext, problems);
+    }
+}
+
+}  // namespace
+
+void check_pals_names(const ryml::Tree& t, std::vector<std::string>& problems) {
+    walk(t, t.root_id(), collect_extensions(t), problems);
+}

--- a/src/pals_check.h
+++ b/src/pals_check.h
@@ -1,0 +1,22 @@
+#ifndef PALS_CHECK_H
+#define PALS_CHECK_H
+
+// Spelling checks against the fixed vocabulary PALS defines: element kinds and
+// parameter group names. A misspelling is not a structural error -- a `FlorP`
+// group or a `kind: marker` parses as valid YAML and simply goes unrecognised
+// later -- so it is caught here and reported rather than silently ignored.
+// Not part of the public C API declared in yaml_c_wrapper.h.
+
+#include <string>
+#include <vector>
+
+#include <ryml.hpp>
+
+// Check every `kind` value and every parameter group name in `t`, appending one
+// message per unrecognised name to `problems` (with a "did you mean" suggestion
+// where a near match exists). Extension data, which is outside the standard by
+// definition, is skipped: a dictionary holding an `extension` key, and any name
+// registered under `PALS: extension_labels`.
+void check_pals_names(const ryml::Tree& t, std::vector<std::string>& problems);
+
+#endif  // PALS_CHECK_H

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -9,6 +9,7 @@
 #include "yaml_tree.h"
 #include "pals_util.h"
 #include "pals_floor.h"
+#include "pals_check.h"
 
 #include "apc/apc.h"
 
@@ -2513,6 +2514,13 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
     } else {
         lat.combined = make_combined_from_original(
             static_cast<ParsedData*>(lat.original), filename);
+
+        // Spell-check against combined, not expanded: every definition appears
+        // there exactly once, as written, so each misspelling is reported once
+        // and names the element the user typed rather than one of the copies
+        // expansion made of it.
+        check_pals_names(GET_TREE(lat.combined), problems);
+
         make_expanded_and_leftover(static_cast<ParsedData*>(lat.combined),
                                    root_lattice, problems, lat.expanded,
                                    lat.leftover);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(tests
   test_multipass.cpp
   test_controllers.cpp
   test_bookkeeper.cpp
+  test_check.cpp
   test_floor.cpp
   # pals_floor.cpp carries hidden visibility in the shared library, so its
   # geometry symbols are compiled directly into the tests for test_floor.cpp.

--- a/tests/test_check.cpp
+++ b/tests/test_check.cpp
@@ -1,0 +1,160 @@
+#include "test_helpers.h"
+
+// ============================================================
+// Spelling checks against the PALS vocabulary (src/pals_check.cpp)
+// ============================================================
+
+namespace {
+
+// Every problem reported for `yaml`, so a test can assert on the whole set.
+std::vector<std::string> problems_for(const char* path, const char* yaml) {
+    write_tmp(path, yaml);
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    std::vector<std::string> out;
+    for (size_t i = 0; i < lat.problems.count; ++i)
+        out.push_back(lat.problems.items[i]);
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+    return out;
+}
+
+bool has(const std::vector<std::string>& ps, const char* needle) {
+    for (const std::string& p : ps)
+        if (p.find(needle) != std::string::npos) return true;
+    return false;
+}
+
+int count_with(const std::vector<std::string>& ps, const char* needle) {
+    int n = 0;
+    for (const std::string& p : ps)
+        if (p.find(needle) != std::string::npos) n++;
+    return n;
+}
+
+}  // namespace
+
+TEST_CASE("a misspelled element kind is reported with a suggestion",
+          "[check][problems]") {
+    // `marker` parses as perfectly good YAML and would simply go unrecognised
+    // downstream, so the mistake has to be caught by name. Case is the mistake
+    // the CamelCase convention invites, so a name that differs only in case is
+    // suggested outright.
+    auto ps = problems_for("tmp_check_kind.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - m:\n"
+                           "        kind: marker\n"
+                           "    - q1:\n"
+                           "        kind: Quadrapole\n"
+                           "        length: 1\n");
+
+    REQUIRE(has(ps, "element 'm': unknown kind 'marker'; did you mean 'Marker'?"));
+    REQUIRE(has(ps,
+                "element 'q1': unknown kind 'Quadrapole'; did you mean "
+                "'Quadrupole'?"));
+}
+
+TEST_CASE("a misspelled parameter group is reported with a suggestion",
+          "[check][problems]") {
+    // A group is the one part of an element written in CamelCase ending in `P`,
+    // so a key of that shape that PALS does not define is a group name spelled
+    // wrong. Plain lower-case parameters are not checked -- they are not drawn
+    // from a fixed vocabulary.
+    auto ps = problems_for("tmp_check_group.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - q1:\n"
+                           "        kind: Quadrupole\n"
+                           "        length: 1\n"
+                           "        FlorP:\n"
+                           "          r: [0, 0, 0]\n"
+                           "        Refereence:\n"
+                           "          species_ref: electron\n"
+                           "        L20_BLW_P:\n"
+                           "          gain: 1\n");
+
+    REQUIRE(has(ps,
+                "element 'q1': unknown parameter group 'FlorP'; did you mean "
+                "'FloorP'?"));
+    // `Refereence` does not end in `P`, so it is not taken for a group at all.
+    REQUIRE(!has(ps, "Refereence"));
+    // Nor is `L20_BLW_P`: PALS never digits or underscores a group name, so the
+    // shape says "outside the standard" rather than "misspelled".
+    REQUIRE(!has(ps, "L20_BLW_P"));
+}
+
+TEST_CASE("correctly spelled kinds and groups are not reported",
+          "[check][problems]") {
+    auto ps = problems_for("tmp_check_clean.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - b1:\n"
+                           "        kind: Bend\n"
+                           "        length: 1\n"
+                           "        ApertureP:\n"
+                           "          x_limit: [-0.1, 0.1]\n"
+                           "        BodyShiftP:\n"
+                           "          x_offset: 0.001\n"
+                           "        MagneticMultipoleP:\n"
+                           "          - order: 0\n"
+                           "            Kn: 0.1\n"
+                           "    - my_const:\n"
+                           "        kind: constant\n"
+                           "        value: 3\n");
+
+    REQUIRE(count_with(ps, "unknown kind") == 0);
+    REQUIRE(count_with(ps, "unknown parameter group") == 0);
+}
+
+TEST_CASE("extension data is exempt from the spelling checks",
+          "[check][problems]") {
+    // Two ways to mark extension data (extensions.md, s:extension-syntax): an
+    // `extension` key, which hands the rest of that dictionary to an extension
+    // schema, and a name registered under `PALS: extension_labels`, which may be
+    // matched in full, by prefix, or by suffix. Neither is PALS' to validate,
+    // and an extension name may be used as an enum value -- `kind: Rotator`.
+    auto ps = problems_for("tmp_check_ext.pals.yaml",
+                           "PALS:\n"
+                           "  extension_labels:\n"
+                           "    names:\n"
+                           "      Rotator: a new kind of element\n"
+                           "    prefixes:\n"
+                           "      SciBmad_: for the SciBmad ecosystem\n"
+                           "    suffixes:\n"
+                           "      _local: site-local data\n"
+                           "  facility:\n"
+                           "    - r23:\n"
+                           "        kind: Rotator\n"
+                           "    - q1:\n"
+                           "        kind: Quadrupole\n"
+                           "        length: 1\n"
+                           "        SciBmad_connect:\n"
+                           "          BogusP: anything at all\n"
+                           "        tuning_local:\n"
+                           "          AlsoBogusP: and here too\n"
+                           "    - synch_connect:\n"
+                           "        extension: Cornell_CESR_Connect\n"
+                           "        NotAGroupP: alarm system stuff\n");
+
+    REQUIRE(count_with(ps, "unknown kind") == 0);
+    REQUIRE(count_with(ps, "unknown parameter group") == 0);
+}
+
+TEST_CASE("an unrecognisable name is reported without a guess",
+          "[check][problems]") {
+    // A suggestion is offered only when something is genuinely close; a name
+    // that resembles nothing is reported on its own rather than paired with the
+    // nearest string in the table.
+    auto ps = problems_for("tmp_check_wild.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - x1:\n"
+                           "        kind: Zzzyzx\n");
+
+    REQUIRE(has(ps, "element 'x1': unknown kind 'Zzzyzx'"));
+    REQUIRE(!has(ps, "'Zzzyzx'; did you mean"));
+}


### PR DESCRIPTION
A misspelling in a name PALS draws from a fixed vocabulary is invisible: `kind: marker` and a `FlorP` group are valid YAML and simply go unrecognised downstream, so the lattice quietly comes out wrong. Both are now checked and reported.

```
element 'm': unknown kind 'marker'; did you mean 'Marker'?
element 'q1': unknown parameter group 'FlorP'; did you mean 'FloorP'?
element 'x1': unknown kind 'Zzzyzx'
```

## What is checked

New `src/pals_check.cpp` holds the two tables and walks the **combined** tree — where each definition appears exactly once as written, so a mistake is reported once, against the name the user typed rather than a copy expansion made of it.

- **Kinds**: the 31 element kinds of `lattice-element-kinds.md`, plus `BeamLine` and `Lattice`, plus the definition kinds `constant` (`fundamentals.md`), `variable` ([pals#240](https://github.com/pals-project/pals/pull/240)) and `Controller` ([pals#237](https://github.com/pals-project/pals/pull/237)).
- **Groups**: the 23 groups under `source/parameters`, plus `ForkFromP` ([pals#272](https://github.com/pals-project/pals/pull/272)).

Group names are recognised by shape — strict CamelCase ending in `P`, the one part of an element written that way. Letters only, so a vendor name like `L20_BLW_P` reads as outside the standard rather than misspelled. Plain lower-case parameters (`length`, `to_line`) are not checked; they are not drawn from a fixed vocabulary.

## Suggestions

A name differing only in case wins outright — that is the mistake the CamelCase convention invites. Otherwise the nearest name within a couple of edits (and never more than a third of the name's length), and nothing at all when two candidates are equally close.

## Extensions

Exempt, as the standard requires (`extensions.md`, s:extension-syntax): a dictionary holding an `extension` key, and any name registered under `PALS: extension_labels` — matched in full, by prefix, or by suffix — including one used as an enum value such as `kind: Rotator`.

## What it finds in this repo's own lattice files

Not fixed here, since they are inputs rather than code:

| File | Finding |
| --- | --- |
| `bta.pals.yaml` | `kind: SBend` ×2 (Bmad's name for `Bend`); `BmadP` ×3 |
| `convert.pals.yaml` | `kind: Aperture` ×2; `kind: SBend` |
| `include.pals.yaml` | `kind: SBend`; `kind: Beamline`; `BmadP` |

The `BmadP` groups are genuine extension data and would go quiet once registered under `extension_labels`. `Beamline` also appears as a typo in the standard, at `lattice-construction.md:198`.

## Tests

New `tests/test_check.cpp`: five cases covering a misspelled kind, a misspelled group, a clean file reporting nothing, extension exemption in all four forms, and a name too far gone to guess at. 152/152 ctest pass; the PALSJulia suite passes against the rebuilt library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
