### PR TITLE
Keep the expression pass off fork_pointer

### DIFF
--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -974,12 +974,20 @@ static size_t find_lattice(ryml::Tree& t, const std::string& name) {
 // Keys whose scalar values are names/flags, never expressions. Skipping them
 // avoids a stray collision between such a name and a constant (e.g. an element
 // literally named `pi`).
+//
+// `fork_pointer` is here for a different reason: it is a node id, and a node id
+// is a number, so evaluating it "succeeds" and rewrites it through
+// format_double. That is lossless as a number but not as text -- an id of 110
+// comes back as `1.1e+02`, the shortest round-tripping form -- and every reader
+// of the pointer parses it with std::stoull, which stops at the `.` and yields
+// 1. See handle_fork.
 static const std::set<std::string>& non_expr_keys() {
     static const std::set<std::string> keys = {
         "kind",       "include",     "use",
         "inherit",    "zero_point",  "to_line",
         "destination_element", "new_branch", "multipass",
-        "propagate_reference", "name", "multipass_index"};
+        "propagate_reference", "name", "multipass_index",
+        "fork_pointer"};
     return keys;
 }
 

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -903,6 +903,132 @@ TEST_CASE("a Fork inside a forked-to branch resolves exactly once",
     rm_tmp(path);
 }
 
+// Every node keyed `key` in the tree, in walk order.
+static std::vector<std::string> all_values_for(YAMLTreeHandle t,
+                                               const char* key) {
+    std::vector<std::string> out;
+    std::vector<YAMLNodeId> stack{get_root(t)};
+    while (!stack.empty()) {
+        YAMLNodeId n = stack.back();
+        stack.pop_back();
+        char* k = get_node_key(t, n);
+        bool hit = k && std::string(k) == key;
+        yaml_free_string(k);
+        if (hit) {
+            char* v = as_string(t, n);
+            out.push_back(v ? std::string(v) : std::string());
+            yaml_free_string(v);
+        }
+        for (size_t i = 0; i < get_size(t, n); i++)
+            stack.push_back(get_child_by_index(t, n, i));
+    }
+    return out;
+}
+
+TEST_CASE("a fork_pointer survives expression substitution intact",
+          "[lattices][problems]") {
+    // A fork_pointer holds a node id, which is a number, so the expression pass
+    // used to "evaluate" it and write the result back through format_double --
+    // the shortest text that round-trips as a double. For most ids that is the
+    // digits themselves, but an id of 110 comes back as `1.1e+02`, and every
+    // reader parses the pointer with std::stoull, which stops at the `.` and
+    // yields 1. That silently cost the fork its ForkFromP entry and its
+    // reference propagation, and left remap_fork_pointers reporting the target
+    // as outside the lattice. non_expr_keys() now skips the key.
+    //
+    // Only a minority of ids format that way -- a multiple of 10 from 100 up --
+    // so the three unused `pad` Drifts below are there to shift the work-tree
+    // ids until two of the five destinations land in that range. Without them
+    // every pointer happens to come out in plain digits and the bug hides. The
+    // assertions hold whatever the ids turn out to be; they simply stop
+    // exercising this if an unrelated change shifts the ids again.
+    const char* path = "tmp_fork_pointer_fmt.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - begin1:\n"
+              "        kind: BeginningEle\n"
+              "        ReferenceP:\n"
+              "          species_ref: \"electron\"\n"
+              "          E_tot_ref: 1e7\n"
+              "    - m:\n"
+              "        kind: Marker\n"
+              "    - dft:\n"
+              "        kind: Drift\n"
+              "        length: 2\n"
+              "    - pad1:\n"
+              "        kind: Drift\n"
+              "        length: 1\n"
+              "    - pad2:\n"
+              "        kind: Drift\n"
+              "        length: 1\n"
+              "    - pad3:\n"
+              "        kind: Drift\n"
+              "        length: 1\n"
+              "    - a_fork:\n"
+              "        kind: Fork\n"
+              "        ForkP:\n"
+              "          to_line: a_line\n"
+              "    - b_fork:\n"
+              "        kind: Fork\n"
+              "        ForkP:\n"
+              "          to_line: b_line\n"
+              "    - c_fork:\n"
+              "        kind: Fork\n"
+              "        ForkP:\n"
+              "          to_line: c_line\n"
+              "    - a_back_fork:\n"
+              "        kind: Fork\n"
+              "        ForkP:\n"
+              "          to_line: a_line\n"
+              "    - zero_line:\n"
+              "        kind: BeamLine\n"
+              "        line: [begin1, dft, a_fork]\n"
+              "    - one_line:\n"
+              "        kind: BeamLine\n"
+              "        line: [begin1, dft, c_fork]\n"
+              "    - a_line:\n"
+              "        kind: BeamLine\n"
+              "        line: [m, dft, b_fork]\n"
+              "    - b_line:\n"
+              "        kind: BeamLine\n"
+              "        line: [m, dft]\n"
+              "    - c_line:\n"
+              "        kind: BeamLine\n"
+              "        line: [m, dft, a_back_fork]\n"
+              "    - root_lat:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - zero_line\n"
+              "          - one_line\n"
+              "    - use: \"root_lat\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.problems.count == 0);
+
+    // Five Forks resolve: two chains of three (zero_line -> a_line -> b_line,
+    // one_line -> c_line -> a_line -> b_line), sharing no branch instances.
+    std::vector<std::string> ptrs = all_values_for(lat.expanded, "fork_pointer");
+    REQUIRE(ptrs.size() == 5);
+    for (const std::string& p : ptrs) {
+        INFO("fork_pointer: " << p);
+        REQUIRE(!p.empty());
+        REQUIRE(p.find_first_not_of("0123456789") == std::string::npos);
+    }
+
+    // Each of those Forks reaches its destination, so each destination carries
+    // the reverse link. A misparsed pointer drops the entry without a word.
+    REQUIRE(all_values_for(lat.expanded, "ForkFromP").size() == 5);
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}
+
 TEST_CASE("new_branch: null with a to_line that is not a branch is reported",
           "[lattices][problems]") {
     // `null` requires `to_line` to name an existing branch. A bare BeamLine


### PR DESCRIPTION
A `fork_pointer` holds a node id, and a node id is a number, so `substitute_values` — the pass that replaces every evaluable scalar with its value — "evaluated" it too and wrote the result back through `format_double`, the shortest text that round-trips as a double:

```
110  →  "%.1g" = 1e+02   → 100 ≠ 110
        "%.2g" = 1.1e+02 → 110 ✓   so the pointer became "1.1e+02"
291  →  "%.3g" = 291                stayed "291"
```

which is why only some pointers looked wrong: an id has to be a multiple of ten from 100 up to reach exponent form. The value is still numerically right — but every reader parses it with `std::stoull`, which stops at the `.` and returns **1**.

### Three readers, three failures, one message

| Reader | Effect of `stoull("1.1e+02") == 1` |
| --- | --- |
| `run_element_bookkeeper` | `fork_seed[1] = def` — the destination branch inherits no reference or floor from the Fork |
| `link_fork_from` | node 1 is not a map, so `continue` — the destination silently loses its `ForkFromP` entry |
| `remap_fork_pointers` | 1 is not in the provenance map — the one visible symptom, `fork_pointer target is outside the expanded lattice` |

### The fix

Add `fork_pointer` to `non_expr_keys()`. Its siblings `to_line`, `destination_element`, `new_branch` and `propagate_reference` were already there; this one was missed because expansion creates it rather than the user writing it, so it never looked like a value the expression pass would see. A node id is not a physics parameter and has no business going through the evaluator — a better place to fix this than making three call sites parse defensively.

### The regression test

It reproduces a chained-and-cross-linked fork lattice and asserts no problems, five all-digit pointers, and five `ForkFromP` groups.

The first version of it passed with the fix reverted: every id happened to land outside the exponent-form range. It now carries three unused `pad` Drifts that shift the work-tree ids until two of the five destinations land in it. Verified both ways — fails with the fix reverted (`lat.problems.count == 0` reports 1), passes with it in. The assertions hold whatever the ids turn out to be; they just stop exercising this particular bug if an unrelated change shifts them again, which the comment says.

153/153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
