### PR TITLE
Name the fork destination: destination_pointer and ForkP.forked_to

### DIFF
--- a/src/pals_check.cpp
+++ b/src/pals_check.cpp
@@ -73,7 +73,7 @@ const std::map<std::string, std::set<std::string>>& group_params() {
         {"FoilP", {"dE_ref"}},
         {"ForkP",
          {"to_line", "destination_element", "direction", "new_branch",
-          "propagate_reference"}},
+          "propagate_reference", "forked_to"}},
         {"ParticleP",
          {"x",           "px",          "y",          "py",
           "z",           "pz",          "spin_x",     "spin_y",

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -91,8 +91,8 @@ static void deep_copy_tracked(ryml::Tree& dst_t, size_t dst_node,
 // provenance. This is what lets `expanded` and `leftover` be cut out of the
 // temporary work tree and still record provenance straight back to `combined`:
 // the work tree is discarded, so links through it would dangle. Nodes with no
-// entry in `via` (created during expansion, e.g. `fork_pointer`) have no source
-// and drop out.
+// entry in `via` (created during expansion, e.g. `destination_pointer`) have
+// no source and drop out.
 static void chain_prov(std::map<size_t, size_t>& prov,
                        const std::map<size_t, size_t>& via) {
     for (auto it = prov.begin(); it != prov.end();) {
@@ -242,9 +242,12 @@ static size_t find_in_line(const ryml::Tree& t, size_t line,
 //     creates nothing.
 //  3. Names the new branch (after `to_line` for SELF, else after `new_branch`).
 //  4. Checks the destination is a kind that may be forked to.
-//  5. Creates a fork_pointer in the element pointing at "destination_element" in
-//     the destination branch, and resolves ForkP.new_branch to the name of the
-//     branch that was made (or `null` when none was).
+//  5. Creates a destination_pointer in the element pointing at
+//     "destination_element" in the destination branch, and resolves
+//     ForkP.new_branch to the name of the branch that was made (or `null` when
+//     none was). The pointer is a node id, for use while expansion runs;
+//     link_fork_connections later turns it into the `ForkP.forked_to` name that
+//     the expanded lattice states the connection by.
 static void handle_fork(ryml::Tree& t, size_t fork_node, size_t branches,
                         std::map<std::string, size_t>& emap,
                         std::map<size_t, size_t>& prov, ProblemList& problems,
@@ -338,7 +341,7 @@ static void handle_fork(ryml::Tree& t, size_t fork_node, size_t branches,
         // enclosing expand may still be walking; without the mark that walk
         // reaches it and expands it a second time, re-running every Fork inside
         // it and so duplicating both their destination branches and their
-        // fork_pointers.
+        // destination_pointers.
         expand(t, branch_node, emap, prov, problems, branches, mp_pass, done);
         done.insert(branch_node);
         created_branch = true;
@@ -397,12 +400,12 @@ static void handle_fork(ryml::Tree& t, size_t fork_node, size_t branches,
         }
     }
 
-    // Add fork_pointer: <node id of target as string>
+    // Add destination_pointer: <node id of target as string>
     ensure_capacity(t, 2);
     std::string id_str = std::to_string(target);
     size_t fp_child = t.append_child(fork_node);
     t.ref(fp_child) |= ryml::KEY | ryml::VAL;
-    t.set_key(fp_child, t.to_arena(ryml::to_csubstr("fork_pointer")));
+    t.set_key(fp_child, t.to_arena(ryml::to_csubstr("destination_pointer")));
     t.set_val(fp_child, t.to_arena(ryml::to_csubstr(id_str)));
 
     // Resolve ForkP.new_branch to the branch this Fork actually instantiated:
@@ -975,8 +978,8 @@ static size_t find_lattice(ryml::Tree& t, const std::string& name) {
 // avoids a stray collision between such a name and a constant (e.g. an element
 // literally named `pi`).
 //
-// `fork_pointer` is here for a different reason: it is a node id, and a node id
-// is a number, so evaluating it "succeeds" and rewrites it through
+// `destination_pointer` is here for a different reason: it is a node id, and a
+// node id is a number, so evaluating it "succeeds" and rewrites it through
 // format_double. That is lossless as a number but not as text -- an id of 110
 // comes back as `1.1e+02`, the shortest round-tripping form -- and every reader
 // of the pointer parses it with std::stoull, which stops at the `.` and yields
@@ -987,7 +990,7 @@ static const std::set<std::string>& non_expr_keys() {
         "inherit",    "zero_point",  "to_line",
         "destination_element", "new_branch", "multipass",
         "propagate_reference", "name", "multipass_index",
-        "fork_pointer"};
+        "destination_pointer", "forked_to"};
     return keys;
 }
 
@@ -2139,9 +2142,9 @@ static size_t append_branch_end(ryml::Tree& t, size_t line) {
 // beginning element from its own reference/floor. Branches are visited in order
 // and a new branch is always appended after the Fork that creates it, so by the
 // time a forked branch is reached its Fork has been bookkept: `fork_seed` maps
-// the destination element (by node id, matching the raw `fork_pointer`) to that
-// Fork. `fork_pointer` still holds the work-tree node id here; it is remapped to
-// the split-out tree only later.
+// the destination element (by node id, matching the raw
+// `destination_pointer`) to that Fork. `destination_pointer` still holds the
+// work-tree node id here; it is remapped to the split-out tree only later.
 static void run_element_bookkeeper(ryml::Tree& t, size_t lat_node,
                                    ProblemList& problems) {
     size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
@@ -2185,7 +2188,7 @@ static void run_element_bookkeeper(ryml::Tree& t, size_t lat_node,
                     forkp != ryml::NONE
                         ? child_val_str(t, forkp, "propagate_reference")
                         : "";
-                std::string ptr = child_val_str(t, def, "fork_pointer");
+                std::string ptr = child_val_str(t, def, "destination_pointer");
                 std::string nb =
                     forkp != ryml::NONE
                         ? child_val_str(t, forkp, "new_branch")
@@ -2209,11 +2212,46 @@ static void run_element_bookkeeper(ryml::Tree& t, size_t lat_node,
     }
 }
 
+// Map every element definition in the expanded lattice to the
+// `{branch-name}>>{element-name}` form the fork parameters name elements by
+// (fork.md, forkfrom.md). Built as a whole before the forks are walked because a
+// Fork names a destination in a branch other than its own, which the walk has
+// either already passed or not yet reached.
+static std::map<size_t, std::string> qualified_element_names(ryml::Tree& t,
+                                                             size_t branches) {
+    std::map<size_t, std::string> names;
+    for (size_t entry = t.first_child(branches); entry != ryml::NONE;
+         entry = t.next_sibling(entry)) {
+        if (!t.is_map(entry)) continue;
+        size_t branch = t.first_child(entry);
+        if (branch == ryml::NONE || !t.has_key(branch)) continue;
+        std::string branch_name(t.key(branch).str, t.key(branch).len);
+        size_t line = t.find_child(branch, ryml::to_csubstr("line"));
+        if (line == ryml::NONE || !t.is_seq(line)) continue;
+        for (size_t le = t.first_child(line); le != ryml::NONE;
+             le = t.next_sibling(le)) {
+            if (!t.is_map(le)) continue;
+            size_t ele = t.first_child(le);
+            if (ele == ryml::NONE || !t.has_key(ele)) continue;
+            names[ele] = branch_name + ">>" +
+                         std::string(t.key(ele).str, t.key(ele).len);
+        }
+    }
+    return names;
+}
+
 /**
- * Record on every fork destination the `Fork` elements that point at it.
+ * Write the two names that record, in the expanded lattice, what each `Fork`
+ * connected to: `ForkP.forked_to` on the Fork, and `ForkFromP` on its
+ * destination.
  *
- * `ForkFromP` (forkfrom.md, s:fork.from.params) is the reverse of the `Fork`'s
- * own `ForkP`: a sequence carrying one entry per incoming Fork, keyed
+ * `forked_to` (fork.md, s:fork.params) is an output parameter naming the
+ * destination element as `{branch-name}>>{element-name}` -- the resolved form of
+ * the `to_line`/`destination_element` the input asked for, so whatever the input
+ * carried under that key is replaced by what the Fork actually reached.
+ *
+ * `ForkFromP` (forkfrom.md, s:fork.from.params) points the other way: a sequence
+ * on the destination carrying one entry per incoming Fork, keyed
  * `{branch-name}>>{element-name}` after the Fork and its branch, with the
  * Fork's index in that branch's line as the value:
  *
@@ -2221,19 +2259,21 @@ static void run_element_bookkeeper(ryml::Tree& t, size_t lat_node,
  *       - inject_line>>inj_fork: 134
  *       - alt_line>>end_fork: 37
  *
- * The index is 1-based -- entry 37 is the 37th element of `alt_line`. The group
- * is built by the parser and exists only in the expanded lattice, so like
- * `fork_pointer` its nodes carry no provenance.
+ * The index is 1-based -- entry 37 is the 37th element of `alt_line`. Both names
+ * are built by the parser and exist only in the expanded lattice, so like
+ * `destination_pointer` their nodes carry no provenance.
  *
  * Runs after expansion, when every branch line is final and the indices are the
- * ones the expanded lattice actually carries. The `fork_pointer` scalars still
- * hold work tree ids at this point -- remap_fork_pointers renumbers them only
- * once the lattice has been cut out into a tree of its own -- so each one names
- * its destination element directly.
+ * ones the expanded lattice actually carries. The `destination_pointer`
+ * scalars still hold work tree ids at this point -- remap_destination_pointers
+ * renumbers them only once the lattice has been cut out into a tree of its own
+ * -- so each one names its destination element directly.
  */
-static void link_fork_from(ryml::Tree& t, size_t lat_node) {
+static void link_fork_connections(ryml::Tree& t, size_t lat_node) {
     size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
     if (branches == ryml::NONE || !t.is_seq(branches)) return;
+
+    std::map<size_t, std::string> qnames = qualified_element_names(t, branches);
 
     for (size_t entry = t.first_child(branches); entry != ryml::NONE;
          entry = t.next_sibling(entry)) {
@@ -2256,9 +2296,10 @@ static void link_fork_from(ryml::Tree& t, size_t lat_node) {
             if (ele == ryml::NONE || !t.has_key(ele)) continue;
             if (child_val_str(t, ele, "kind") != "Fork") continue;
 
-            // A Fork that failed to resolve has no fork_pointer, and the reason
-            // was reported when it was handled; there is nothing to link to.
-            std::string ptr = child_val_str(t, ele, "fork_pointer");
+            // A Fork that failed to resolve has no destination_pointer, and
+            // the reason was reported when it was handled; there is nothing to
+            // link to.
+            std::string ptr = child_val_str(t, ele, "destination_pointer");
             if (ptr.empty()) continue;
             size_t dest;
             try {
@@ -2267,6 +2308,15 @@ static void link_fork_from(ryml::Tree& t, size_t lat_node) {
                 continue;
             }
             if (dest >= t.capacity() || !t.is_map(dest)) continue;
+
+            // Name the destination on the Fork. A destination that is not in
+            // `qnames` is not an element of any branch line, which handle_fork
+            // does not produce a pointer to.
+            size_t forkp = t.find_child(ele, ryml::to_csubstr("ForkP"));
+            auto dest_name = qnames.find(dest);
+            if (forkp != ryml::NONE && dest_name != qnames.end())
+                set_plain_child(t, forkp, "forked_to",
+                                dest_name->second.c_str());
 
             std::string name = branch_name + ">>" +
                                std::string(t.key(ele).str, t.key(ele).len);
@@ -2283,19 +2333,20 @@ static void link_fork_from(ryml::Tree& t, size_t lat_node) {
     }
 }
 
-// Rewrite the `fork_pointer` scalars of a freshly split-out tree. handle_fork
-// stores the raw node id of the fork's destination element, but it runs while
-// expansion is still on the work tree; cutting the lattice out into its own tree
-// renumbers every node, so each pointer has to be translated to the id its
-// target now carries. `from_work` maps work ids to ids in `t`. A pointer whose
-// target did not come across (it should always be inside the lattice) is left
-// alone and reported.
-static void remap_fork_pointers(ryml::Tree& t, size_t node,
+// Rewrite the `destination_pointer` scalars of a freshly split-out tree.
+// handle_fork stores the raw node id of the fork's destination element, but it
+// runs while expansion is still on the work tree; cutting the lattice out into
+// its own tree renumbers every node, so each pointer has to be translated to
+// the id its target now carries. `from_work` maps work ids to ids in `t`. A
+// pointer whose target did not come across (it should always be inside the
+// lattice) is left alone and reported.
+static void remap_destination_pointers(ryml::Tree& t, size_t node,
                                 const std::map<size_t, size_t>& from_work,
                                 ProblemList& problems) {
     if (node == ryml::NONE) return;
 
-    if (t.has_key(node) && t.key(node) == ryml::to_csubstr("fork_pointer") &&
+    if (t.has_key(node) &&
+        t.key(node) == ryml::to_csubstr("destination_pointer") &&
         t.has_val(node)) {
         std::string old(t.val(node).str, t.val(node).len);
         size_t target = 0;
@@ -2306,8 +2357,9 @@ static void remap_fork_pointers(ryml::Tree& t, size_t node,
         }
         auto it = from_work.find(target);
         if (it == from_work.end()) {
-            add_problem(problems,
-                        "fork_pointer target is outside the expanded lattice");
+            add_problem(
+                problems,
+                "destination_pointer target is outside the expanded lattice");
             return;
         }
         std::string id_str = std::to_string(it->second);
@@ -2315,7 +2367,7 @@ static void remap_fork_pointers(ryml::Tree& t, size_t node,
     }
 
     for (size_t c = t.first_child(node); c != ryml::NONE; c = t.next_sibling(c))
-        remap_fork_pointers(t, c, from_work, problems);
+        remap_destination_pointers(t, c, from_work, problems);
 }
 
 // Builds the `expanded` and `leftover` trees from `combined`.
@@ -2385,13 +2437,13 @@ static void make_expanded_and_leftover(ParsedData* comb,
         // With every input now a plain number, walk each branch element-by-
         // element to fill in the reference, floor, s-position, and field-
         // dependent output parameters. This adds new ReferenceP/FloorP nodes,
-        // which carry no provenance (like fork_pointer) and so simply do not
+        // which carry no provenance (like destination_pointer) and so simply do not
         // appear in the correspondence map.
         run_element_bookkeeper(t, lat_node, problems);
 
         // Last, so the line indices it records are the finished ones -- the
         // bookkeeper caps every branch with a `branch_end` element.
-        link_fork_from(t, lat_node);
+        link_fork_connections(t, lat_node);
 
         size_t wrapper = t.parent(lat_node);
         skip = (wrapper != ryml::NONE && !t.is_root(wrapper) &&
@@ -2418,7 +2470,8 @@ static void make_expanded_and_leftover(ParsedData* comb,
         // pointers need.
         std::map<size_t, size_t> from_work;
         for (const auto& kv : exp->provenance) from_work[kv.second] = kv.first;
-        remap_fork_pointers(exp->tree, exp->tree.root_id(), from_work, problems);
+        remap_destination_pointers(exp->tree, exp->tree.root_id(), from_work,
+                                   problems);
 
         chain_prov(exp->provenance, work.provenance);
     }

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -122,7 +122,8 @@ struct lattices {
  * expansion can duplicate nodes (scalar substitution, `repeat`, `inherit`,
  * forks), a single combined/original node may appear in several links — one per
  * copy. A field is YAML_NULL_ID when no corresponding node exists (e.g. the
- * `fork_pointer` scalars synthesised during expansion have no original source).
+ * `destination_pointer` scalars synthesised during expansion have no original
+ * source).
  *
  * Expansion splits the document, so a link carries either an `expanded` id or a
  * `leftover` id, never both; the two are tied together through the `combined`

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -74,17 +74,17 @@ TEST_CASE("leftover keeps the rest of the document", "[lattices]") {
 // handle_fork writes the raw node id of the fork's destination element. That id
 // is assigned before the lattice is cut out into its own tree, so it must be
 // translated to survive the renumbering.
-TEST_CASE("fork_pointer resolves inside the expanded tree", "[lattices]") {
+TEST_CASE("destination_pointer resolves inside the expanded tree", "[lattices]") {
     struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", "lat1");
 
-    // Find the fork_pointer scalar anywhere in the expanded tree.
+    // Find the destination_pointer scalar anywhere in the expanded tree.
     YAMLNodeId fp = YAML_NULL_ID;
     std::vector<YAMLNodeId> stack{get_root(lat.expanded)};
     while (!stack.empty()) {
         YAMLNodeId n = stack.back();
         stack.pop_back();
         char* key = get_node_key(lat.expanded, n);
-        if (key && std::string(key) == "fork_pointer") fp = n;
+        if (key && std::string(key) == "destination_pointer") fp = n;
         yaml_free_string(key);
         for (size_t i = 0; i < get_size(lat.expanded, n); i++)
             stack.push_back(get_child_by_index(lat.expanded, n, i));
@@ -452,9 +452,9 @@ TEST_CASE("a Fork needs only to_line; destination_element and new_branch default
         REQUIRE(std::string(lat.problems.items[i]).find("f1") ==
                 std::string::npos);
 
-    // The fork resolved to a target, so the element carries a fork_pointer and
+    // The fork resolved to a target, so the element carries a destination_pointer and
     // the defaulted branch (named after to_line) exists.
-    YAMLNodeId fp = find_by_key(lat.expanded, "fork_pointer");
+    YAMLNodeId fp = find_by_key(lat.expanded, "destination_pointer");
     REQUIRE(fp != YAML_NULL_ID);
 
     // Expansion resolves ForkP.new_branch to the name of the branch it made,
@@ -474,15 +474,20 @@ TEST_CASE("a Fork needs only to_line; destination_element and new_branch default
 
 // Helper: the keyed element definition of a branch's first line element.
 // expanded -> lat1(0) -> branches -> branch entry(idx) -> branch map(0) ->
-// line -> line entry(0) -> element def(0).
-static YAMLNodeId first_element_of_branch(YAMLTreeHandle t, size_t branch_idx) {
+// line -> line entry(pos) -> element def(0).
+static YAMLNodeId element_of_branch(YAMLTreeHandle t, size_t branch_idx,
+                                    size_t pos) {
     YAMLNodeId lat1 = get_child_by_index(t, get_root(t), 0);
     YAMLNodeId branches = get_child_by_key(t, lat1, "branches");
     YAMLNodeId branch = get_child_by_index(
         t, get_child_by_index(t, branches, branch_idx), 0);
     YAMLNodeId line = get_child_by_key(t, branch, "line");
-    YAMLNodeId entry = get_child_by_index(t, line, 0);
+    YAMLNodeId entry = get_child_by_index(t, line, pos);
     return get_child_by_index(t, entry, 0);
+}
+
+static YAMLNodeId first_element_of_branch(YAMLTreeHandle t, size_t branch_idx) {
+    return element_of_branch(t, branch_idx, 0);
 }
 
 TEST_CASE("a Fork propagates reference and floor into its new branch",
@@ -662,8 +667,8 @@ TEST_CASE("new_branch: null forks into an existing branch, creating none",
     YAMLNodeId branches = get_child_by_key(lat.expanded, lat1, "branches");
     REQUIRE(get_size(lat.expanded, branches) == 2);
 
-    // The Fork still connects: it carries a fork_pointer.
-    REQUIRE(find_by_key(lat.expanded, "fork_pointer") != YAML_NULL_ID);
+    // The Fork still connects: it carries a destination_pointer.
+    REQUIRE(find_by_key(lat.expanded, "destination_pointer") != YAML_NULL_ID);
 
     // ForkP.new_branch stays `null` — no branch was made.
     YAMLNodeId forkp = find_by_key(lat.expanded, "ForkP");
@@ -741,8 +746,9 @@ TEST_CASE("a destination of a kind that cannot be forked to is reported",
     REQUIRE(reported == 2);
 
     // Neither Fork resolved, so nothing was linked in either direction.
-    REQUIRE(find_by_key(lat.expanded, "fork_pointer") == YAML_NULL_ID);
+    REQUIRE(find_by_key(lat.expanded, "destination_pointer") == YAML_NULL_ID);
     REQUIRE(find_by_key(lat.expanded, "ForkFromP") == YAML_NULL_ID);
+    REQUIRE(find_by_key(lat.expanded, "forked_to") == YAML_NULL_ID);
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
@@ -825,6 +831,91 @@ TEST_CASE("a fork destination lists its incoming Forks in ForkFromP",
     rm_tmp(path);
 }
 
+// Read `ForkP.forked_to` off an element of a branch line.
+static std::string forked_to_of(YAMLTreeHandle t, size_t branch_idx,
+                                size_t pos) {
+    YAMLNodeId forkp = get_child_by_key(
+        t, element_of_branch(t, branch_idx, pos), "ForkP");
+    if (forkp == YAML_NULL_ID) return "";
+    char* v = as_string(t, get_child_by_key(t, forkp, "forked_to"));
+    std::string out(v ? v : "");
+    yaml_free_string(v);
+    return out;
+}
+
+TEST_CASE("a Fork names its destination in ForkP.forked_to", "[lattices]") {
+    // `forked_to` (fork.md, s:fork.params) is an output parameter: the parser
+    // writes the destination element as `{branch-name}>>{element-name}`. The
+    // branch name is the one the expanded lattice ends up with, which is not in
+    // general the `to_line` the input named -- all three settings of
+    // `new_branch` are here, and only the SELF one has the two coincide.
+    const char* path = "tmp_forked_to.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - m0:\n"
+              "        kind: Marker\n"
+              "    - dump_begin:\n"
+              "        kind: Marker\n"
+              "    - alt_begin:\n"
+              "        kind: Marker\n"
+              "    - dump_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - dump_begin\n"
+              "    - alt_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - alt_begin\n"
+              "    - ring:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - m0\n"
+              "          - f1:\n"
+              "              kind: Fork\n"
+              "              ForkP:\n"
+              "                to_line: dump_line\n"
+              "                destination_element: dump_begin\n"
+              "                new_branch: proton_dump\n"
+              "          - f2:\n"
+              "              kind: Fork\n"
+              "              ForkP:\n"
+              "                to_line: alt_line\n"
+              "          - f3:\n"
+              "              kind: Fork\n"
+              "              ForkP:\n"
+              "                to_line: proton_dump\n"
+              "                new_branch: null\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - ring\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.problems.count == 0);
+
+    // f1 renamed the branch it built, so `forked_to` names `proton_dump` where
+    // `to_line` said `dump_line`.
+    REQUIRE(forked_to_of(lat.expanded, 0, 1) == "proton_dump>>dump_begin");
+
+    // f2 took the default (SELF): the branch is named after the beam line, and
+    // the destination defaults to that line's first element.
+    REQUIRE(forked_to_of(lat.expanded, 0, 2) == "alt_line>>alt_begin");
+
+    // f3 pointed into the branch f1 had already built, and names the same
+    // destination as f1 does.
+    REQUIRE(forked_to_of(lat.expanded, 0, 3) == "proton_dump>>dump_begin");
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}
+
 TEST_CASE("a Fork inside a forked-to branch resolves exactly once",
           "[lattices]") {
     // A chained fork: `ring` forks to `mid`, and `mid` itself forks to `end`.
@@ -832,7 +923,7 @@ TEST_CASE("a Fork inside a forked-to branch resolves exactly once",
     // the destination element, and appends it to `branches` -- which the
     // enclosing walk over `branches` is still iterating. Expanding it a second
     // time would re-run the Fork it holds, giving two `end` branches and two
-    // fork_pointers on the one element, so the branch is expanded only once.
+    // destination_pointers on the one element, so the branch is expanded only once.
     //
     // `ring` is followed by a second listed branch, so the walk over `branches`
     // has somewhere to go after `ring` and reaches the entry `ring`'s Fork
@@ -883,14 +974,14 @@ TEST_CASE("a Fork inside a forked-to branch resolves exactly once",
     YAMLNodeId branches = get_child_by_key(lat.expanded, lat1, "branches");
     REQUIRE(get_size(lat.expanded, branches) == 4);
 
-    // f2, the Fork in the branch that f1 built, ran once: one fork_pointer.
+    // f2, the Fork in the branch that f1 built, ran once: one destination_pointer.
     YAMLNodeId f2 = first_element_of_branch(lat.expanded, 2);
     REQUIRE(key_eq(lat.expanded, f2, "f2"));
     int pointers = 0;
     for (size_t i = 0; i < get_size(lat.expanded, f2); ++i) {
         char* k = get_node_key(lat.expanded,
                                get_child_by_index(lat.expanded, f2, i));
-        if (k && std::string(k) == "fork_pointer") pointers++;
+        if (k && std::string(k) == "destination_pointer") pointers++;
         yaml_free_string(k);
     }
     REQUIRE(pointers == 1);
@@ -925,15 +1016,15 @@ static std::vector<std::string> all_values_for(YAMLTreeHandle t,
     return out;
 }
 
-TEST_CASE("a fork_pointer survives expression substitution intact",
+TEST_CASE("a destination_pointer survives expression substitution intact",
           "[lattices][problems]") {
-    // A fork_pointer holds a node id, which is a number, so the expression pass
+    // A destination_pointer holds a node id, which is a number, so the expression pass
     // used to "evaluate" it and write the result back through format_double --
     // the shortest text that round-trips as a double. For most ids that is the
     // digits themselves, but an id of 110 comes back as `1.1e+02`, and every
     // reader parses the pointer with std::stoull, which stops at the `.` and
     // yields 1. That silently cost the fork its ForkFromP entry and its
-    // reference propagation, and left remap_fork_pointers reporting the target
+    // reference propagation, and left remap_destination_pointers reporting the target
     // as outside the lattice. non_expr_keys() now skips the key.
     //
     // Only a minority of ids format that way -- a multiple of 10 from 100 up --
@@ -942,7 +1033,7 @@ TEST_CASE("a fork_pointer survives expression substitution intact",
     // every pointer happens to come out in plain digits and the bug hides. The
     // assertions hold whatever the ids turn out to be; they simply stop
     // exercising this if an unrelated change shifts the ids again.
-    const char* path = "tmp_fork_pointer_fmt.pals.yaml";
+    const char* path = "tmp_destination_pointer_fmt.pals.yaml";
     write_tmp(path,
               "PALS:\n"
               "  facility:\n"
@@ -1009,10 +1100,10 @@ TEST_CASE("a fork_pointer survives expression substitution intact",
 
     // Five Forks resolve: two chains of three (zero_line -> a_line -> b_line,
     // one_line -> c_line -> a_line -> b_line), sharing no branch instances.
-    std::vector<std::string> ptrs = all_values_for(lat.expanded, "fork_pointer");
+    std::vector<std::string> ptrs = all_values_for(lat.expanded, "destination_pointer");
     REQUIRE(ptrs.size() == 5);
     for (const std::string& p : ptrs) {
-        INFO("fork_pointer: " << p);
+        INFO("destination_pointer: " << p);
         REQUIRE(!p.empty());
         REQUIRE(p.find_first_not_of("0123456789") == std::string::npos);
     }


### PR DESCRIPTION
Rename the synthesised `fork_pointer` scalar to `destination_pointer`, and
have expansion write `ForkP.forked_to` on every resolved Fork.

`forked_to` (fork.md, s:fork.params) is an output parameter naming the
destination element as `{branch-name}>>{element-name}` -- the same form
`ForkFromP` keys its entries by, pointing the other way. It is written from the
`destination_pointer`, so a Fork that failed to resolve gets neither.

The branch name it carries is the one the expanded lattice ends up with, which
is not in general the `to_line` the input named: `new_branch` may rename the
branch that gets built. So it is written in the same post-expansion pass that
builds `ForkFromP`, where every branch name and line index is final, off a map
of every element to its qualified name -- a Fork's destination is in a branch
other than its own, which a single walk has either already passed or not yet
reached.

`link_fork_from` is renamed `link_fork_connections`, since it now writes both
directions of the link.

`forked_to` joins the check's `ForkP` vocabulary and the expression pass's
non-expression keys (`>>` is not arithmetic).


🤖 Generated with [Claude Code](https://claude.com/claude-code)
