### PR TITLE
Upper case the BendP enum defaults

### DIFF
--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -2020,8 +2020,8 @@ struct GroupDefault {
 static const GroupDefault kGroupDefaults[] = {
     {"RFP", "cavity_type", "STANDING_WAVE"},
     {"RFP", "zero_phase", "ACCELERATING"},
-    {"BendP", "ref_geometry", "arc"},
-    {"BendP", "multipole_geometry", "follows_ref_geometry"},
+    {"BendP", "ref_geometry", "ARC"},
+    {"BendP", "multipole_geometry", "FOLLOWS_REF_GEOMETRY"},
     {"ApertureP", "shape", "ELLIPTICAL"},
     {"ApertureP", "location", "ENTRANCE_END"},
     {"ApertureP", "aperture_active", "true"},

--- a/tests/test_bookkeeper.cpp
+++ b/tests/test_bookkeeper.cpp
@@ -400,9 +400,9 @@ TEST_CASE("Bookkeeper derives all bend strength forms from the angle",
 
     // The non-zero enum defaults of the present BendP group are made explicit.
     YAMLNodeId bp = get_child_by_key(t, find_by_key(t, "b1"), "BendP");
-    REQUIRE(val_eq(t, get_child_by_key(t, bp, "ref_geometry"), "arc"));
+    REQUIRE(val_eq(t, get_child_by_key(t, bp, "ref_geometry"), "ARC"));
     REQUIRE(val_eq(t, get_child_by_key(t, bp, "multipole_geometry"),
-                   "follows_ref_geometry"));
+                   "FOLLOWS_REF_GEOMETRY"));
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);


### PR DESCRIPTION
bend.md now writes its enum values in upper case, matching the convention
already followed by aperture.md, rf.md and fork.md. The BendP entries in
kGroupDefaults were the last two lower case values in the table, so the
expanded lattice held `ref_geometry: arc` where every other group held an
upper case default.

The checker validates key names, never values, so nothing else in the
library reads these; the bookkeeper test that pins the materialized
defaults is updated alongside.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
