### PR TITLE
Default the bend actual field from g_ref

### DIFF
--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -1970,6 +1970,51 @@ static void resolve_bend(ryml::Tree& t, size_t ele, double& length,
     get_num_child(t, ele, "length", length);
 }
 
+// Default the actual bending field from the reference one (bend.md,
+// `Kn0_from_g_ref`). The field the particle actually sees is the dipole
+// component of MagneticMultipoleP, and unless the author says otherwise a bend
+// bends its own reference particle along the reference curve: `Kn0` = `g_ref`,
+// equivalently `Bn0` = `Bn0_ref`. `Kn0_from_g_ref: false` leaves the component
+// alone, for a bend whose actual field is zero or comes from somewhere else.
+//
+// All four forms of the dipole component count as "set" -- `Kn0L` and `Bn0L`
+// state the same field as `Kn0` and `Bn0`, only integrated over the length --
+// and only the normal ones: a skew dipole is a separate component, not this one.
+// The group is created when the default applies to a bend that carries none,
+// since otherwise the field would have nowhere to go. Whichever form is written
+// here, resolve_magnetic_multipoles fills the other three next.
+static void resolve_bend_actual_field(ryml::Tree& t, size_t ele) {
+    size_t bp = t.find_child(ele, ryml::to_csubstr("BendP"));
+    if (bp == ryml::NONE) return;
+    std::string flag = child_val_str(t, bp, "Kn0_from_g_ref");
+    if (!flag.empty() && !is_true_flag(flag)) return;  // absent means true
+
+    size_t mp = t.find_child(ele, ryml::to_csubstr("MagneticMultipoleP"));
+    if (mp != ryml::NONE)
+        for (const char* k : {"Kn0", "Kn0L", "Bn0", "Bn0L"})
+            if (t.find_child(mp, ryml::to_csubstr(k)) != ryml::NONE) return;
+
+    // g_ref and Bn0_ref are tied together by the curvature linking above, so
+    // g_ref is the one to take whenever the reference momentum was known;
+    // Bn0_ref carries the field when it was not. A zero reference bend field is
+    // no field at all, and a zero is not held.
+    double g = 0.0, B = 0.0;
+    const char* key = nullptr;
+    double value = 0.0;
+    if (get_num_child(t, bp, "g_ref", g) && g != 0.0) {
+        key = "Kn0";
+        value = g;
+    } else if (get_num_child(t, bp, "Bn0_ref", B) && B != 0.0) {
+        key = "Bn0";
+        value = B;
+    }
+    if (!key) return;
+
+    if (mp == ryml::NONE)
+        mp = find_or_add_map_child(t, ele, "MagneticMultipoleP");
+    set_num_child(t, mp, key, value);
+}
+
 // Split a multipole component key into its (normal/skew char, order digits),
 // e.g. "Bn2L" -> ('n', "2"). `prefixes` is the pair of accepted leading tokens
 // (magnetic "Bn"/"Bs"/"Kn"/"Ks" collapse to the field forms here; electric
@@ -2087,8 +2132,11 @@ static void compute_dependent(ryml::Tree& t, size_t ele, const std::string& kind
     }
 
     std::string ename = ele_name(t, ele);
-    if (kind == "Bend")
+    if (kind == "Bend") {
         resolve_bend(t, ele, length, has_factor, factor, ename, problems);
+        // Before the multipoles: this seeds the dipole component they resolve.
+        resolve_bend_actual_field(t, ele);
+    }
     resolve_magnetic_multipoles(t, ele, length, has_factor, factor, ename,
                                 problems);
     resolve_electric_multipoles(t, ele, length, ename, problems);
@@ -2120,9 +2168,11 @@ static void compute_rf_dependent(ryml::Tree& t, size_t ele, double length,
 // Parameters with a non-zero (or enum/boolean) default, filled in for any group
 // that is *present* in the element. The expanded lattice holds every non-zero
 // parameter, so an author who writes a group but omits these gets the defaults
-// made explicit. A group absent from the element is left untouched -- only
-// ReferenceP and FloorP are added by the parser. Parameters whose default is
-// zero/null/false are not listed: they are not "held".
+// made explicit. A group absent from the element is left untouched -- it is
+// added only by the parser (ReferenceP, FloorP) or to hold a derived value with
+// nowhere else to go (MagneticMultipoleP on a curved bend, see
+// resolve_bend_actual_field). Parameters whose default is zero/null/false are
+// not listed: they are not "held".
 struct GroupDefault {
     const char* group;
     const char* key;
@@ -2133,6 +2183,7 @@ static const GroupDefault kGroupDefaults[] = {
     {"RFP", "zero_phase", "ACCELERATING"},
     {"BendP", "ref_geometry", "ARC"},
     {"BendP", "multipole_geometry", "FOLLOWS_REF_GEOMETRY"},
+    {"BendP", "Kn0_from_g_ref", "true"},
     {"ApertureP", "shape", "ELLIPTICAL"},
     {"ApertureP", "location", "ENTRANCE_END"},
     {"ApertureP", "aperture_active", "true"},

--- a/tests/test_bookkeeper.cpp
+++ b/tests/test_bookkeeper.cpp
@@ -613,6 +613,162 @@ TEST_CASE("Bookkeeper flags an inconsistent bend strength", "[bookkeeper]") {
     delete_tree(lat.leftover);
 }
 
+TEST_CASE("Bookkeeper defaults the bend actual field from g_ref",
+          "[bookkeeper]") {
+    // Kn0_from_g_ref (bend.md) is true by default, so a bend that says nothing
+    // about its actual field bends its own reference particle along the
+    // reference curve: Kn0 = g_ref. The element carries no MagneticMultipoleP,
+    // so the group is created to hold it, and the other three forms of the
+    // dipole component follow as usual.
+    struct lattices lat = expand_src(one_ele_yaml(
+        "          - bnd:\n"
+        "              kind: Bend\n"
+        "              length: 2.0\n"
+        "              BendP:\n"
+        "                g_ref: 0.1\n"));
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0"), 0.1));
+    REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0L"), 0.2));
+    REQUIRE(close_rel(param_num(t, "bnd", "MagneticMultipoleP", "Bn0"),
+                      0.1 / electron_factor()));
+    REQUIRE(close_rel(param_num(t, "bnd", "MagneticMultipoleP", "Bn0L"),
+                      0.2 / electron_factor()));
+    // The flag itself is a non-false default of a present group, so it is made
+    // explicit alongside the enum defaults.
+    YAMLNodeId bp = get_child_by_key(t, find_by_key(t, "bnd"), "BendP");
+    REQUIRE(val_eq(t, get_child_by_key(t, bp, "Kn0_from_g_ref"), "true"));
+    REQUIRE_FALSE(any_problem_contains(lat, "inconsistent"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper writes no actual field when Kn0_from_g_ref is false",
+          "[bookkeeper]") {
+    // The author has said the actual field is not the reference one. Nothing is
+    // written, and the bend keeps no multipole group at all.
+    struct lattices lat = expand_src(one_ele_yaml(
+        "          - bnd:\n"
+        "              kind: Bend\n"
+        "              length: 2.0\n"
+        "              BendP:\n"
+        "                g_ref: 0.1\n"
+        "                Kn0_from_g_ref: false\n"));
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(get_child_by_key(t, find_by_key(t, "bnd"),
+                             "MagneticMultipoleP") == YAML_NULL_ID);
+    // The reference bend is untouched: only the actual field is being declined.
+    REQUIRE(close(param_num(t, "bnd", "BendP", "angle_ref"), 0.2));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper keeps an actual bend field the author set",
+          "[bookkeeper]") {
+    // Kn0 is set to something other than g_ref -- a bend running off its
+    // reference field, which is exactly what the parameters are separate for.
+    // The default does not apply, and the difference is not an inconsistency.
+    struct lattices lat = expand_src(one_ele_yaml(
+        "          - bnd:\n"
+        "              kind: Bend\n"
+        "              length: 2.0\n"
+        "              BendP:\n"
+        "                g_ref: 0.1\n"
+        "              MagneticMultipoleP:\n"
+        "                Kn0: 0.3\n"));
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0"), 0.3));
+    REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0L"), 0.6));
+    REQUIRE(close(param_num(t, "bnd", "BendP", "g_ref"), 0.1));
+    REQUIRE_FALSE(any_problem_contains(lat, "inconsistent"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper counts an integrated actual field as set",
+          "[bookkeeper]") {
+    // Kn0L states the same field as Kn0, just integrated over the length, so
+    // the default does not apply: Kn0 comes from Kn0L / length = 0.3, not from
+    // g_ref. A Kn0 of 0.1 here would have contradicted the author's own value.
+    struct lattices lat = expand_src(one_ele_yaml(
+        "          - bnd:\n"
+        "              kind: Bend\n"
+        "              length: 2.0\n"
+        "              BendP:\n"
+        "                g_ref: 0.1\n"
+        "              MagneticMultipoleP:\n"
+        "                Kn0L: 0.6\n"));
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0"), 0.3));
+    REQUIRE_FALSE(any_problem_contains(lat, "inconsistent"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper adds the actual field to a group of other multipoles",
+          "[bookkeeper]") {
+    // A different order says nothing about the dipole component: the quadrupole
+    // the author gave stays, and Kn0 joins it in the group already there.
+    struct lattices lat = expand_src(one_ele_yaml(
+        "          - bnd:\n"
+        "              kind: Bend\n"
+        "              length: 2.0\n"
+        "              BendP:\n"
+        "                g_ref: 0.1\n"
+        "              MagneticMultipoleP:\n"
+        "                Kn1: 0.5\n"));
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0"), 0.1));
+    REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn1"), 0.5));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("Bookkeeper gives a straight bend no actual field", "[bookkeeper]") {
+    // No curvature, so there is no reference field to copy and nothing to hold:
+    // a zero Kn0 is not written, and no group is created for it.
+    struct lattices lat = expand_src(one_ele_yaml(
+        "          - bnd:\n"
+        "              kind: Bend\n"
+        "              length: 2.0\n"
+        "              BendP:\n"
+        "                e1: 0.01\n"));
+    YAMLTreeHandle t = lat.expanded;
+
+    REQUIRE(get_child_by_key(t, find_by_key(t, "bnd"),
+                             "MagneticMultipoleP") == YAML_NULL_ID);
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
 TEST_CASE("Bookkeeper flags an inconsistent multipole component",
           "[bookkeeper]") {
     // Bn1 1.2 over length 0.5 implies Bn1L 0.6, but Bn1L is set to 0.5.
@@ -654,7 +810,8 @@ TEST_CASE("Bookkeeper materializes RF enum defaults and L_active",
 
 TEST_CASE("Bookkeeper leaves absent parameter groups alone", "[bookkeeper]") {
     // Groups not present in the file are not materialized: a plain drift gains no
-    // BendP/RFP/multipole groups. Only ReferenceP and FloorP are parser-added.
+    // BendP/RFP/multipole groups. Only ReferenceP and FloorP are parser-added,
+    // and MagneticMultipoleP on a curved bend, which has an actual field to hold.
     struct lattices lat = expand_bookkeeper();
     YAMLTreeHandle t = lat.expanded;
     YAMLNodeId d1 = find_by_key(t, "d1");


### PR DESCRIPTION
Implements the `Kn0_from_g_ref` defaulting of `bend.md`, the behavior that replaced the `g_actual` / `bend_field_actual` pair retired in #72.

Unless the author says otherwise, a bend bends its own reference particle along the reference curve, so the actual bending field is the reference one: `Kn0` = `g_ref` (equivalently `Bn0` = `Bn0_ref`). `resolve_bend_actual_field` runs between the bend and multipole resolvers, seeding the dipole component that `resolve_magnetic_multipoles` then completes into all four forms.

```yaml
b1:
  kind: Bend
  length: 1.5
  BendP:
    g_ref: 0.1
    Kn0_from_g_ref: true    # materialized default
    ...
  MagneticMultipoleP:       # created to hold the actual field
    Kn0: 0.1
    Kn0L: 0.15000000000000002
    Bn0: -0.33356405164803304
    Bn0L: -0.5003460774720496
```

The default stands down whenever the author has stated the field: any of `Kn0`, `Kn0L`, `Bn0`, `Bn0L` counts, since the integrated forms say the same thing over the length. A skew dipole does not — that is a different component. `Kn0_from_g_ref: false` declines the default outright, and a straight bend has no reference field to copy, so nothing is written and no group appears.

Two notes on where things land:

- **`MagneticMultipoleP` is created on a curved bend that carries none.** That is a third exception to "an absent group is left untouched", after the parser-added `ReferenceP` and `FloorP`; without it the default would be unobservable, since the common bend writes no multipole group at all. The comment on `kGroupDefaults` and the "leaves absent parameter groups alone" test both now say so.
- **`Kn0_from_g_ref: true` joins `kGroupDefaults`**, a non-false default of a group the element already carries, alongside `ref_geometry: ARC`.

Six new bookkeeper tests: the default itself, the `false` setting, an author-set `Kn0` kept as-is, `Kn0L` counting as set, the field joining a group of other orders, and the straight bend. 174 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
