### PR TITLE
Check parameter names, and the groups a kind may carry

### DIFF
--- a/src/pals_check.cpp
+++ b/src/pals_check.cpp
@@ -1,6 +1,7 @@
 #include "pals_check.h"
 
 #include <algorithm>
+#include <map>
 #include <set>
 #include <string>
 #include <vector>
@@ -42,6 +43,235 @@ const std::set<std::string>& known_groups() {
         "ReferenceP",        "RFP",         "SolenoidP",   "TaylorP",
         "TrackingP",         "TwissP"};
     return g;
+}
+
+// The components of each parameter group, from its section under
+// source/parameters. A group absent from this table is one whose contents are
+// not a fixed vocabulary (see open_groups) or whose names are generated rather
+// than listed (see is_multipole_param).
+const std::map<std::string, std::set<std::string>>& group_params() {
+    static const std::map<std::string, std::set<std::string>> p = {
+        {"ApertureP",
+         {"x_min", "x_max", "x_center", "x_width", "y_min", "y_max", "y_center",
+          "y_width", "shape", "location", "vertices", "material", "thickness",
+          "aperture_shifts_with_body", "aperture_active"}},
+        {"BeamBeamP",
+         {"sigma_x", "sigma_y", "sigma_z", "alpha_x", "beta_x", "alpha_y",
+          "beta_y", "charge", "energy", "N_particle"}},
+        {"BendP",
+         {"angle_ref", "bend_field_ref", "bend_field_actual", "e1", "e2",
+          "e1_rect", "e2_rect", "edge1_int", "edge2_int", "g_ref", "g_actual",
+          "h1", "h2", "L_chord", "L_sagitta", "L_rectangle",
+          "multipole_geometry", "ref_geometry", "rho_ref", "tilt_ref"}},
+        {"BodyShiftP",
+         {"x_offset", "y_offset", "z_offset", "x_rot", "y_rot", "z_rot"}},
+        {"ConverterP", {"species_out", "E_tot_ref_out"}},
+        {"FloorP", {"x", "y", "z", "theta", "phi", "psi", "user_set"}},
+        {"FloorShiftP",
+         {"x_offset", "y_offset", "z_offset", "t_offset", "x_rot", "y_rot",
+          "z_rot"}},
+        {"FoilP", {"dE_ref"}},
+        {"ForkP",
+         {"to_line", "destination_element", "direction", "new_branch",
+          "propagate_reference"}},
+        {"ParticleP",
+         {"x",           "px",          "y",          "py",
+          "z",           "pz",          "spin_x",     "spin_y",
+          "spin_z",      "sigma_xx",    "sigma_xpx",  "sigma_xy",
+          "sigma_xpy",   "sigma_xz",    "sigma_xpz",  "sigma_pxpx",
+          "sigma_pxy",   "sigma_pxpy",  "sigma_pxz",  "sigma_pxpz",
+          "sigma_yy",    "sigma_ypy",   "sigma_yz",   "sigma_ypz",
+          "sigma_pypy",  "sigma_pyz",   "sigma_pypz", "sigma_zz",
+          "sigma_zpz",   "sigma_pzpz"}},
+        {"PatchP",
+         {"x_offset", "y_offset", "z_offset", "x_rot", "y_rot", "z_rot",
+          "flexible", "ref_coords", "user_sets_length"}},
+        {"ReferenceChangeP",
+         {"dtime_ref", "dE_ref", "dpc_ref", "time_ref", "E_tot_ref", "pc_ref",
+          "species_ref"}},
+        {"ReferenceP", {"species_ref", "pc_ref", "E_tot_ref", "time_ref"}},
+        {"RFP",
+         {"frequency", "harmon", "voltage", "gradient", "phase",
+          "multipass_phase", "cavity_type", "num_cells", "zero_phase",
+          "L_active", "dE_ref"}},
+        {"SolenoidP", {"Ksol", "Bsol"}},
+        {"TaylorP",
+         {"x_out", "px_out", "y_out", "py_out", "z_out", "pz_out", "S_q1_out",
+          "S_qx_out", "S_qy_out", "S_qz_out", "ref_in"}},
+        {"TwissP",
+         {"alpha_a", "alpha_b", "beta_a", "beta_b", "cmat11", "cmat12",
+          "cmat21", "cmat22", "eta_x", "eta_y", "etap_x", "etap_y",
+          "deta_x_ds", "deta_y_ds", "phi_a", "phi_b"}}};
+    return p;
+}
+
+// The parameter groups each element kind may carry, from the "Element parameter
+// groups associated with this element kind are" list in its section of
+// lattice-element-kinds.md.
+//
+// A kind absent from this table is one nothing is documented for, and so is not
+// checked: `Feedback`, `Fiducial` and `Girder` are still "Under Construction",
+// and `BeamLine`, `Lattice`, `Controller`, `constant` and `variable` are not
+// lattice elements at all. `Placeholder` is present with an empty list on
+// purpose -- its section says it has no associated parameter groups.
+const std::map<std::string, std::set<std::string>>& kind_groups() {
+    // Carried by every physical element.
+    static const std::set<std::string> common = {
+        "ApertureP", "BodyShiftP", "FloorP", "MetaP", "ReferenceP",
+        "TrackingP"};
+    // The above plus multipoles, which is the list most magnets have.
+    static const std::set<std::string> magnet = [] {
+        std::set<std::string> s = common;
+        s.insert({"ElectricMultipoleP", "MagneticMultipoleP"});
+        return s;
+    }();
+    auto with = [](std::set<std::string> base,
+                   std::initializer_list<const char*> extra) {
+        for (const char* e : extra) base.insert(e);
+        return base;
+    };
+
+    static const std::map<std::string, std::set<std::string>> g = {
+        {"ACKicker", with(common, {"ACKickerP"})},
+        {"BeamBeam", with(common, {"BeamBeamP"})},
+        // TwissP and ParticleP are not in the BeginningEle list in
+        // lattice-element-kinds.md yet; they are being added there. Both state
+        // the initial conditions of a branch -- twiss.md says as much -- and
+        // the beginning element is where a branch states them, which is why no
+        // other kind's list mentions either group. ForkFromP is the reverse
+        // fork link (pals#272), which the parser writes onto the three kinds a
+        // Fork may point at.
+        {"BeginningEle", with(common, {"TwissP", "ParticleP", "ForkFromP"})},
+        {"Bend", with(magnet, {"BendP"})},
+        {"Converter", with(magnet, {"ConverterP"})},
+        {"CrabCavity", magnet},
+        {"Drift", common},
+        {"EGun", magnet},
+        {"FloorShift", {"FloorShiftP", "MetaP", "ReferenceP"}},
+        {"Foil", with(common, {"FoilP"})},
+        {"Fork", with(common, {"ForkP", "ForkFromP"})},
+        {"Instrument", magnet},
+        {"Kicker", magnet},
+        // ApertureP is not in the Marker list in lattice-element-kinds.md yet;
+        // it is being added there. A Marker often stands in for a beam position
+        // monitor, which has an aperture like any other physical element.
+        {"Marker",
+         {"ApertureP", "BodyShiftP", "FloorP", "MetaP", "ReferenceP",
+          "ForkFromP"}},
+        {"Mask", magnet},
+        {"Match", common},
+        {"Multipole", magnet},
+        {"Octupole", magnet},
+        {"Patch", with(common, {"PatchP"})},
+        {"Placeholder", {}},
+        {"Quadrupole", magnet},
+        {"ReferenceChange",
+         {"FloorP", "MetaP", "ReferenceChangeP", "ReferenceP", "TrackingP"}},
+        {"RFCavity", with(magnet, {"RFP", "SolenoidP"})},
+        {"Sextupole", magnet},
+        {"Solenoid", with(magnet, {"SolenoidP"})},
+        {"Taylor", with(common, {"TaylorP"})},
+        {"UnionEle", common},
+        {"Wiggler", magnet}};
+    return g;
+}
+
+// Groups whose contents are deliberately not a closed vocabulary, so their
+// entries are left alone:
+//  - MetaP may hold arbitrary metadata beyond its six components (meta.md).
+//  - TrackingP is program-specific by design (tracking.md).
+//  - ACKickerP and GirderP are "In Construction" -- nothing to check against.
+//  - ForkFromP is built by the parser, keyed `{branch}>>{element}` (pals#272).
+const std::set<std::string>& open_groups() {
+    static const std::set<std::string> g = {"MetaP", "TrackingP", "ACKickerP",
+                                            "GirderP", "ForkFromP"};
+    return g;
+}
+
+// Keys any parameter group may carry: a group defined outside an element is
+// given a `kind` naming the group and may be given a `name`, and any group may
+// pull its values from another with `inherit` (lattice-element-parameters.md,
+// s:inherit.params).
+bool is_group_meta_key(const std::string& key) {
+    return key == "inherit" || key == "name" || key == "kind";
+}
+
+// True if `key` names a multipole component of `group`. These names are
+// generated from the multipole order rather than listed: a field component is
+// `Bn`/`Bs`/`Kn`/`Ks` (magnetic) or `En`/`Es` (electric) followed by the order,
+// optionally `L` for the length-integrated form and `_taper` for the tapering
+// parameter that goes with it; the tilt of an order is `tilt` followed by the
+// order (magneticmultipole.md, electricmultipole.md).
+bool is_multipole_param(const std::string& group, const std::string& key) {
+    static const std::set<std::string> magnetic = {"Bn", "Bs", "Kn", "Ks"};
+    static const std::set<std::string> electric = {"En", "Es"};
+    const std::set<std::string>& field =
+        group == "MagneticMultipoleP" ? magnetic : electric;
+
+    // `geometry` selects how the multipoles of a bend are evaluated.
+    if (key == "geometry") return true;
+
+    std::string s = key;
+    // `_taper` names the tapering parameter of the field parameter it follows.
+    const std::string taper = "_taper";
+    if (s.size() > taper.size() &&
+        s.compare(s.size() - taper.size(), taper.size(), taper) == 0)
+        s.resize(s.size() - taper.size());
+    // The length-integrated form appends `L`.
+    if (s.size() > 1 && s.back() == 'L') s.pop_back();
+
+    std::string stem;
+    if (s.compare(0, 4, "tilt") == 0 && s.size() > 4) {
+        // Tilt has neither an integrated nor a tapering form, so the trimming
+        // above must not have fired.
+        if (s != key) return false;
+        stem = "tilt";
+    } else if (s.size() > 2 && field.count(s.substr(0, 2))) {
+        stem = s.substr(0, 2);
+    } else {
+        return false;
+    }
+    // Whatever follows the stem is the order, and must be a number.
+    for (size_t i = stem.size(); i < s.size(); ++i)
+        if (s[i] < '0' || s[i] > '9') return false;
+    return s.size() > stem.size();
+}
+
+// The parameters an element of `kind` may carry outside any parameter group:
+// the six that fit no group (lattice-element-parameters.md, s:non.params),
+// `inherit` and the line-item modifiers usable on an element defined in place,
+// and then whatever the kind itself is built from.
+const std::set<std::string>& element_params(const std::string& kind) {
+    static const std::set<std::string> base = {
+        "field_master", "is_on",  "kind",      "length",
+        "name",         "s_position", "inherit", "direction",
+        "multipass_index"};
+    static const std::set<std::string> beamline = [] {
+        std::set<std::string> s = base;
+        s.insert({"line", "multipass", "zero_point", "repeat"});
+        return s;
+    }();
+    static const std::set<std::string> lattice = [] {
+        std::set<std::string> s = base;
+        s.insert("branches");
+        return s;
+    }();
+    static const std::set<std::string> controller = [] {
+        std::set<std::string> s = base;
+        s.insert({"control_type", "variables", "controls"});
+        return s;
+    }();
+    static const std::set<std::string> definition = [] {
+        std::set<std::string> s = base;
+        s.insert("value");
+        return s;
+    }();
+
+    if (kind == "BeamLine") return beamline;
+    if (kind == "Lattice") return lattice;
+    if (kind == "Controller") return controller;
+    if (kind == "constant" || kind == "variable") return definition;
+    return base;
 }
 
 // A parameter group is named in strict CamelCase and ends in `P`; every other
@@ -159,25 +389,98 @@ void add(std::vector<std::string>& problems, const std::string& msg) {
     problems.push_back(msg);
 }
 
-// "element 'q1': " when the map is keyed, "" when it is not.
-std::string where(const ryml::Tree& t, size_t node) {
-    if (!t.has_key(node)) return "";
-    return "element '" + std::string(t.key(node).str, t.key(node).len) + "': ";
+// "element 'q1': " when the map is keyed, "" when it is not. `group` names the
+// parameter group being looked at, and is empty at element level:
+// "element 'q1' ForkP: ".
+std::string where(const ryml::Tree& t, size_t node, const std::string& group) {
+    std::string s;
+    if (t.has_key(node))
+        s = "element '" + std::string(t.key(node).str, t.key(node).len) + "'";
+    if (!group.empty()) s += (s.empty() ? "" : " ") + group;
+    return s.empty() ? "" : s + ": ";
 }
 
 void report(std::vector<std::string>& problems, const ryml::Tree& t,
-            size_t node, const std::string& what, const std::string& bad,
-            const std::set<std::string>& known) {
-    std::string msg = where(t, node) + "unknown " + what + " '" + bad + "'";
+            size_t node, const std::string& group, const std::string& what,
+            const std::string& bad, const std::set<std::string>& known) {
+    std::string msg =
+        where(t, node, group) + "unknown " + what + " '" + bad + "'";
     std::string fix = suggest(bad, known);
     if (!fix.empty()) msg += "; did you mean '" + fix + "'?";
     add(problems, msg);
+}
+
+// Check the entries of one parameter group. `owner` is the element the group
+// hangs off (or the group's own definition when it stands alone), used only to
+// name the group in the message.
+void check_group(const ryml::Tree& t, size_t owner, size_t group_node,
+                 const std::string& group, const Extensions& ext,
+                 std::vector<std::string>& problems) {
+    auto entry = group_params().find(group);
+    bool listed = entry != group_params().end();
+    bool multipole = group == "MagneticMultipoleP" ||
+                     group == "ElectricMultipoleP";
+    if (!listed && !multipole) return;
+
+    // A group may be given as a sequence of single-key maps as well as a map;
+    // MagneticMultipoleP is written both ways.
+    std::vector<size_t> maps;
+    if (t.is_map(group_node)) {
+        maps.push_back(group_node);
+    } else if (t.is_seq(group_node)) {
+        for (size_t e = t.first_child(group_node); e != ryml::NONE;
+             e = t.next_sibling(e))
+            if (t.is_map(e)) maps.push_back(e);
+    }
+
+    for (size_t m : maps) {
+        // An `extension` key hands the rest of the dictionary to an extension
+        // schema, exactly as it does at element level.
+        if (t.find_child(m, ryml::to_csubstr("extension")) != ryml::NONE)
+            continue;
+        for (size_t c = t.first_child(m); c != ryml::NONE;
+             c = t.next_sibling(c)) {
+            if (!t.has_key(c)) continue;
+            std::string k(t.key(c).str, t.key(c).len);
+            if (ext.marks(k) || is_group_meta_key(k)) continue;
+            if (multipole ? is_multipole_param(group, k)
+                          : entry->second.count(k) != 0)
+                continue;
+            // A multipole name is generated, so there is no table to suggest
+            // from -- the nearest listed name would be a guess at a different
+            // order, which is worse than no guess at all.
+            report(problems, t, owner, group, "parameter", k,
+                   multipole ? std::set<std::string>() : entry->second);
+        }
+    }
+}
+
+// Check the parameters an element carries outside any parameter group.
+void check_element(const ryml::Tree& t, size_t node, const std::string& kind,
+                   const Extensions& ext,
+                   std::vector<std::string>& problems) {
+    const std::set<std::string>& known = element_params(kind);
+    for (size_t c = t.first_child(node); c != ryml::NONE;
+         c = t.next_sibling(c)) {
+        if (!t.has_key(c)) continue;
+        std::string k(t.key(c).str, t.key(c).len);
+        // Group names are judged by looks_like_group, extension data not at all.
+        if (ext.marks(k) || looks_like_group(k) || known.count(k)) continue;
+        // A key whose value holds an `extension` marks itself: the name is the
+        // extension's to choose, since `<some_name>: {extension: ...}` is the
+        // form used where no label is registered (extensions.md).
+        if (t.is_map(c) &&
+            t.find_child(c, ryml::to_csubstr("extension")) != ryml::NONE)
+            continue;
+        report(problems, t, node, "", "parameter", k, known);
+    }
 }
 
 void walk(const ryml::Tree& t, size_t node, const Extensions& ext,
           std::vector<std::string>& problems) {
     if (node == ryml::NONE) return;
 
+    std::string ele_kind;  // set when this map is an element definition
     if (t.is_map(node)) {
         // An `extension` key hands the rest of this dictionary to an extension
         // schema, which PALS explicitly does not validate.
@@ -187,9 +490,26 @@ void walk(const ryml::Tree& t, size_t node, const Extensions& ext,
         size_t kind = t.find_child(node, ryml::to_csubstr("kind"));
         if (kind != ryml::NONE && t.has_val(kind)) {
             std::string v(t.val(kind).str, t.val(kind).len);
-            if (!v.empty() && !known_kinds().count(v) && !ext.marks(v))
-                report(problems, t, node, "kind", v, known_kinds());
+            if (known_groups().count(v)) {
+                // A parameter group defined outside an element names itself
+                // with `kind` (lattice-element-parameters.md, s:inherit.params),
+                // so this map is the group rather than an element.
+                check_group(t, node, node, v, ext, problems);
+            } else if (known_kinds().count(v)) {
+                ele_kind = v;
+                check_element(t, node, v, ext, problems);
+            } else if (!v.empty() && !ext.marks(v)) {
+                report(problems, t, node, "", "kind", v, known_kinds());
+            }
         }
+    }
+
+    // The groups this element's kind may carry, or null when the kind does not
+    // constrain them (or this map is not an element at all).
+    const std::set<std::string>* allowed = nullptr;
+    if (!ele_kind.empty()) {
+        auto it = kind_groups().find(ele_kind);
+        if (it != kind_groups().end()) allowed = &it->second;
     }
 
     for (size_t c = t.first_child(node); c != ryml::NONE;
@@ -198,9 +518,26 @@ void walk(const ryml::Tree& t, size_t node, const Extensions& ext,
             std::string k(t.key(c).str, t.key(c).len);
             if (ext.marks(k)) continue;  // registered extension data
             if (k == "extension_labels") continue;
-            if (looks_like_group(k) && !known_groups().count(k))
-                report(problems, t, node, "parameter group", k,
-                       known_groups());
+            if (looks_like_group(k)) {
+                if (!known_groups().count(k)) {
+                    report(problems, t, node, "", "parameter group", k,
+                           known_groups());
+                    continue;
+                }
+                // A group PALS defines, but not one this kind has: a
+                // `SolenoidP` on a `Drift` is a real group in the wrong place,
+                // so it is reported against the kind rather than the spelling.
+                if (allowed && !allowed->count(k)) {
+                    add(problems, where(t, node, "") + "parameter group '" + k +
+                                      "' is not valid for kind '" + ele_kind +
+                                      "'");
+                    continue;
+                }
+                // Not a closed vocabulary: leave the whole subtree alone rather
+                // than judge names the standard does not define.
+                if (open_groups().count(k)) continue;
+                check_group(t, node, c, k, ext, problems);
+            }
         }
         walk(t, c, ext, problems);
     }

--- a/tests/test_check.cpp
+++ b/tests/test_check.cpp
@@ -80,11 +80,223 @@ TEST_CASE("a misspelled parameter group is reported with a suggestion",
     REQUIRE(has(ps,
                 "element 'q1': unknown parameter group 'FlorP'; did you mean "
                 "'FloorP'?"));
-    // `Refereence` does not end in `P`, so it is not taken for a group at all.
-    REQUIRE(!has(ps, "Refereence"));
-    // Nor is `L20_BLW_P`: PALS never digits or underscores a group name, so the
-    // shape says "outside the standard" rather than "misspelled".
-    REQUIRE(!has(ps, "L20_BLW_P"));
+    // Neither `Refereence` nor `L20_BLW_P` has the shape of a group -- one does
+    // not end in `P`, and PALS never digits or underscores a group name -- so
+    // neither is judged against the group table. They are still keys of a
+    // Quadrupole that PALS does not define, and are caught as parameters.
+    REQUIRE(!has(ps, "parameter group 'Refereence'"));
+    REQUIRE(!has(ps, "parameter group 'L20_BLW_P'"));
+    REQUIRE(has(ps, "element 'q1': unknown parameter 'Refereence'"));
+    REQUIRE(has(ps, "element 'q1': unknown parameter 'L20_BLW_P'"));
+}
+
+TEST_CASE("a misspelled parameter inside a group is reported",
+          "[check][problems]") {
+    // Each group has a fixed component list (one section each under
+    // source/parameters), so a key that is not on it is a mistake -- `xxx` is
+    // no more a ForkP parameter than `FlorP` is a group.
+    auto ps = problems_for("tmp_check_param.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - f1:\n"
+                           "        kind: Fork\n"
+                           "        ForkP:\n"
+                           "          to_line: dump\n"
+                           "          xxx: abc\n"
+                           "    - b1:\n"
+                           "        kind: Bend\n"
+                           "        length: 1\n"
+                           "        BendP:\n"
+                           "          edge_int2: 0.02\n"
+                           "          e1: 0.1\n");
+
+    REQUIRE(has(ps, "element 'f1' ForkP: unknown parameter 'xxx'"));
+    // `edge_int2` is Bmad's spelling of what bend.md calls `edge2_int`. It is
+    // reported without a guess: two edits from `edge2_int` and equally two from
+    // `edge1_int`, and a tie is not worth resolving by coin toss.
+    REQUIRE(has(ps, "element 'b1' BendP: unknown parameter 'edge_int2'"));
+    REQUIRE(!has(ps, "'edge_int2'; did you mean"));
+    // Correct names are left alone.
+    REQUIRE(!has(ps, "'to_line'"));
+    REQUIRE(!has(ps, "'e1'"));
+}
+
+TEST_CASE("multipole component names are accepted by shape, not by list",
+          "[check][problems]") {
+    // A multipole component name is generated from its order, so there is no
+    // list to check against: `Bn`/`Bs`/`Kn`/`Ks` (magnetic) or `En`/`Es`
+    // (electric) plus the order, optionally `L` for the length-integrated form
+    // and `_taper` for the tapering parameter, and `tilt` plus the order.
+    auto ps = problems_for("tmp_check_mult.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - q1:\n"
+                           "        kind: Quadrupole\n"
+                           "        length: 1\n"
+                           "        MagneticMultipoleP:\n"
+                           "          tilt7: 0.7\n"
+                           "          Bn3: 27.3\n"
+                           "          Bn2L: 34.7\n"
+                           "          Ks1: 1\n"
+                           "          Kn2L_taper: 0.1\n"
+                           "          Kn_bogus: 5\n"
+                           "          tiltL: 3\n"
+                           "        ElectricMultipoleP:\n"
+                           "          En3: 1\n"
+                           "          Es2L: 2\n"
+                           "          Bn3: 4\n");
+
+    REQUIRE(count_with(ps, "unknown parameter") == 3);
+    REQUIRE(has(ps, "MagneticMultipoleP: unknown parameter 'Kn_bogus'"));
+    // `tilt` has no length-integrated form, so the trailing `L` is not one.
+    REQUIRE(has(ps, "MagneticMultipoleP: unknown parameter 'tiltL'"));
+    // A magnetic component in the electric group is not an electric one.
+    REQUIRE(has(ps, "ElectricMultipoleP: unknown parameter 'Bn3'"));
+    // No suggestion is offered: the nearest listed name would be a guess at a
+    // different multipole order.
+    REQUIRE(!has(ps, "'Kn_bogus'; did you mean"));
+}
+
+TEST_CASE("a misspelled element parameter is reported", "[check][problems]") {
+    // The parameters outside any group are a short fixed list
+    // (lattice-element-parameters.md, s:non.params), extended by what the kind
+    // is built from -- `line` for a BeamLine, `branches` for a Lattice.
+    auto ps = problems_for("tmp_check_ele.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - q1:\n"
+                           "        kind: Quadrupole\n"
+                           "        lenght: 1\n"
+                           "        s_position: 2\n"
+                           "        is_on: true\n"
+                           "    - ring:\n"
+                           "        kind: BeamLine\n"
+                           "        line:\n"
+                           "          - q1\n"
+                           "    - lat1:\n"
+                           "        kind: Lattice\n"
+                           "        branches:\n"
+                           "          - ring\n");
+
+    REQUIRE(has(ps,
+                "element 'q1': unknown parameter 'lenght'; did you mean "
+                "'length'?"));
+    REQUIRE(count_with(ps, "unknown parameter") == 1);
+}
+
+TEST_CASE("groups with no fixed vocabulary are left alone",
+          "[check][problems]") {
+    // MetaP may hold arbitrary metadata beyond its six components (meta.md) and
+    // TrackingP is program-specific by design (tracking.md), so neither is
+    // checked -- nor is anything nested inside them.
+    auto ps = problems_for("tmp_check_open.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - q1:\n"
+                           "        kind: Quadrupole\n"
+                           "        length: 1\n"
+                           "        MetaP:\n"
+                           "          alias: QUAD1\n"
+                           "          blueprint: anything at all\n"
+                           "          power_supply:\n"
+                           "            NotAGroupP: 3\n"
+                           "        TrackingP:\n"
+                           "          SciBmad:\n"
+                           "            ds_step: 0.3\n"
+                           "        GirderP:\n"
+                           "          undocumented_so_far: 1\n");
+
+    REQUIRE(count_with(ps, "unknown parameter") == 0);
+    REQUIRE(count_with(ps, "unknown parameter group") == 0);
+}
+
+TEST_CASE("a parameter group the element's kind does not have is reported",
+          "[check][problems]") {
+    // Each kind lists the groups it carries (lattice-element-kinds.md). A group
+    // PALS defines but this kind does not have is a real group in the wrong
+    // place, so it is reported against the kind, not the spelling.
+    auto ps = problems_for("tmp_check_kindgroup.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - d1:\n"
+                           "        kind: Drift\n"
+                           "        length: 1\n"
+                           "        SolenoidP:\n"
+                           "          Ksol: 10\n"
+                           "        ApertureP:\n"
+                           "          x_width: 0.02\n"
+                           "    - s1:\n"
+                           "        kind: Solenoid\n"
+                           "        length: 1\n"
+                           "        SolenoidP:\n"
+                           "          Ksol: 10\n"
+                           "    - beg:\n"
+                           "        kind: BeginningEle\n"
+                           "        TwissP:\n"
+                           "          beta_a: 12.5\n"
+                           "        ParticleP:\n"
+                           "          x: 1\n");
+
+    REQUIRE(has(ps,
+                "element 'd1': parameter group 'SolenoidP' is not valid for "
+                "kind 'Drift'"));
+    // A Drift does have an aperture, and a Solenoid does have SolenoidP.
+    REQUIRE(count_with(ps, "not valid for kind") == 1);
+    // TwissP and ParticleP state the initial conditions of a branch, which is
+    // what the beginning element is for.
+    REQUIRE(!has(ps, "TwissP"));
+    REQUIRE(!has(ps, "ParticleP"));
+}
+
+TEST_CASE("kinds with no documented group list are not constrained",
+          "[check][problems]") {
+    // `Girder` is still "Under Construction" -- nothing is documented to check
+    // its groups against -- while `Placeholder` says outright that it has none.
+    auto ps = problems_for("tmp_check_nolist.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - g1:\n"
+                           "        kind: Girder\n"
+                           "        BodyShiftP:\n"
+                           "          x_offset: 0.001\n"
+                           "    - p1:\n"
+                           "        kind: Placeholder\n"
+                           "        ApertureP:\n"
+                           "          x_width: 0.02\n");
+
+    REQUIRE(!has(ps, "kind 'Girder'"));
+    REQUIRE(has(ps,
+                "element 'p1': parameter group 'ApertureP' is not valid for "
+                "kind 'Placeholder'"));
+}
+
+TEST_CASE("a parameter group defined on its own is checked as a group",
+          "[check][problems]") {
+    // A group defined outside an element names itself with `kind` and may be
+    // given a `name` or `inherit` another (lattice-element-parameters.md,
+    // s:inherit.params). `kind: ApertureP` is a group name, not an element
+    // kind, and its entries are ApertureP's.
+    auto ps = problems_for("tmp_check_named.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - ap1:\n"
+                           "        kind: ApertureP\n"
+                           "        x_min: -0.03\n"
+                           "        x_max: 0.04\n"
+                           "        x_mim: 0.01\n"
+                           "    - q0:\n"
+                           "        kind: Quadrupole\n"
+                           "        length: 1\n"
+                           "        ApertureP:\n"
+                           "          inherit: ap1\n");
+
+    REQUIRE(!has(ps, "unknown kind 'ApertureP'"));
+    REQUIRE(has(ps,
+                "element 'ap1' ApertureP: unknown parameter 'x_mim'; did you "
+                "mean 'x_min'?"));
+    // `inherit` is a group's own key, not one of ApertureP's components.
+    REQUIRE(!has(ps, "'inherit'"));
+    REQUIRE(count_with(ps, "unknown parameter") == 1);
 }
 
 TEST_CASE("correctly spelled kinds and groups are not reported",

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -229,7 +229,7 @@ TEST_CASE("parse_and_expand_PALS reports expansion problems",
               "    - DH1A:\n"
               "        kind: Bend\n"
               "        BendP:\n"
-              "          edge_int2: 0.02 * thingB>MagneticMultipoleP.NotThere\n"
+              "          edge2_int: 0.02 * thingB>MagneticMultipoleP.NotThere\n"
               "          e1: 3 * missing_const\n"
               "    - ghost_child:\n"
               "        kind: Bend\n"
@@ -263,7 +263,7 @@ TEST_CASE("parse_and_expand_PALS reports expansion problems",
     REQUIRE(has("reference to undefined element or line 'NoSuchElement'"));
     REQUIRE(has("inherit: 'ghost_ancestor' is not defined"));
     REQUIRE(has("could not evaluate expression for constants.a_const"));
-    REQUIRE(has("could not evaluate expression for BendP.edge_int2"));
+    REQUIRE(has("could not evaluate expression for BendP.edge2_int"));
     REQUIRE(has("could not evaluate expression for BendP.e1"));
 
     // Exactly those five: plain names (`kind: Bend`, the line references that

--- a/tests/test_expressions.cpp
+++ b/tests/test_expressions.cpp
@@ -265,7 +265,7 @@ TEST_CASE("parse_and_expand_PALS resolves element-parameter references",
               "        kind: Bend\n"
               "        length: 0.2\n"
               "        BendP:\n"
-              "          edge_int2: 0.02 * thingB>MagneticMultipoleP.Kn2L\n"
+              "          edge2_int: 0.02 * thingB>MagneticMultipoleP.Kn2L\n"
               "    - main_line:\n"
               "        kind: BeamLine\n"
               "        line:\n"
@@ -283,7 +283,7 @@ TEST_CASE("parse_and_expand_PALS resolves element-parameter references",
     REQUIRE(dh1a != YAML_NULL_ID);
     YAMLNodeId bendp = get_child_by_key(lat.expanded, dh1a, "BendP");
     REQUIRE(close(
-        num_val(lat.expanded, get_child_by_key(lat.expanded, bendp, "edge_int2")),
+        num_val(lat.expanded, get_child_by_key(lat.expanded, bendp, "edge2_int")),
         0.02 * 0.1));
 
     // A clean lattice reports no problems.
@@ -313,7 +313,7 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
               "        ReferenceP:\n"
               "          species_ref: species\n"
               "        BendP:\n"
-              "          e_tot: 1.1 * mass_of(species)\n"
+              "          h1: 1.1 * mass_of(species)\n"
               "    - main_line:\n"
               "        kind: BeamLine\n"
               "        line:\n"
@@ -338,7 +338,7 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
     REQUIRE(dh1a != YAML_NULL_ID);
     YAMLNodeId bendp = get_child_by_key(lat.expanded, dh1a, "BendP");
     REQUIRE(close(num_val(lat.expanded,
-                          get_child_by_key(lat.expanded, bendp, "e_tot")),
+                          get_child_by_key(lat.expanded, bendp, "h1")),
                   1.1 * m_3he));
 
     // A bare identifier naming the species constant (`species_ref: species`) is


### PR DESCRIPTION
The name checks so far stopped at kinds and group names, so `ForkP: {xxx: abc}` and a `SolenoidP` on a `Drift` both passed. Three more, all against what the standard documents:

```
element 'b_fork' ForkP: unknown parameter 'xxx'
element 'q1': unknown parameter 'lenght'; did you mean 'length'?
element 'd1': parameter group 'SolenoidP' is not valid for kind 'Drift'
```

### Parameters inside a group

Checked against the group's component list, one section each under `source/parameters`. Left alone, subtree and all, rather than judged against a list that does not exist:

- **`MetaP`** — meta.md says it may hold arbitrary metadata beyond its six components.
- **`TrackingP`** — program-specific by design.
- **`ACKickerP`, `GirderP`** — still "In Construction".
- **`ForkFromP`** — keyed `{branch}>>{element}` by the parser.

The two multipole groups can't use a list at all, since the names are generated from the order. They're matched by shape: `Bn`/`Bs`/`Kn`/`Ks` (magnetic) or `En`/`Es` (electric) + order, optional `L` for the integrated form and `_taper` for the tapering parameter, and `tilt` + order. No suggestion there — the nearest listed name would just be a guess at a different order.

### Element parameters

Checked against the six that fit no group (`field_master`, `is_on`, `kind`, `length`, `name`, `s_position`) plus `inherit` and the line-item modifiers, extended per kind: `line`/`multipass`/`zero_point`/`repeat` for `BeamLine`, `branches` for `Lattice`, `control_type`/`variables`/`controls` for `Controller`, `value` for `constant`/`variable`. So `line:` on a Quadrupole is an error, not a misspelling.

### Which groups a kind may carry

From the "Element parameter groups associated with this element kind are" list in each kind's section of `lattice-element-kinds.md` — 26 kinds. Reported as a kind mismatch, not a spelling one, so no "did you mean": the group is real, it is just in the wrong place.

A kind with no list is **not** constrained — `Feedback`, `Fiducial` and `Girder` are still "Under Construction". `Placeholder` **is**, to nothing at all: its section says outright that it has no associated parameter groups. Nor are `BeamLine`/`Lattice`/`Controller`/`constant`/`variable`, which are not lattice elements.

Three entries run ahead of the merged standard and are marked as such where they are written: **`ApertureP` on `Marker`**, and **`TwissP`/`ParticleP` on `BeginningEle`**. Both are being added to the spec. `ForkFromP` also goes to the three kinds a Fork may point at, matching the destination-kind rule from #63.

### Two false positives the wider checks exposed

- A parameter group defined outside an element names itself with `kind` (`kind: ApertureP`, s:inherit.params). Such a map is the group, not an element with an unknown kind, and its entries are checked as that group's. `inherit`/`name`/`kind` are allowed in any group.
- A key whose value holds an `extension` marks itself, so the name is the extension's to choose — the form used where no label is registered.

### Fixtures

Three were quietly wrong in exactly the way these checks look for: `edge_int2` for what bend.md calls `edge2_int`, and `BendP.e_tot`, which is not a BendP parameter at all.

### Verification

160/160, and a scan of every `*.pals.yaml` in both repos is clean except for two deliberate cases (`ReferenceChangeP` on a Quadrupole in `convert.pals.yaml`, and an `xxx` left in `fork.pals.yaml` as the case that prompted this).

Not covered: `edge_int2` gets no suggestion, being two edits from `edge2_int` and equally two from `edge1_int` — a tie reported rather than broken by coin toss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
