### PR TITLE
Apply controllers and implement set commands during lattice expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Pals-cpp is the parser library for PALS accelerator lattice files. It uses rapid
 5. Elements in a lattice defined outside of it will have their definitions brought it.
 6. Fork elements will create new branches in the lattice to their destination branch. 
 7. Mathematical expressions are evaluated to numbers (see below).
+8. `set` commands are executed and controllers are applied to the parameters they drive, on either side of an `expand_lattice` node (see below).
 
 ## Expression Evaluation
 As a final step of expansion, every scalar value in the `expanded` tree that is a
@@ -31,14 +32,18 @@ is right-associative, so `2^3^2` is `2^(3^2) = 512`; and a unary sign binds
 ecosystem.
 
 **Controllers.** A `kind: Controller` element bundles expressions that drive
-lattice parameters. Its `variables:` form a controller-scoped symbol table
-(variables may reference earlier variables of the same controller and, via the
-`controller>variable` syntax, variables of another controller), and each entry
-in `controls:` pairs a `parameter` target with an `expression`. Controller
-`variables` and control `expression`s are evaluated against that scoped table
-(rather than the global one), and each control `expression` is computed and its
-value written into the control entry. The `parameter` target specs and
-`control_type` are names and are left untouched.
+lattice parameters. Its `variables:` form a controller-scoped symbol table —
+each initial value is a constant expression (constants and functions only, no
+variables), and each entry in `controls:` pairs a `parameter` target — a
+name-matching string — with an `expression` over that controller's own
+variables, reaching nothing outside the controller. `control_type:
+ABSOLUTE` (the default) means the controllers determine the parameter outright,
+so during expansion each matched parameter is set to the sum of the values of
+every ABSOLUTE controller driving it; `control_type: RELATIVE` describes a knob
+the simulation program varies afterwards and so changes nothing at expansion.
+A controller may also drive another controller's variable, named
+`controller>variable`, which makes controllers a hierarchy evaluated from the
+top down. See [Evaluating expressions](docs/src/guide/expressions.md).
 
 The particle-data functions `mass_of`, `charge_of`, and `anomalous_moment_of` take
 a quoted species name (e.g. `mass_of("#3He")`); an unquoted name is an error. A
@@ -48,6 +53,17 @@ functions and the physical values behind the named constants are provided by
 (a C++ mirror of [AtomicAndPhysicalConstants.jl](https://github.com/bmad-sim/AtomicAndPhysicalConstants.jl)),
 fetched automatically by CMake. A single expression can also be evaluated on its
 own via `evaluate_pals_expression()`.
+
+**Set commands.** A `set` writes a value into every parameter its `parameter`
+name-matching string selects; in the `value` expression `PARAMETER` is the
+current value and `SELF` the element that owns it
+(`value: 2*PARAMETER + atan(SELF.BendP.g_ref)`). The compact `sets:` form is a
+list of `target: value` pairs. An `expand_lattice` node in the `facility` list
+decides what a set acts on: before it, the element *definitions* (and only those
+defined earlier in the list); after it, the already-expanded lattice, so each
+copy of a repeated element is written separately. `absolute_error` and
+`relative_error` are reported rather than applied — the standard does not
+specify the error distribution.
 
 ## Usage
 First, to build, run the following in the root directory:  
@@ -100,8 +116,9 @@ The library sources live in `src/`, split by concern:
   low-level tree helpers (`ensure_capacity`, `deep_copy_recursive`).
 - `pals_expand.cpp` — the lattice expansion pipeline that builds the four-tree
   representation (`original` / `combined` / `expanded` / `leftover`): include
-  splicing, structural expansion (repeats, inherits, forks), expression /
-  controller evaluation, and the element bookkeeper that walks each branch
+  splicing, structural expansion (repeats, inherits, forks), expression,
+  controller and `set` evaluation, and the element bookkeeper that walks each
+  branch
   filling in reference parameters, floor placement, s-positions and dependent
   parameters.
 - `pals_check.{h,cpp}` — spelling checks against the fixed PALS vocabulary

--- a/docs/src/guide/expressions.md
+++ b/docs/src/guide/expressions.md
@@ -160,9 +160,7 @@ A `Controller` element bundles expressions that drive lattice parameters. Its
 `variables:` form a symbol table *scoped to that controller*, and each
 `controls:` entry pairs a `parameter` target with an `expression`. During
 expansion the controller variables are evaluated against that scoped table, and
-each control `expression` is computed and written back into its control entry.
-Controller variables may reference one another and, via the
-`controller>variable` syntax, variables of another controller:
+each control `expression` is computed and written back into its control entry:
 
 ```yaml
 - ps27:
@@ -170,14 +168,157 @@ Controller variables may reference one another and, via the
     control_type: ABSOLUTE
     variables:
       cur1: 0.023
-      cur2: cur1 / c_light      # references an earlier controller variable
+      cur2: 1e8 / c_light       # a constant expression, as initial values are
     controls:
       - parameter: Qa.*>MagneticMultipoleP.Ks2L
         expression: 0.075*sin(cur1) + 0.3*cur2   # → a number in `expanded`
 ```
 
-The `parameter` target specification and `control_type` are names, not
-expressions, and are left untouched.
+A variable's **initial value is a constant expression**: it may use the built-in
+and user-defined constants and the functions, but no variable at all — not even
+another variable of the same controller. That is what makes the initial values
+independent of the order they are written in. A variable written with no value
+is zero.
+
+A control **`expression` uses its own controller's variables**, and nothing from
+outside the controller: neither an initial value nor a control expression may
+reference a lattice parameter or another controller's variable. Both of those
+are spelled with `>`, and keeping them out is what makes the evaluation order
+well defined. The `parameter` target specification and `control_type` are names,
+not expressions, and are left untouched.
+
+### How controllers are applied
+
+The `parameter` target is a [name-matching string](../api.md#name-matching), so one entry
+drives every element it matches. What happens to those parameters depends on
+`control_type`:
+
+- **`ABSOLUTE`** (the default, materialized into the tree when the key is
+  omitted) means the controllers determine the parameter outright. Each matched
+  parameter is set to the **sum** of the values of every ABSOLUTE controller
+  driving it, replacing whatever the element itself gave. A parameter the
+  element does not carry is created, group and all.
+- **`RELATIVE`** describes a knob — an orbit bump, a chromaticity family —
+  whose *changes* the simulation program applies after the file is read. It
+  changes nothing during expansion: the parameter keeps the value its element
+  gives, and only the control expression is evaluated, for the program's use.
+
+The controllers are applied after the branches are expanded and before the
+element bookkeeper runs, so the reference, floor and dependent parameters are
+computed from the driven values — a driven `Kn1L` yields the matching `Bn1L`.
+
+A controller may also drive another controller's variable, which is named
+`controller>variable`:
+
+```yaml
+- high:
+    kind: Controller
+    variables:
+      knob: 3
+    controls:
+      - parameter: low>cur       # a variable of the `low` controller
+        expression: knob / 4
+```
+
+Controllers therefore form a hierarchy, which is evaluated from the top
+downwards; a driven variable takes its driving value instead of its own initial
+value. The order controllers are written in the file does not matter. These are
+reported as problems: a circular control hierarchy, a parameter driven by both
+an ABSOLUTE and a RELATIVE controller, a parameter that is both controlled and
+assigned a delayed (`expr(...)`) expression, a target that matches nothing in
+the expanded lattice, and a `control_type` that is neither `ABSOLUTE` nor
+`RELATIVE`.
+
+A control expression containing `random()`/`random_gauss()` is deferred like any
+other, keeping its text — and so drives nothing, leaving the expanded tree
+reproducible.
+
+## Set commands
+
+A `set` writes a value into every parameter its `parameter` name-matching string
+selects. In the `value` expression, `PARAMETER` stands for the current value of
+the parameter being written and `SELF` for the element that owns it:
+
+```yaml
+- set:
+    parameter: B1.*>BendP.e1
+    value: 2*PARAMETER + atan(SELF.BendP.g_ref)
+```
+
+Pattern matching applies to the `parameter` target only, never inside `value`.
+The compact form is a list of `target: value` pairs with no error terms:
+
+```yaml
+- sets:
+    - Q1>MagneticMultipoleP.Kn1L: 0.25
+    - D1>length: 2 * 1.5
+```
+
+A parameter of a known element that has not been written reads as **zero**, so
+`PARAMETER + 0.02` works on an element that carries no such group yet — the
+group is created. The exception is a parameter that is *still to be derived*:
+if any member of its linked family is written (the four interchangeable forms
+`BnN`/`BnNL`/`KnN`/`KnNL` of a magnetic multipole component, the two forms of an
+electric one, or the tied BendP geometry), then its value comes from the
+bookkeeper and reading it before that is an error:
+
+```yaml
+- Q1:
+    kind: Quadrupole
+    MagneticMultipoleP:
+      Ks1: 0.34
+- set:
+    parameter: Q2>MagneticMultipoleP.Bs1
+    value: Q1>MagneticMultipoleP.Bs1   # error: Bs1 needs the reference momentum
+```
+
+`absolute_error` and `relative_error` are read but **not applied**: the standard
+gives the error magnitude (`absolute_error + relative_error * |value|`) but not
+its distribution, and this library never invents randomness. The deterministic
+`value` is written and a problem is reported. A `value` that itself calls
+`random()`/`random_gauss()` is deferred like any other, leaving its parameter
+untouched.
+
+### `expand_lattice` and where a set acts
+
+An `expand_lattice` node divides the `facility` list in two, and which side a
+set sits on decides what it writes:
+
+```yaml
+facility:
+  - q1:
+      kind: Quadrupole
+      MagneticMultipoleP:
+        Kn1L: 0.375
+  - bline:
+      kind: BeamLine
+      line:
+        - q1:
+            repeat: 3
+  - lat: {kind: Lattice, branches: bline}
+
+  - expand_lattice
+
+  - set:
+      parameter: lat>>>q1>MagneticMultipoleP.Kn1L
+      value: PARAMETER * (1 + 1e-4*random_gauss())
+```
+
+- **Before** `expand_lattice` a set acts on the element *definitions*, and only
+  on those defined earlier in the list — an element defined after it is
+  untouched. One definition is written once, so all three copies of `q1` would
+  inherit the same value.
+- **After** `expand_lattice` a set acts on the already-expanded lattice, so each
+  of the three copies is a separate element and is written separately. The
+  bookkeeper has already run at this point, so a value may use computed
+  parameters such as `SELF.s_position`.
+
+The full expansion order is: pre-expansion sets → branch and fork expansion →
+ABSOLUTE controllers → bookkeeper → post-expansion sets → ABSOLUTE controllers
+again → bookkeeper again. Applying the controllers last is what keeps a
+controller authoritative over a parameter a later set also writes; the second
+bookkeeper pass recomputes the reference, floor and s-position values, and the
+family members a post-expansion set invalidated.
 
 ## Evaluating a single expression
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,13 +34,15 @@ document:
    inline.
 3. **`expanded`** — the selected lattice fully expanded, and nothing else:
    elements substituted with their definitions, `repeat`ed beamlines unrolled,
-   `inherit`ed ancestors merged, forks resolved, and every mathematical
-   expression evaluated to a number. It is rooted at the lattice entry itself,
-   without the `PALS`/`facility` scaffolding it was defined under.
+   `inherit`ed ancestors merged, forks resolved, every mathematical expression
+   evaluated to a number, `set` commands executed, and the ABSOLUTE controllers
+   applied to the parameters they drive. It is rooted at the lattice entry
+   itself, without the `PALS`/`facility` scaffolding it was defined under.
 4. **`leftover`** — everything the expanded tree does not carry, keeping that
    scaffolding: element and beamline definitions, `use` statements, constants,
-   controllers, and any lattice that was not the one expanded. A definition
-   substituted into the lattice is copied, so it appears in both views.
+   controllers, `set` commands, and any lattice that was not the one expanded.
+   A definition substituted into the lattice is copied, so it appears in both
+   views.
 
 See [Building and using the library](guide/usage.md) to get started,
 [Evaluating expressions](guide/expressions.md) for the expression grammar and

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -1,9 +1,9 @@
 // PALS lattice expansion pipeline: builds the four-tree representation
 // (original / combined / expanded / leftover) from a PALS YAML file. Splices
-// includes, expands the selected lattice (repeats, inherits, forks), and
-// evaluates expression/controller values into the expanded tree. Name matching
-// and parameter lookup live in pals_match.cpp; the generic YAML tree wrapper in
-// yaml_c_wrapper.cpp.
+// includes, expands the selected lattice (repeats, inherits, forks), evaluates
+// expressions into the expanded tree, and applies the controllers that drive
+// its parameters. Name matching and parameter lookup live in pals_match.cpp;
+// the generic YAML tree wrapper in yaml_c_wrapper.cpp.
 
 #include "yaml_c_wrapper.h"
 #include "yaml_tree.h"
@@ -1008,12 +1008,107 @@ static std::string format_double(double v) {
     return std::string(buf);
 }
 
+// ------------------------------------------------------------
+// Tree-writing helpers, shared by the controller pass and the element
+// bookkeeper: both fill parameters into element definitions, creating the
+// enclosing parameter group when it is not already there.
+// ------------------------------------------------------------
+
+// A keyed sequence child of `parent`, created (empty) if absent.
+static size_t find_or_add_seq_child(ryml::Tree& t, size_t parent,
+                                    const char* key) {
+    size_t c = t.find_child(parent, ryml::to_csubstr(key));
+    if (c != ryml::NONE) return c;
+    ensure_capacity(t, 2);
+    c = t.append_child(parent);
+    t.ref(c) |= ryml::KEY | ryml::SEQ;
+    t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+    return c;
+}
+
+// A keyed map child of `parent`, created (empty) if absent. An existing scalar
+// placeholder of the same key is converted to a map in place.
+static size_t find_or_add_map_child(ryml::Tree& t, size_t parent,
+                                    const char* key) {
+    size_t c = t.find_child(parent, ryml::to_csubstr(key));
+    if (c != ryml::NONE) {
+        if (!t.is_map(c)) {
+            t.change_type(c, ryml::KEYMAP);
+            t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+        }
+        return c;
+    }
+    ensure_capacity(t, 2);
+    c = t.append_child(parent);
+    t.ref(c) |= ryml::KEY | ryml::MAP;
+    t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+    return c;
+}
+
+// Set (or create) a keyed scalar child to the shortest round-tripping decimal.
+static void set_num_child(ryml::Tree& t, size_t parent, const char* key,
+                          double v) {
+    size_t c = t.find_child(parent, ryml::to_csubstr(key));
+    if (c == ryml::NONE) {
+        ensure_capacity(t, 2);
+        c = t.append_child(parent);
+        t.ref(c) |= ryml::KEY | ryml::VAL;
+        t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+    }
+    t.set_val(c, t.to_arena(ryml::to_csubstr(format_double(v))));
+}
+
+// Overwrite a scalar value node in place with a number.
+static void set_scalar_num(ryml::Tree& t, size_t node, double v) {
+    t.set_val(node, t.to_arena(ryml::to_csubstr(format_double(v))));
+}
+
+// Set (or create) a keyed scalar child to a string. Double-quoted so a leading
+// '#' in a species name survives YAML's comment rule on re-emit.
+static void set_str_child(ryml::Tree& t, size_t parent, const char* key,
+                          const std::string& v) {
+    size_t c = t.find_child(parent, ryml::to_csubstr(key));
+    if (c == ryml::NONE) {
+        ensure_capacity(t, 2);
+        c = t.append_child(parent);
+        t.ref(c) |= ryml::KEY | ryml::VAL;
+        t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+    }
+    t.set_val(c, t.to_arena(ryml::to_csubstr(v)));
+    t.set_val_style(c, ryml::VAL_DQUO);
+}
+
+// Set (or create) a keyed scalar child to a bare (unquoted) token. Used for
+// enum and boolean defaults (e.g. `cavity_type: STANDING_WAVE`, `direction:
+// FORWARDS`, `aperture_active: true`), which are plain YAML scalars, not strings.
+static void set_plain_child(ryml::Tree& t, size_t parent, const char* key,
+                            const char* v) {
+    size_t c = t.find_child(parent, ryml::to_csubstr(key));
+    if (c == ryml::NONE) {
+        ensure_capacity(t, 2);
+        c = t.append_child(parent);
+        t.ref(c) |= ryml::KEY | ryml::VAL;
+        t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+    }
+    t.set_val(c, t.to_arena(ryml::to_csubstr(v)));
+}
+
 // True if `node` is a map defining a `kind: Controller` element.
 static bool is_controller(const ryml::Tree& t, size_t node) {
     if (node == ryml::NONE || !t.is_map(node)) return false;
     size_t kind = t.find_child(node, ryml::to_csubstr("kind"));
     if (kind == ryml::NONE || !t.has_val(kind)) return false;
     return t.val(kind) == ryml::to_csubstr("Controller");
+}
+
+// True if `node` is a facility `set` or `sets` node. Their `parameter` targets
+// are name-matching strings and their `value`s are expressions evaluated once
+// per matched element, both handled by the set pass, so the generic pass has to
+// leave the whole subtree alone.
+static bool is_set_node(const ryml::Tree& t, size_t node) {
+    if (node == ryml::NONE || !t.has_key(node)) return false;
+    ryml::csubstr k = t.key(node);
+    return k == ryml::to_csubstr("set") || k == ryml::to_csubstr("sets");
 }
 
 // Collects user constant/variable definitions (name -> defining expression),
@@ -1088,15 +1183,16 @@ static bool looks_like_expression(const std::string& body, bool was_expr) {
 }
 
 // Replaces every evaluable scalar value in the subtree with its numeric value.
-// Controller subtrees are skipped: their variables and control expressions use
-// a controller-scoped symbol table and are handled by evaluate_controllers.
+// Controller and `set` subtrees are skipped: their expressions are evaluated
+// against a scope of their own, by evaluate_controllers and execute_set.
 // A value that looks like an expression but cannot be evaluated is recorded in
 // `problems`.
 static void substitute_values(ryml::Tree& t, size_t node,
                               const pals::SymbolLookup& resolve,
                               const pals::SpeciesLookup& species,
                               ProblemList& problems) {
-    if (node == ryml::NONE || is_controller(t, node)) return;
+    if (node == ryml::NONE || is_controller(t, node) || is_set_node(t, node))
+        return;
 
     if (t.has_val(node)) {
         bool skip = false;
@@ -1156,154 +1252,494 @@ static void collect_controllers(const ryml::Tree& t, size_t node,
 
 // A controller `variables` entry awaiting evaluation.
 struct CtrlVar {
-    size_t node;         // scalar value node to overwrite in place
-    size_t ctrl;         // index into the controllers vector
-    std::string qname;   // fully-qualified name, `controller>variable`
-    std::string bare;    // unqualified name, as used within the controller
-    std::string text;    // defining expression
+    size_t node = ryml::NONE;  // scalar value node to overwrite in place
+    size_t ctrl = 0;           // index into the controllers vector
+    std::string name;          // unqualified name, as used in the controller
+    std::string text;          // initial-value expression ("" = the default, 0)
     bool done = false;
+    // Set when an ABSOLUTE controller above this one in the hierarchy drives
+    // this variable: the driving value replaces the initial value.
+    bool driven = false;
+    double driven_value = 0.0;
+};
+
+// A controller `controls` entry: a `parameter` target and the `expression`
+// giving the value it is driven to.
+struct CtrlControl {
+    size_t expr_node = ryml::NONE;  // `expression` scalar, rewritten in place
+    std::string param;              // `parameter` target spec
+    std::string text;               // expression source
+    bool ok = false;                // evaluated to a number
+    double value = 0.0;
+    // Set when `param` names another controller's variable rather than a
+    // lattice parameter; that is what makes controllers a hierarchy.
+    size_t target_ctrl = SIZE_MAX;
+    std::string target_var;
+};
+
+// One `kind: Controller` element.
+struct Ctrl {
+    size_t node = ryml::NONE;
+    std::string name;
+    bool absolute = true;      // control_type: ABSOLUTE, the default
+    std::vector<size_t> vars;  // indices into the flat CtrlVar list
+    std::vector<CtrlControl> controls;
 };
 
 // Iterates the `variables` of a controller, in both the documented map form
 // (`cur1: 0.023`) and the compact seq-of-single-key-maps form, invoking `emit`
-// with each (name, value-node) pair.
+// with each (name, value-node) pair. A variable written with no value at all
+// (`cur1:`) is emitted too: its value is the default, zero.
 template <typename F>
 static void for_each_ctrl_var(const ryml::Tree& t, size_t vars, F&& emit) {
+    auto visit = [&](size_t kv) {
+        if (t.has_key(kv) && !t.is_map(kv) && !t.is_seq(kv))
+            emit(std::string(t.key(kv).str, t.key(kv).len), kv);
+    };
     if (vars == ryml::NONE) return;
     if (t.is_map(vars)) {
         for (size_t kv = t.first_child(vars); kv != ryml::NONE;
              kv = t.next_sibling(kv))
-            if (t.has_key(kv) && t.has_val(kv))
-                emit(std::string(t.key(kv).str, t.key(kv).len), kv);
+            visit(kv);
     } else if (t.is_seq(vars)) {
         for (size_t el = t.first_child(vars); el != ryml::NONE;
              el = t.next_sibling(el))
             for (size_t kv = t.first_child(el); kv != ryml::NONE;
                  kv = t.next_sibling(kv))
-                if (t.has_key(kv) && t.has_val(kv))
-                    emit(std::string(t.key(kv).str, t.key(kv).len), kv);
+                visit(kv);
     }
 }
 
-// Evaluates controllers. Each controller's `variables` form a controller-scoped
-// symbol table (variables may reference earlier variables of the same
-// controller and, via the `controller>variable` syntax, variables of another
-// controller). Once the tables are resolved, every control `expression` is
-// computed with its controller's table and the numeric value is written into
-// the control entry. Controller expressions are "delayed" in the standard, but
-// per the PALS expansion model the expanded tree carries the computed value.
-static void evaluate_controllers(ryml::Tree& t,
-                                 const pals::SymbolLookup& global_resolve,
-                                 const pals::SpeciesLookup& species,
-                                 ProblemList& problems) {
-    std::vector<size_t> controllers;
-    collect_controllers(t, t.root_id(), controllers);
-    if (controllers.empty()) return;
+// Trimmed scalar value of a node; "" when the node holds nothing. A YAML null
+// (`~`, `null`) reads as "no value given" the same as an empty scalar does.
+static std::string scalar_text(const ryml::Tree& t, size_t node) {
+    if (node == ryml::NONE || !t.has_val(node)) return "";
+    std::string v(t.val(node).str, t.val(node).len);
+    size_t a = v.find_first_not_of(" \t\r\n");
+    if (a == std::string::npos) return "";
+    v = v.substr(a, v.find_last_not_of(" \t\r\n") - a + 1);
+    if (v == "~" || v == "null") return "";
+    return v;
+}
 
-    std::vector<std::string> names(controllers.size());
-    for (size_t i = 0; i < controllers.size(); ++i)
-        if (t.has_key(controllers[i]))
-            names[i].assign(t.key(controllers[i]).str,
-                            t.key(controllers[i]).len);
+// The identifiers appearing in an expression: maximal runs of name characters
+// that do not start with a digit. Used to spot a name an expression is not
+// allowed to use, which a plain substring search would get wrong (`c_light`
+// does not reference a variable named `light`).
+static std::vector<std::string> expression_identifiers(const std::string& s) {
+    std::vector<std::string> out;
+    auto name_char = [](char c) {
+        return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+    };
+    for (size_t i = 0; i < s.size();) {
+        if (!name_char(s[i])) {
+            ++i;
+            continue;
+        }
+        size_t j = i;
+        while (j < s.size() && name_char(s[j])) ++j;
+        if (!std::isdigit(static_cast<unsigned char>(s[i])))
+            out.push_back(s.substr(i, j - i));
+        i = j;
+    }
+    return out;
+}
 
-    // Symbol tables, filled in as variables resolve.
-    std::vector<std::map<std::string, double>> locals(controllers.size());
-    std::map<std::string, double> qualified;  // `controller>variable` -> value
+// Reads every `kind: Controller` in the tree into `ctrls` (and their variables
+// into the flat `vars` list), materializing the `control_type` default and
+// rejecting the expressions the standard does not allow.
+static void collect_controller_defs(ryml::Tree& t, std::vector<Ctrl>& ctrls,
+                                    std::vector<CtrlVar>& vars,
+                                    ProblemList& problems) {
+    std::vector<size_t> nodes;
+    collect_controllers(t, t.root_id(), nodes);
 
-    // Resolver scoped to controller `ci`: unqualified names come from that
-    // controller's table, `>`-qualified names from any controller, and anything
-    // else falls through to the global resolver (built-in / user constants).
-    auto make_resolver = [&locals, &qualified, &global_resolve](
-                             size_t ci) -> pals::SymbolLookup {
-        return [ci, &locals, &qualified, &global_resolve](
-                   const std::string& name, double& out) -> bool {
-            if (name.find('>') != std::string::npos) {
-                auto it = qualified.find(name);
-                if (it == qualified.end()) return false;
-                out = it->second;
-                return true;
-            }
-            auto& lv = locals[ci];
-            auto it = lv.find(name);
-            if (it != lv.end()) {
-                out = it->second;
-                return true;
-            }
-            return global_resolve ? global_resolve(name, out) : false;
-        };
+    // Neither an initial value nor a control expression may reach outside its
+    // own controller (miscellaneous.md, s:controller). Every such reference --
+    // a lattice parameter, another controller's variable -- is spelled with
+    // `>`, so one test covers both, and it is what keeps evaluation order
+    // decidable from the `controls` hierarchy alone.
+    auto reject_refs = [&problems](const std::string& what,
+                                   const std::string& text) {
+        if (text.find('>') == std::string::npos) return false;
+        add_problem(problems,
+                    what + " may not reference a lattice parameter or another "
+                           "controller's variable: " + text);
+        return true;
     };
 
-    // Gather every variable definition across all controllers.
-    std::vector<CtrlVar> vars;
-    for (size_t ci = 0; ci < controllers.size(); ++ci) {
-        size_t vnode = t.find_child(controllers[ci], ryml::to_csubstr("variables"));
+    for (size_t node : nodes) {
+        Ctrl c;
+        c.node = node;
+        if (t.has_key(node)) c.name.assign(t.key(node).str, t.key(node).len);
+
+        std::string ct = scalar_text(t, t.find_child(node, ryml::to_csubstr(
+                                                               "control_type")));
+        if (ct.empty()) {
+            set_plain_child(t, node, "control_type", "ABSOLUTE");
+        } else if (ct == "RELATIVE") {
+            c.absolute = false;
+        } else if (ct != "ABSOLUTE") {
+            add_problem(problems, "controller '" + c.name +
+                                      "': control_type must be ABSOLUTE or "
+                                      "RELATIVE, not " + ct);
+        }
+
+        size_t vnode = t.find_child(node, ryml::to_csubstr("variables"));
         for_each_ctrl_var(t, vnode, [&](const std::string& vname, size_t vn) {
             CtrlVar v;
             v.node = vn;
-            v.ctrl = ci;
-            v.bare = vname;
-            v.qname = names[ci] + ">" + vname;
-            v.text = std::string(t.val(vn).str, t.val(vn).len);
+            v.ctrl = ctrls.size();
+            v.name = vname;
+            v.text = scalar_text(t, vn);
+            if (reject_refs("controller '" + c.name + "' variable '" + vname +
+                                "'",
+                            v.text))
+                v.text.clear();
+            c.vars.push_back(vars.size());
             vars.push_back(std::move(v));
         });
+
+        // An initial value may not name a variable at all, not even one of this
+        // controller's own: it is a constant expression, so no variable has to
+        // be evaluated before any other. Only the control `expression`s use the
+        // variables. Checked here, once every name of this controller is known,
+        // so it does not matter which order the variables are written in.
+        std::set<std::string> vnames;
+        for (size_t vi : c.vars) vnames.insert(vars[vi].name);
+        for (size_t vi : c.vars) {
+            for (const std::string& id : expression_identifiers(vars[vi].text)) {
+                if (!vnames.count(id)) continue;
+                add_problem(problems, "controller '" + c.name + "' variable '" +
+                                          vars[vi].name +
+                                          "': an initial value may not "
+                                          "reference the variable '" + id + "'");
+                vars[vi].text.clear();
+                break;
+            }
+        }
+
+        size_t controls = t.find_child(node, ryml::to_csubstr("controls"));
+        if (controls != ryml::NONE) {
+            for (size_t entry = t.first_child(controls); entry != ryml::NONE;
+                 entry = t.next_sibling(entry)) {
+                if (!t.is_map(entry)) continue;
+                CtrlControl cc;
+                cc.param = scalar_text(
+                    t, t.find_child(entry, ryml::to_csubstr("parameter")));
+                cc.expr_node = t.find_child(entry, ryml::to_csubstr("expression"));
+                cc.text = scalar_text(t, cc.expr_node);
+                if (cc.param.empty()) {
+                    add_problem(problems, "controller '" + c.name +
+                                              "': a controls entry has no "
+                                              "`parameter` target");
+                    continue;
+                }
+                if (cc.expr_node == ryml::NONE) {
+                    add_problem(problems,
+                                "controller '" + c.name + "': controls entry '" +
+                                    cc.param + "' has no `expression`");
+                    continue;
+                }
+                if (reject_refs("controller '" + c.name + "' control expression",
+                                cc.text))
+                    continue;
+                c.controls.push_back(std::move(cc));
+            }
+        }
+        ctrls.push_back(std::move(c));
+    }
+}
+
+// Orders the controllers so that every controller comes before the ones whose
+// variables it drives, which is the "start at the top of the hierarchy and work
+// downwards" evaluation the standard calls for. Controllers not related by
+// `controls` keep their file order, so the result does not depend on how the
+// file is written. A cycle is a file error: it is reported, and the controllers
+// caught in it are appended in file order so evaluation still produces
+// something for everything outside the cycle.
+static std::vector<size_t> controller_order(const std::vector<Ctrl>& ctrls,
+                                            ProblemList& problems) {
+    std::vector<std::vector<size_t>> below(ctrls.size());
+    std::vector<size_t> indeg(ctrls.size(), 0);
+    for (size_t ci = 0; ci < ctrls.size(); ++ci)
+        for (const CtrlControl& c : ctrls[ci].controls)
+            if (c.target_ctrl != SIZE_MAX) {
+                below[ci].push_back(c.target_ctrl);
+                ++indeg[c.target_ctrl];
+            }
+
+    std::vector<size_t> order;
+    std::vector<bool> queued(ctrls.size(), false);
+    for (size_t pass = 0; pass < ctrls.size(); ++pass) {
+        bool progress = false;
+        for (size_t ci = 0; ci < ctrls.size(); ++ci) {
+            if (queued[ci] || indeg[ci] != 0) continue;
+            queued[ci] = true;
+            order.push_back(ci);
+            for (size_t cj : below[ci]) --indeg[cj];
+            progress = true;
+        }
+        if (!progress) break;
     }
 
-    // Fixed-point evaluation resolves acyclic dependencies regardless of the
-    // order variables are written (within a controller or across controllers).
-    for (size_t pass = 0, limit = vars.size() + 1; pass <= limit; ++pass) {
-        bool changed = false;
-        for (CtrlVar& v : vars) {
-            if (v.done) continue;
-            pals::SymbolLookup res = make_resolver(v.ctrl);
+    if (order.size() != ctrls.size()) {
+        std::string names;
+        for (size_t ci = 0; ci < ctrls.size(); ++ci)
+            if (!queued[ci]) {
+                if (!names.empty()) names += ", ";
+                names += "'" + ctrls[ci].name + "'";
+                order.push_back(ci);
+            }
+        add_problem(problems,
+                    "controllers form a circular control hierarchy: " + names);
+    }
+    return order;
+}
+
+// What the ABSOLUTE controllers add up to for one lattice parameter, keyed on
+// (element definition, dotted path) so a parameter an element does not carry
+// yet still has an identity.
+struct CtrlTarget {
+    double sum = 0.0;
+    bool has_absolute = false;
+    bool has_relative = false;
+    bool deferred = false;  // some driving expression stayed unevaluated
+};
+
+// Evaluates the controllers and applies them to the expanded lattice.
+//
+// Each controller's `variables` are a symbol table scoped to that controller:
+// an initial value may use the controller's own variables, the built-in and
+// user constants, and nothing else. A variable written with no value is zero.
+// Controllers are walked from the top of the hierarchy downwards, so a variable
+// driven from above already holds its driving value by the time the controller
+// owning it is evaluated. Every control `expression` is then computed with its
+// controller's table and the number written back into the control entry, and
+// the ABSOLUTE controllers are applied to the lattice parameters they drive.
+//
+// `lat_node` is the expanded lattice; parameter targets are matched inside it,
+// which is what keeps a controller from also driving the unexpanded element
+// definitions still sitting in `facility`. Passing ryml::NONE evaluates the
+// controllers without applying them.
+static void evaluate_controllers(ryml::Tree& t, size_t lat_node,
+                                 const pals::SymbolLookup& global_resolve,
+                                 const pals::SpeciesLookup& species,
+                                 ProblemList& problems) {
+    std::vector<Ctrl> ctrls;
+    std::vector<CtrlVar> vars;
+    collect_controller_defs(t, ctrls, vars, problems);
+    if (ctrls.empty()) return;
+
+    std::map<std::string, size_t> by_name;
+    for (size_t ci = 0; ci < ctrls.size(); ++ci) by_name[ctrls[ci].name] = ci;
+
+    // (controller, variable) -> index into `vars`.
+    std::map<std::pair<size_t, std::string>, size_t> var_of;
+    for (size_t vi = 0; vi < vars.size(); ++vi)
+        var_of[{vars[vi].ctrl, vars[vi].name}] = vi;
+
+    // Split each `parameter` target into the two things it can name. A target
+    // whose part before the `>` is a controller name is a controller variable
+    // (`ps27>cur1`); anything else is a lattice parameter.
+    for (Ctrl& c : ctrls) {
+        for (CtrlControl& cc : c.controls) {
+            size_t gt = cc.param.find('>');
+            if (gt == std::string::npos) continue;
+            auto it = by_name.find(cc.param.substr(0, gt));
+            if (it == by_name.end()) continue;
+            std::string var = cc.param.substr(gt + 1);
+            if (!var_of.count({it->second, var})) {
+                add_problem(problems, "controller '" + c.name + "' controls '" +
+                                          cc.param + "': controller '" +
+                                          it->first + "' has no variable '" +
+                                          var + "'");
+                continue;
+            }
+            cc.target_ctrl = it->second;
+            cc.target_var = var;
+        }
+    }
+
+    std::vector<size_t> order = controller_order(ctrls, problems);
+
+    // Symbol tables, filled in as each controller is reached.
+    std::vector<std::map<std::string, double>> locals(ctrls.size());
+    auto resolver_for = [&locals, &global_resolve](size_t ci) {
+        return pals::SymbolLookup(
+            [ci, &locals, &global_resolve](const std::string& name,
+                                           double& out) -> bool {
+                auto it = locals[ci].find(name);
+                if (it != locals[ci].end()) {
+                    out = it->second;
+                    return true;
+                }
+                return global_resolve ? global_resolve(name, out) : false;
+            });
+    };
+
+    std::map<std::pair<size_t, std::string>, CtrlTarget> targets;
+
+    for (size_t ci : order) {
+        Ctrl& c = ctrls[ci];
+        pals::SymbolLookup res = resolver_for(ci);
+
+        // Build this controller's symbol table. A driven variable takes the
+        // value the controllers above set -- that is what it replaced its own
+        // initial value with. Every other initial value is a constant
+        // expression (no variable may appear in one), so a single pass in any
+        // order settles the table.
+        for (size_t vi : c.vars) {
+            CtrlVar& v = vars[vi];
+            if (v.driven) {
+                locals[ci][v.name] = v.driven_value;
+                set_scalar_num(t, v.node, v.driven_value);
+                v.done = true;
+                continue;
+            }
+            if (v.text.empty()) {  // no value given: the default is zero
+                locals[ci][v.name] = 0.0;
+                set_scalar_num(t, v.node, 0.0);
+                v.done = true;
+                continue;
+            }
             bool was_expr = false;
             std::string body = strip_expr_wrapper(v.text, was_expr);
-            pals::EvalOutcome r = pals::eval_expression(body, res, species);
+            // `global_resolve`, not `res`: an initial value sees the built-in
+            // and user constants, never the variables.
+            pals::EvalOutcome r =
+                pals::eval_expression(body, global_resolve, species);
             if (r.ok) {
-                locals[v.ctrl][v.bare] = r.value;
-                qualified[v.qname] = r.value;
-                t.set_val(v.node,
-                          t.to_arena(ryml::to_csubstr(format_double(r.value))));
+                locals[ci][v.name] = r.value;
+                set_scalar_num(t, v.node, r.value);
                 v.done = true;
-                changed = true;
             } else if (r.deferred) {
                 v.done = true;  // random(); leave the text untouched
             }
         }
-        if (!changed) break;
-    }
 
-    // Any variable still unresolved is a genuine problem (unknown symbol or a
-    // dependency cycle); random()-deferred ones were marked done above.
-    for (const CtrlVar& v : vars)
-        if (!v.done)
-            add_problem(problems, "controller '" + names[v.ctrl] +
-                                      "' variable '" + v.bare +
-                                      "': could not evaluate '" + v.text + "'");
+        for (size_t vi : c.vars)
+            if (!vars[vi].done)
+                add_problem(problems, "controller '" + c.name + "' variable '" +
+                                          vars[vi].name +
+                                          "': could not evaluate '" +
+                                          vars[vi].text + "'");
 
-    // Compute each control `expression` with its controller's table and store
-    // the value back in the control entry.
-    for (size_t ci = 0; ci < controllers.size(); ++ci) {
-        size_t controls =
-            t.find_child(controllers[ci], ryml::to_csubstr("controls"));
-        if (controls == ryml::NONE) continue;
-        pals::SymbolLookup res = make_resolver(ci);
-        for (size_t entry = t.first_child(controls); entry != ryml::NONE;
-             entry = t.next_sibling(entry)) {
-            if (!t.is_map(entry)) continue;
-            size_t enode = t.find_child(entry, ryml::to_csubstr("expression"));
-            if (enode == ryml::NONE || !t.has_val(enode)) continue;
+        for (CtrlControl& cc : c.controls) {
             bool was_expr = false;
-            std::string body = strip_expr_wrapper(
-                std::string(t.val(enode).str, t.val(enode).len), was_expr);
+            std::string body = strip_expr_wrapper(cc.text, was_expr);
             pals::EvalOutcome r = pals::eval_expression(body, res, species);
-            if (r.ok)
-                t.set_val(enode,
-                          t.to_arena(ryml::to_csubstr(format_double(r.value))));
-            else if (!r.deferred)
-                add_problem(problems, "controller '" + names[ci] +
+            if (r.ok) {
+                cc.ok = true;
+                cc.value = r.value;
+                set_scalar_num(t, cc.expr_node, r.value);
+            } else if (!r.deferred) {
+                add_problem(problems, "controller '" + c.name +
                                           "' control expression could not be "
                                           "evaluated: " + body);
+            }
+            // Deferred (random()) expressions keep their text, as everywhere
+            // else, and so drive nothing: the expanded tree stays reproducible.
+
+            if (cc.target_ctrl == SIZE_MAX) continue;
+            // Only ABSOLUTE control reaches the variable now. A RELATIVE
+            // controller describes how the variable *changes* once the program
+            // varies the knob, which is outside lattice expansion.
+            if (!c.absolute || !cc.ok) continue;
+            CtrlVar& tv = vars[var_of[{cc.target_ctrl, cc.target_var}]];
+            if (!tv.driven) {
+                tv.driven = true;
+                tv.driven_value = 0.0;
+            }
+            tv.driven_value += cc.value;  // several ABSOLUTE controllers sum
         }
+    }
+
+    if (lat_node == ryml::NONE) return;
+
+    // Gather what drives each lattice parameter. Targets are keyed on the
+    // element and the path rather than on a parameter node, so a parameter the
+    // element does not carry yet is still recognised as the same target.
+    for (const Ctrl& c : ctrls) {
+        for (const CtrlControl& cc : c.controls) {
+            if (cc.target_ctrl != SIZE_MAX) continue;
+            ElementMatches m = match_element_parameters(t, lat_node, cc.param);
+            if (!m.valid) {
+                add_problem(problems, "controller '" + c.name +
+                                          "': malformed parameter target '" +
+                                          cc.param + "'");
+                continue;
+            }
+            bool named = m.has_param;
+            for (const std::string& p : m.path)
+                if (p.empty()) named = false;
+            if (!named) {
+                add_problem(problems, "controller '" + c.name + "': target '" +
+                                          cc.param +
+                                          "' names no element parameter");
+                continue;
+            }
+            if (m.elements.empty()) {
+                add_problem(problems, "controller '" + c.name + "': target '" +
+                                          cc.param +
+                                          "' matches nothing in the expanded "
+                                          "lattice");
+                continue;
+            }
+            std::string path;
+            for (const std::string& p : m.path)
+                path += (path.empty() ? "" : ".") + p;
+            for (size_t def : m.elements) {
+                CtrlTarget& tg = targets[{def, path}];
+                if (c.absolute) {
+                    tg.has_absolute = true;
+                    if (cc.ok)
+                        tg.sum += cc.value;
+                    else
+                        tg.deferred = true;
+                } else {
+                    tg.has_relative = true;
+                }
+            }
+        }
+    }
+
+    for (const auto& kv : targets) {
+        size_t def = kv.first.first;
+        const CtrlTarget& tg = kv.second;
+        std::vector<std::string> path = split_dots(kv.first.second);
+        std::string where = std::string(t.key(def).str, t.key(def).len) + ">" +
+                            kv.first.second;
+
+        // "A given lattice parameter may not be assigned a delayed evaluation
+        // expression and be controlled by a controller." This runs before
+        // substitute_values, while the `expr(...)` wrapper is still there to see.
+        size_t existing = resolve_param_path(t, def, path);
+        if (existing != ryml::NONE && t.has_val(existing)) {
+            bool was_expr = false;
+            strip_expr_wrapper(std::string(t.val(existing).str,
+                                           t.val(existing).len),
+                               was_expr);
+            if (was_expr)
+                add_problem(problems, where +
+                                          " is both controlled and assigned a "
+                                          "delayed evaluation expression");
+        }
+
+        if (tg.has_absolute && tg.has_relative) {
+            add_problem(problems, where +
+                                      " is controlled by both an ABSOLUTE and a "
+                                      "RELATIVE controller");
+            continue;
+        }
+        // A RELATIVE controller leaves the parameter at the value the element
+        // itself gives; only the sum of the ABSOLUTE ones is applied here.
+        if (!tg.has_absolute || tg.deferred) continue;
+
+        size_t parent = def;
+        for (size_t i = 0; i + 1 < path.size(); ++i)
+            parent = find_or_add_map_child(t, parent, path[i].c_str());
+        set_num_child(t, parent, path.back().c_str(), tg.sum);
     }
 }
 
@@ -1329,25 +1765,31 @@ static size_t resolve_ele_param_ref(const ryml::Tree& t,
     return node;
 }
 
-// Evaluates all expressions in the (already expanded) tree in place. Records
-// any that could not be evaluated in `problems`.
-static void evaluate_expressions(ryml::Tree& t, ProblemList& problems) {
-    std::map<std::string, std::string> defs;
-    collect_defs(t, t.root_id(), defs);
+// Builds the expression-evaluation context for `t`: a resolver for user
+// constants/variables and element-parameter references, and the species-name
+// lookup that lets a particle-data function take a symbol. The tables the two
+// read are held by shared_ptr, so the returned functions stay usable after this
+// returns -- `set` commands need a context per command, since each one runs
+// against a tree the previous ones have written to.
+static void make_expression_context(const ryml::Tree& t,
+                                    pals::SymbolLookup& resolve_out,
+                                    pals::SpeciesLookup& species_out) {
+    auto defs = std::make_shared<std::map<std::string, std::string>>();
+    collect_defs(t, t.root_id(), *defs);
 
     // Element name -> definition map, so expressions may reference another
     // element's parameter via `element>group. ... .param`.
-    std::map<std::string, size_t> emap;
-    make_ele_map(emap, t, t.root_id());
+    auto emap = std::make_shared<std::map<std::string, size_t>>();
+    make_ele_map(*emap, t, t.root_id());
 
     // Resolves a symbol whose value is a species-name string (e.g.
     // `species: "#3He"`), so a particle-data function may take it by name:
     // `mass_of(species)`. The stored value is returned verbatim (trimmed, with
     // any surrounding quotes stripped); the expression evaluator validates it.
-    pals::SpeciesLookup species = [&defs](const std::string& name,
-                                          std::string& out) -> bool {
-        auto di = defs.find(name);
-        if (di == defs.end()) return false;
+    pals::SpeciesLookup species = [defs](const std::string& name,
+                                         std::string& out) -> bool {
+        auto di = defs->find(name);
+        if (di == defs->end()) return false;
         std::string v = di->second;
         size_t a = v.find_first_not_of(" \t\r\n");
         size_t b = v.find_last_not_of(" \t\r\n");
@@ -1367,7 +1809,8 @@ static void evaluate_expressions(ryml::Tree& t, ProblemList& problems) {
     auto active = std::make_shared<std::set<std::string>>();
     std::shared_ptr<pals::SymbolLookup> resolve =
         std::make_shared<pals::SymbolLookup>();
-    *resolve = [&defs, &t, &emap, cache, active, resolve, species](
+    const ryml::Tree* tp = &t;
+    *resolve = [defs, tp, emap, cache, active, resolve, species](
                    const std::string& name, double& out) -> bool {
         auto ci = cache->find(name);
         if (ci != cache->end()) {
@@ -1378,12 +1821,12 @@ static void evaluate_expressions(ryml::Tree& t, ProblemList& problems) {
         // to that parameter's value, evaluated as an expression in turn.
         std::string body;
         if (name.find('>') != std::string::npos) {
-            size_t vn = resolve_ele_param_ref(t, emap, name);
+            size_t vn = resolve_ele_param_ref(*tp, *emap, name);
             if (vn == ryml::NONE) return false;
-            body = std::string(t.val(vn).str, t.val(vn).len);
+            body = std::string(tp->val(vn).str, tp->val(vn).len);
         } else {
-            auto di = defs.find(name);
-            if (di == defs.end()) return false;
+            auto di = defs->find(name);
+            if (di == defs->end()) return false;
             body = di->second;
         }
         if (!active->insert(name).second) return false;  // cycle
@@ -1397,10 +1840,21 @@ static void evaluate_expressions(ryml::Tree& t, ProblemList& problems) {
         return true;
     };
 
-    // Controllers first (controller-scoped symbol tables), then the generic
-    // pass over the rest of the tree (which skips controller subtrees).
-    evaluate_controllers(t, *resolve, species, problems);
-    substitute_values(t, t.root_id(), *resolve, species, problems);
+    resolve_out = *resolve;
+    species_out = species;
+}
+
+// Evaluates all expressions in the (already expanded) tree in place, and
+// applies the controllers to `lat_node`. Records anything that could not be
+// evaluated in `problems`.
+static void evaluate_expressions(ryml::Tree& t, size_t lat_node,
+                                 ProblemList& problems) {
+    pals::SymbolLookup resolve;
+    pals::SpeciesLookup species;
+    make_expression_context(t, resolve, species);
+
+    evaluate_controllers(t, lat_node, resolve, species, problems);
+    substitute_values(t, t.root_id(), resolve, species, problems);
 }
 
 // ============================================================
@@ -1464,78 +1918,457 @@ static bool get_str_child(const ryml::Tree& t, size_t parent, const char* key,
     return true;
 }
 
-// A keyed sequence child of `parent`, created (empty) if absent.
-static size_t find_or_add_seq_child(ryml::Tree& t, size_t parent,
-                                    const char* key) {
-    size_t c = t.find_child(parent, ryml::to_csubstr(key));
-    if (c != ryml::NONE) return c;
-    ensure_capacity(t, 2);
-    c = t.append_child(parent);
-    t.ref(c) |= ryml::KEY | ryml::SEQ;
-    t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
-    return c;
+// ============================================================
+// SET COMMANDS AND THE expand_lattice SPLIT
+// ============================================================
+//
+// A `set` (miscellaneous.md, s:set) writes a value into every parameter its
+// `parameter` name-matching string selects:
+//
+//   - set:
+//       parameter: B1.*>BendP.e1
+//       value: 2*PARAMETER + atan(SELF.BendP.g_ref)
+//
+// In the `value` expression `PARAMETER` stands for the current value of the
+// parameter being written and `SELF` for the element that owns it. The compact
+// `sets:` form is a list of `target: value` pairs with no error terms.
+//
+// Where a set acts depends on where it sits relative to the `expand_lattice`
+// node (lattice-construction.md, s:expand.lat), which divides the `facility`
+// list in two. A set in the pre-expansion list acts on the element
+// *definitions*, and only on those defined before it in the list, so one
+// definition is written once and every expanded copy inherits the value. A set
+// in the post-expansion list acts on the already-expanded lattice, so each copy
+// of a repeated element is written separately -- which is the point of
+// `expand_lattice`.
+
+// The `facility` sequence of the PALS node, or ryml::NONE. Includes have already
+// been spliced into it in place, so there is one list holding every node of
+// every file, in order.
+static size_t find_facility(const ryml::Tree& t) {
+    size_t pals = t.find_child(t.root_id(), ryml::to_csubstr("PALS"));
+    if (pals == ryml::NONE) return ryml::NONE;
+    size_t fac = t.find_child(pals, ryml::to_csubstr("facility"));
+    return (fac != ryml::NONE && t.is_seq(fac)) ? fac : ryml::NONE;
 }
 
-// A keyed map child of `parent`, created (empty) if absent. An existing scalar
-// placeholder of the same key is converted to a map in place.
-static size_t find_or_add_map_child(ryml::Tree& t, size_t parent,
-                                    const char* key) {
-    size_t c = t.find_child(parent, ryml::to_csubstr(key));
-    if (c != ryml::NONE) {
-        if (!t.is_map(c)) {
-            t.change_type(c, ryml::KEYMAP);
-            t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+// The keyed child of a facility entry (the entry is an anonymous wrapper map
+// holding one keyed node), or ryml::NONE for a bare scalar entry such as
+// `- expand_lattice`.
+static size_t entry_content(const ryml::Tree& t, size_t entry) {
+    if (entry == ryml::NONE || !t.is_map(entry)) return ryml::NONE;
+    size_t c = t.first_child(entry);
+    return (c != ryml::NONE && t.has_key(c)) ? c : ryml::NONE;
+}
+
+// True for the `expand_lattice` node that splits the facility list. Written as
+// a bare scalar (`- expand_lattice`); the keyed form is accepted too, since a
+// trailing colon is an easy thing to write.
+static bool is_expand_lattice(const ryml::Tree& t, size_t entry) {
+    if (entry == ryml::NONE) return false;
+    if (!t.has_key(entry) && t.has_val(entry))
+        return t.val(entry) == ryml::to_csubstr("expand_lattice");
+    size_t c = entry_content(t, entry);
+    return c != ryml::NONE && t.key(c) == ryml::to_csubstr("expand_lattice");
+}
+
+// The parameters that are computed from one another, so that writing one leaves
+// the rest of the family stale. A magnetic multipole component has four
+// interchangeable forms (BnN, BnNL, KnN, KnNL, tied by the length and the
+// reference momentum); an electric one has two; a bend's geometry is tied
+// together through BendP. Returns the family including `key` itself, or an empty
+// set for a parameter that stands alone.
+//
+// This is also what tells a value expression that a parameter is *not yet
+// computable* rather than zero: before the bookkeeper has run, an absent
+// parameter with a written family member is one whose value is still to be
+// derived (lattice-construction.md, s:lattice.expand).
+static std::set<std::string> linked_family(const std::string& group,
+                                           const std::string& key) {
+    // `<letter><n|s><digits>[L]`, the shape both multipole groups use.
+    auto split_component = [](const std::string& k, const char* letters,
+                              std::string& comp) {
+        if (k.size() < 3 || !std::strchr(letters, k[0])) return false;
+        if (k[1] != 'n' && k[1] != 's') return false;
+        size_t i = 2;
+        while (i < k.size() && std::isdigit(static_cast<unsigned char>(k[i])))
+            ++i;
+        if (i == 2) return false;
+        if (i != k.size() && !(i + 1 == k.size() && k[i] == 'L')) return false;
+        comp = k.substr(1, i - 1);  // e.g. "n1"
+        return true;
+    };
+
+    std::string comp;
+    if (group == "MagneticMultipoleP" && split_component(key, "BK", comp))
+        return {"B" + comp, "B" + comp + "L", "K" + comp, "K" + comp + "L"};
+    if (group == "ElectricMultipoleP" && split_component(key, "E", comp))
+        return {"E" + comp, "E" + comp + "L"};
+
+    static const std::set<std::string> bend = {
+        "g_ref",     "radius_ref", "Bn0_ref",
+        "angle_ref", "L_chord",    "L_rectangle"};
+    if (group == "BendP" && bend.count(key)) return bend;
+
+    return {};
+}
+
+// Everything a `set` needs to know about where it is writing: the element, the
+// group node holding the parameter (ryml::NONE until it is created), the
+// parameter key, and the group name for the family lookup.
+struct SetTarget {
+    size_t ele = ryml::NONE;
+    std::vector<std::string> path;
+    std::string group;  // "" for an ungrouped parameter such as `length`
+    std::string key;
+};
+
+static SetTarget make_target(size_t ele, const std::vector<std::string>& path) {
+    SetTarget tg;
+    tg.ele = ele;
+    tg.path = path;
+    tg.key = path.empty() ? "" : path.back();
+    if (path.size() >= 2) tg.group = path[path.size() - 2];
+    return tg;
+}
+
+// True when `path` names a parameter of `ele` that is not written but is still
+// to be derived from a family member that is -- reading it is an error rather
+// than reading zero. Only meaningful before the bookkeeper has run.
+static bool awaits_derivation(const ryml::Tree& t, size_t ele,
+                              const std::vector<std::string>& path) {
+    if (path.empty()) return false;
+    if (resolve_param_path(t, ele, path) != ryml::NONE) return false;
+    SetTarget tg = make_target(ele, path);
+    std::set<std::string> family = linked_family(tg.group, tg.key);
+    if (family.empty()) return false;
+    std::vector<std::string> sib = path;
+    for (const std::string& member : family) {
+        if (member == tg.key) continue;
+        sib.back() = member;
+        if (resolve_param_path(t, ele, sib) != ryml::NONE) return true;
+    }
+    return false;
+}
+
+// Reads the value a `set` expression sees for a parameter: the written value if
+// there is one, otherwise zero (an unwritten parameter of a known element is
+// zero, per s:lattice.expand). `pending` reports the third case -- the value is
+// still to be derived, so reading it is an error.
+static bool read_set_operand(const ryml::Tree& t, size_t ele,
+                             const std::vector<std::string>& path,
+                             const pals::SymbolLookup& resolve,
+                             const pals::SpeciesLookup& species, bool pre,
+                             double& out, bool& pending) {
+    pending = false;
+    if (ele == ryml::NONE || path.empty()) return false;
+    size_t node = resolve_param_path(t, ele, path);
+    if (node != ryml::NONE && t.has_val(node)) {
+        bool was_expr = false;
+        std::string body = strip_expr_wrapper(
+            std::string(t.val(node).str, t.val(node).len), was_expr);
+        pals::EvalOutcome r = pals::eval_expression(body, resolve, species);
+        if (!r.ok) return false;
+        out = r.value;
+        return true;
+    }
+    if (pre && awaits_derivation(t, ele, path)) {
+        pending = true;
+        return false;
+    }
+    out = 0.0;
+    return true;
+}
+
+// Delete the rest of a parameter's family, so the bookkeeper derives it again
+// from the value just written instead of flagging the two as inconsistent.
+// Provenance entries go with them: ryml reuses freed ids, and a stale link would
+// then point the correspondence map at the wrong node.
+static void invalidate_family(ryml::Tree& t, const SetTarget& tg,
+                              std::map<size_t, size_t>& prov) {
+    std::set<std::string> family = linked_family(tg.group, tg.key);
+    if (family.empty()) return;
+    std::vector<std::string> sib = tg.path;
+    for (const std::string& member : family) {
+        if (member == tg.key) continue;
+        sib.back() = member;
+        size_t node = resolve_param_path(t, tg.ele, sib);
+        if (node == ryml::NONE) continue;
+        erase_prov_subtree(t, node, prov);
+        t.remove(node);
+    }
+}
+
+// One `set` command, read out of the tree.
+struct SetCommand {
+    std::string param;   // `parameter`: the name-matching target
+    std::string value;   // `value`: the expression to write
+    double abs_error = 0.0;
+    double rel_error = 0.0;
+    bool has_error = false;
+};
+
+// Execute one `set` against the elements `matches` selected. `pre` distinguishes
+// a pre-expansion set (acting on definitions, where a derived value is not yet
+// available) from a post-expansion one (acting on the expanded lattice, where
+// writing a parameter makes its family stale).
+static void execute_set(ryml::Tree& t, const SetCommand& cmd,
+                        const ElementMatches& matches, bool pre,
+                        const pals::SymbolLookup& resolve,
+                        const pals::SpeciesLookup& species,
+                        std::map<size_t, size_t>& prov, ProblemList& problems) {
+    std::string what = "set '" + cmd.param + "'";
+
+    if (!matches.valid) {
+        add_problem(problems, what + ": malformed parameter target");
+        return;
+    }
+    if (!matches.has_param || matches.path.empty() ||
+        matches.path.back().empty()) {
+        add_problem(problems, what + ": target names no element parameter");
+        return;
+    }
+    if (matches.elements.empty()) {
+        add_problem(problems, what + ": target matches nothing" +
+                                  (pre ? " defined before it" : ""));
+        return;
+    }
+    // "the true error is absolute_error + relative_error * |value|" -- but the
+    // standard does not say how that error is distributed, and this library
+    // never invents randomness (random()/random_gauss() are deferred for the
+    // same reason). The deterministic value is written and the error is not.
+    if (cmd.has_error)
+        add_problem(problems, what +
+                                  ": absolute_error/relative_error are not "
+                                  "applied -- the standard does not specify "
+                                  "the error distribution");
+
+    // Only a pre-expansion set needs the element map, to spot a reference to a
+    // parameter whose value has still to be derived.
+    std::map<std::string, size_t> emap;
+    if (pre) make_ele_map(emap, t, t.root_id());
+
+    for (size_t ele : matches.elements) {
+        SetTarget tg = make_target(ele, matches.path);
+        std::string ename(t.key(ele).str, t.key(ele).len);
+        std::string where = what + " on '" + ename + "'";
+
+        // `PARAMETER` is the value being replaced; `SELF.<path>` reaches the
+        // rest of the element. Both are scoped to this one element, so the
+        // resolver is rebuilt for each.
+        bool pending = false;
+        std::string pending_name;
+        pals::SymbolLookup scoped = [&](const std::string& name,
+                                        double& out) -> bool {
+            if (name == "PARAMETER") {
+                bool p = false;
+                bool ok = read_set_operand(t, ele, tg.path, resolve, species,
+                                           pre, out, p);
+                if (p) {
+                    pending = true;
+                    pending_name = matches.path.back();
+                }
+                return ok;
+            }
+            if (name.compare(0, 5, "SELF.") == 0) {
+                std::vector<std::string> path = split_dots(name.substr(5));
+                bool p = false;
+                bool ok =
+                    read_set_operand(t, ele, path, resolve, species, pre, out, p);
+                if (p) {
+                    pending = true;
+                    pending_name = name;
+                }
+                return ok;
+            }
+            // An `element>path` reference reads by the same rules: the written
+            // value, else zero, else -- when a family member is written, so the
+            // value is still to be derived -- an error.
+            size_t gt = name.find('>');
+            if (pre && gt != std::string::npos) {
+                auto it = emap.find(name.substr(0, gt));
+                if (it != emap.end()) {
+                    std::vector<std::string> ref =
+                        split_dots(name.substr(gt + 1));
+                    bool p = false;
+                    bool ok = read_set_operand(t, it->second, ref, resolve,
+                                               species, pre, out, p);
+                    if (p) {
+                        pending = true;
+                        pending_name = name;
+                    }
+                    return ok;
+                }
+            }
+            return resolve ? resolve(name, out) : false;
+        };
+
+        bool was_expr = false;
+        std::string body = strip_expr_wrapper(cmd.value, was_expr);
+        pals::EvalOutcome r = pals::eval_expression(body, scoped, species);
+        if (pending) {
+            add_problem(problems, where + ": '" + pending_name +
+                                      "' has no value yet -- it is derived "
+                                      "during lattice expansion");
+            continue;
         }
-        return c;
+        if (r.deferred) continue;  // random(); leave the parameter alone
+        if (!r.ok) {
+            add_problem(problems,
+                        where + ": could not evaluate value: " + cmd.value);
+            continue;
+        }
+
+        size_t parent = ele;
+        for (size_t i = 0; i + 1 < tg.path.size(); ++i)
+            parent = find_or_add_map_child(t, parent, tg.path[i].c_str());
+        set_num_child(t, parent, tg.key.c_str(), r.value);
+        // After the bookkeeper has run the rest of the family holds values
+        // derived from the old one; drop them so the next pass rebuilds them.
+        if (!pre) invalidate_family(t, tg, prov);
     }
-    ensure_capacity(t, 2);
-    c = t.append_child(parent);
-    t.ref(c) |= ryml::KEY | ryml::MAP;
-    t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
-    return c;
 }
 
-// Set (or create) a keyed scalar child to the shortest round-tripping decimal.
-static void set_num_child(ryml::Tree& t, size_t parent, const char* key,
-                          double v) {
-    size_t c = t.find_child(parent, ryml::to_csubstr(key));
-    if (c == ryml::NONE) {
-        ensure_capacity(t, 2);
-        c = t.append_child(parent);
-        t.ref(c) |= ryml::KEY | ryml::VAL;
-        t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+// Read a `set` node into a SetCommand. Returns false (with a problem recorded)
+// when the required components are missing.
+static bool read_set_command(const ryml::Tree& t, size_t node, SetCommand& cmd,
+                             ProblemList& problems) {
+    cmd.param = child_val_str(t, node, "parameter");
+    cmd.value = child_val_str(t, node, "value");
+    if (cmd.param.empty()) {
+        add_problem(problems, "set: no `parameter` target");
+        return false;
     }
-    t.set_val(c, t.to_arena(ryml::to_csubstr(format_double(v))));
+    if (cmd.value.empty()) {
+        add_problem(problems, "set '" + cmd.param + "': no `value`");
+        return false;
+    }
+    double e = 0.0;
+    if (get_num_child(t, node, "absolute_error", e) && e != 0.0) {
+        cmd.abs_error = e;
+        cmd.has_error = true;
+    }
+    if (get_num_child(t, node, "relative_error", e) && e != 0.0) {
+        cmd.rel_error = e;
+        cmd.has_error = true;
+    }
+    return true;
 }
 
-// Set (or create) a keyed scalar child to a string. Double-quoted so a leading
-// '#' in a species name survives YAML's comment rule on re-emit.
-static void set_str_child(ryml::Tree& t, size_t parent, const char* key,
-                          const std::string& v) {
-    size_t c = t.find_child(parent, ryml::to_csubstr(key));
-    if (c == ryml::NONE) {
-        ensure_capacity(t, 2);
-        c = t.append_child(parent);
-        t.ref(c) |= ryml::KEY | ryml::VAL;
-        t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+// The set commands a facility entry holds: one for a `set` node, one per pair
+// for the compact `sets` list. Anything else yields none.
+static std::vector<SetCommand> entry_set_commands(const ryml::Tree& t,
+                                                  size_t entry,
+                                                  ProblemList& problems) {
+    std::vector<SetCommand> out;
+    size_t c = entry_content(t, entry);
+    if (c == ryml::NONE) return out;
+    std::string key(t.key(c).str, t.key(c).len);
+
+    if (key == "set") {
+        SetCommand cmd;
+        if (read_set_command(t, c, cmd, problems)) out.push_back(std::move(cmd));
+        return out;
     }
-    t.set_val(c, t.to_arena(ryml::to_csubstr(v)));
-    t.set_val_style(c, ryml::VAL_DQUO);
+    if (key != "sets") return out;
+
+    // Compact form: a list of `target: value` pairs (written as a sequence of
+    // single-key maps, or as a plain map).
+    auto emit = [&](size_t kv) {
+        if (!t.has_key(kv) || !t.has_val(kv)) return;
+        SetCommand cmd;
+        cmd.param.assign(t.key(kv).str, t.key(kv).len);
+        cmd.value.assign(t.val(kv).str, t.val(kv).len);
+        out.push_back(std::move(cmd));
+    };
+    if (t.is_map(c)) {
+        for (size_t kv = t.first_child(c); kv != ryml::NONE;
+             kv = t.next_sibling(kv))
+            emit(kv);
+    } else if (t.is_seq(c)) {
+        for (size_t el = t.first_child(c); el != ryml::NONE;
+             el = t.next_sibling(el))
+            for (size_t kv = t.first_child(el); kv != ryml::NONE;
+                 kv = t.next_sibling(kv))
+                emit(kv);
+    }
+    return out;
 }
 
-// Set (or create) a keyed scalar child to a bare (unquoted) token. Used for
-// enum and boolean defaults (e.g. `cavity_type: STANDING_WAVE`, `direction:
-// FORWARDS`, `aperture_active: true`), which are plain YAML scalars, not strings.
-static void set_plain_child(ryml::Tree& t, size_t parent, const char* key,
-                            const char* v) {
-    size_t c = t.find_child(parent, ryml::to_csubstr(key));
-    if (c == ryml::NONE) {
-        ensure_capacity(t, 2);
-        c = t.append_child(parent);
-        t.ref(c) |= ryml::KEY | ryml::VAL;
-        t.set_key(c, t.to_arena(ryml::to_csubstr(key)));
+// The facility list split at `expand_lattice`, in order. `post` is empty when
+// there is no such node, which is the usual case.
+struct FacilitySplit {
+    std::vector<size_t> pre;
+    std::vector<size_t> post;
+};
+
+static FacilitySplit split_facility(const ryml::Tree& t) {
+    FacilitySplit out;
+    size_t fac = find_facility(t);
+    if (fac == ryml::NONE) return out;
+    bool after = false;
+    for (size_t e = t.first_child(fac); e != ryml::NONE; e = t.next_sibling(e)) {
+        if (!after && is_expand_lattice(t, e)) {
+            after = true;
+            continue;
+        }
+        (after ? out.post : out.pre).push_back(e);
     }
-    t.set_val(c, t.to_arena(ryml::to_csubstr(v)));
+    return out;
+}
+
+// Run the `set` commands of the pre-expansion list, in list order. Each acts on
+// the element definitions that precede it, which is why the entries are walked
+// rather than the tree: `Q2` defined after a set is not touched by it.
+static void run_pre_expansion_sets(ryml::Tree& t,
+                                   const std::vector<size_t>& entries,
+                                   std::map<size_t, size_t>& prov,
+                                   ProblemList& problems) {
+    std::vector<std::vector<SetCommand>> cmds(entries.size());
+    bool any = false;
+    for (size_t i = 0; i < entries.size(); ++i) {
+        cmds[i] = entry_set_commands(t, entries[i], problems);
+        if (!cmds[i].empty()) any = true;
+    }
+    if (!any) return;  // the usual case: no sets at all
+
+    std::vector<size_t> defined;
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (cmds[i].empty()) {
+            defined.push_back(entries[i]);
+            continue;
+        }
+        // A fresh context per command: each set writes to the tree the next one
+        // reads, so a memoized value from before it would be stale.
+        for (const SetCommand& cmd : cmds[i]) {
+            pals::SymbolLookup resolve;
+            pals::SpeciesLookup species;
+            make_expression_context(t, resolve, species);
+            execute_set(t, cmd,
+                        match_definition_parameters(t, defined, cmd.param), true,
+                        resolve, species, prov, problems);
+        }
+    }
+}
+
+// Run the `set` commands of the post-expansion list against the expanded
+// lattice. Order still matters -- a later set sees what an earlier one wrote --
+// but every set sees the whole lattice, since it has already been built.
+static void run_post_expansion_sets(ryml::Tree& t, size_t lat_node,
+                                    const std::vector<size_t>& entries,
+                                    std::map<size_t, size_t>& prov,
+                                    ProblemList& problems) {
+    if (lat_node == ryml::NONE) return;
+    for (size_t e : entries) {
+        for (const SetCommand& cmd : entry_set_commands(t, e, problems)) {
+            pals::SymbolLookup resolve;
+            pals::SpeciesLookup species;
+            make_expression_context(t, resolve, species);
+            execute_set(t, cmd,
+                        match_element_parameters(t, lat_node, cmd.param), false,
+                        resolve, species, prov, problems);
+        }
+    }
 }
 
 // Reference parameters at one end of an element (ReferenceP). Energy and
@@ -2411,8 +3244,12 @@ static void run_element_bookkeeper(ryml::Tree& t, size_t lat_node,
 
         // An empty branch has no final state to record; otherwise cap it with a
         // `branch_end` Placeholder carrying the downstream end of the last
-        // element.
-        if (prev != ryml::NONE)
+        // element. A second pass (after post-expansion sets) walks a branch that
+        // already carries the one the first pass appended: the loop above has
+        // just bookkept it like any other element, so there is nothing to add.
+        bool capped = prev != ryml::NONE &&
+                      t.key(prev) == ryml::to_csubstr("branch_end");
+        if (prev != ryml::NONE && !capped)
             _element_bookkeeper(t, prev, append_branch_end(t, line), problems);
     }
 }
@@ -2603,6 +3440,15 @@ static void make_expanded_and_leftover(ParsedData* comb,
     deep_copy_tracked(t, t.root_id(), comb->tree, comb->tree.root_id(),
                       work.provenance);
 
+    // The `facility` list divided at `expand_lattice` (lattice-construction.md,
+    // s:lattice.expand). With no such node everything is the pre-expansion list
+    // and `post` is empty, which is the usual case.
+    FacilitySplit facility = split_facility(t);
+
+    // The pre-expansion `set` commands run first, on the element definitions,
+    // so expansion copies the values they write into every use of a definition.
+    run_pre_expansion_sets(t, facility.pre, work.provenance, problems);
+
     std::map<std::string, size_t> emap;
     make_ele_map(emap, t, t.root_id());
 
@@ -2636,9 +3482,13 @@ static void make_expanded_and_leftover(ParsedData* comb,
         number_multipass_branches(t, lat_node, work.provenance);
 
         // Evaluate every mathematical expression to a number (immediate and
-        // expr()-delayed alike). Node ids are unchanged -- only scalar text is
-        // rewritten -- so provenance stays valid.
-        evaluate_expressions(t, problems);
+        // expr()-delayed alike), and apply the ABSOLUTE controllers to the
+        // parameters they drive -- both before the bookkeeper, so the reference
+        // and dependent parameters below are computed from the driven values.
+        // Node ids of existing nodes are unchanged -- only scalar text is
+        // rewritten -- so provenance stays valid; a parameter a controller
+        // creates is new and simply has no provenance, like ReferenceP/FloorP.
+        evaluate_expressions(t, lat_node, problems);
 
         // With every input now a plain number, walk each branch element-by-
         // element to fill in the reference, floor, s-position, and field-
@@ -2646,6 +3496,19 @@ static void make_expanded_and_leftover(ParsedData* comb,
         // which carry no provenance (like destination_pointer) and so simply do not
         // appear in the correspondence map.
         run_element_bookkeeper(t, lat_node, problems);
+
+        // Anything after `expand_lattice` acts on the lattice just built: its
+        // sets reach each expanded copy of an element separately, and the
+        // controllers are then applied again (over both lists) so they stay
+        // authoritative over any parameter a set touched. The bookkeeper runs a
+        // second time to recompute what those writes invalidated -- reference
+        // and floor parameters, and the family members execute_set dropped.
+        if (!facility.post.empty()) {
+            run_post_expansion_sets(t, lat_node, facility.post, work.provenance,
+                                    problems);
+            evaluate_expressions(t, lat_node, problems);
+            run_element_bookkeeper(t, lat_node, problems);
+        }
 
         // Last, so the line indices it records are the finished ones -- the
         // bookkeeper caps every branch with a `branch_end` element.

--- a/src/pals_expression.cpp
+++ b/src/pals_expression.cpp
@@ -162,20 +162,23 @@ class Parser {
   std::string read_identifier() {
     skip_ws();
     size_t start = pos_;
-    bool seen_gt = false;
+    bool dotted = false;
     while (pos_ < s_.size()) {
       char c = s_[pos_];
       // `>` joins a controller name to one of its variables (`ps27>cur1`) or an
       // element name to a parameter path (`thingB>MagneticMultipoleP.Kn2L`);
       // PALS has no `>` operator, so it is unambiguous inside an identifier.
       if (std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '>') {
-        if (c == '>') seen_gt = true;
+        if (c == '>') dotted = true;
         ++pos_;
-      } else if (c == '.' && seen_gt) {
-        // A `.` is part of the identifier only inside an element-parameter
-        // reference (after `>`), where it separates the parameter group from
-        // the parameter. Elsewhere `.` begins a number and is not an identifier
-        // character.
+      } else if (c == '.' &&
+                 (dotted || s_.compare(start, pos_ - start, "SELF") == 0)) {
+        // A `.` is part of the identifier only in a parameter path: after the
+        // `>` of an element-parameter reference, or after the `SELF` of a `set`
+        // value expression (`SELF.BendP.g_ref`), where it separates the
+        // parameter group from the parameter. Elsewhere `.` begins a number and
+        // is not an identifier character.
+        dotted = true;
         ++pos_;
       } else {
         break;

--- a/src/pals_match.cpp
+++ b/src/pals_match.cpp
@@ -267,11 +267,16 @@ static bool any_full_match(pcre2_code* re, const std::vector<std::string>& names
 // "beamline" is any map that owns a `line` sequence; its name is the map's key.
 // `lattice` is the name of the enclosing Lattice, `beamlines` the names of all
 // enclosing beamlines (so a branch qualifier can match through sub-lines).
+//
+// `resolve_params` chooses what a match yields when the selector names a
+// parameter: the parameter node itself (what match_names reports, so an element
+// lacking it simply does not match), or the element definition (what a caller
+// that means to create the parameter needs).
 static void match_elements(const ryml::Tree& t, size_t node,
                            const std::string& lattice,
                            const std::vector<std::string>& beamlines,
-                           const NameSelector& sel, std::vector<size_t>& out,
-                           std::set<size_t>& seen) {
+                           const NameSelector& sel, bool resolve_params,
+                           std::vector<size_t>& out, std::set<size_t>& seen) {
     if (node == ryml::NONE) return;
 
     std::string cur_lattice = lattice;
@@ -298,8 +303,9 @@ static void match_elements(const ryml::Tree& t, size_t node,
                 if (!full_match(sel.name, node_key_str(t, def))) continue;
                 if (sel.has_kind && child_val_str(t, def, "kind") != sel.kind)
                     continue;
-                size_t hit = sel.has_param ? resolve_param_path(t, def, sel.path)
-                                           : def;
+                size_t hit = (sel.has_param && resolve_params)
+                                 ? resolve_param_path(t, def, sel.path)
+                                 : def;
                 if (hit != ryml::NONE && seen.insert(hit).second)
                     out.push_back(hit);
             }
@@ -307,7 +313,8 @@ static void match_elements(const ryml::Tree& t, size_t node,
     }
 
     for (size_t c = t.first_child(node); c != ryml::NONE; c = t.next_sibling(c))
-        match_elements(t, c, cur_lattice, cur_beamlines, sel, out, seen);
+        match_elements(t, c, cur_lattice, cur_beamlines, sel, resolve_params,
+                       out, seen);
 }
 
 // Classify a single keyed node as a constant/variable and, if its name matches,
@@ -379,6 +386,53 @@ static void match_const_var(const ryml::Tree& t, pcre2_code* name_re,
                 t, t.find_child(c, ryml::to_csubstr("PALS")), name_re, out, seen);
 }
 
+ElementMatches match_element_parameters(const ryml::Tree& t, size_t root,
+                                        const std::string& spec) {
+    ElementMatches out;
+    NameSelector sel = parse_selector(spec);
+    out.valid = sel.valid;
+    out.has_param = sel.has_param;
+    out.path = sel.path;
+    if (sel.valid) {
+        std::set<size_t> seen;
+        match_elements(t, root == ryml::NONE ? t.root_id() : root, "", {}, sel,
+                       false, out.elements, seen);
+    }
+    free_selector(sel);
+    return out;
+}
+
+ElementMatches match_definition_parameters(const ryml::Tree& t,
+                                           const std::vector<size_t>& entries,
+                                           const std::string& spec) {
+    ElementMatches out;
+    NameSelector sel = parse_selector(spec);
+    out.valid = sel.valid && !sel.lattice_present && !sel.branch_present;
+    out.has_param = sel.has_param;
+    out.path = sel.path;
+    if (out.valid) {
+        std::set<size_t> seen;
+        for (size_t entry : entries) {
+            // A facility entry is an anonymous map wrapping one keyed
+            // definition; anything else (a bare `use` scalar, say) names no
+            // element.
+            if (entry == ryml::NONE || !t.is_map(entry)) continue;
+            size_t def = t.first_child(entry);
+            if (def == ryml::NONE || !t.has_key(def) || !t.is_map(def)) continue;
+            if (full_match(sel.name, node_key_str(t, def)) &&
+                !(sel.has_kind && child_val_str(t, def, "kind") != sel.kind) &&
+                seen.insert(def).second)
+                out.elements.push_back(def);
+            // An element may equally be defined inline inside a beamline of
+            // this entry rather than as an entry of its own, and it is just as
+            // much "defined by this point" in the list.
+            match_elements(t, entry, "", {}, sel, false, out.elements, seen);
+        }
+    }
+    free_selector(sel);
+    return out;
+}
+
 extern "C" {
 
 YAML_API struct name_matches match_names(YAMLTreeHandle tree,
@@ -392,7 +446,7 @@ YAML_API struct name_matches match_names(YAMLTreeHandle tree,
     std::set<size_t> seen;
 
     if (sel.valid) {
-        match_elements(t, t.root_id(), "", {}, sel, hits, seen);
+        match_elements(t, t.root_id(), "", {}, sel, true, hits, seen);
 
         // A bare name (no lattice/branch/kind qualifier and no parameter path)
         // also matches constants and variables directly by name.
@@ -439,7 +493,7 @@ YAML_API struct param_value get_parameter_value(YAMLTreeHandle tree,
         sel.has_param = false;
         std::vector<size_t> eles;
         std::set<size_t> seen;
-        match_elements(t, t.root_id(), "", {}, sel, eles, seen);
+        match_elements(t, t.root_id(), "", {}, sel, true, eles, seen);
         free_selector(sel);
         if (eles.empty()) return out;  // no such element -> missing
         for (size_t ele : eles)

--- a/src/pals_util.h
+++ b/src/pals_util.h
@@ -28,4 +28,34 @@ size_t resolve_param_path(const ryml::Tree& t, size_t ele,
 // it. `was_expr` reports whether an `expr(...)` wrapper was present.
 std::string strip_expr_wrapper(const std::string& s, bool& was_expr);
 
+// What a PALS name-matching string (match_names syntax, see yaml_c_wrapper.h)
+// selected, reported as the element definitions it matched plus the parameter
+// path it named. Elements are listed whether or not they carry that parameter,
+// so a caller that *writes* the parameter -- a controller driving it -- can
+// create it. Constants and variables are not considered.
+struct ElementMatches {
+    std::vector<size_t> elements;   // matched element definition maps
+    std::vector<std::string> path;  // dotted parameter path, empty if none named
+    bool has_param = false;         // the string named a parameter at all
+    bool valid = true;              // false when a pattern failed to compile
+};
+
+// Run a name-matching string over the subtree at `root` (ryml::NONE for the
+// whole tree). Scoping to the expanded lattice node is what keeps a controller
+// from also matching the unexpanded element definitions still sitting in
+// `facility`.
+ElementMatches match_element_parameters(const ryml::Tree& t, size_t root,
+                                        const std::string& spec);
+
+// Like match_element_parameters, but over element *definitions* rather than
+// elements sitting in a beamline `line`: `entries` are `facility` list entries,
+// each an anonymous wrapper map holding one keyed definition. This is what a
+// `set` ahead of `expand_lattice` acts on, so passing only the entries that
+// precede the set is what restricts it to the elements defined by that point.
+// A `{lattice}>>>` or `{branch}>>` qualifier cannot apply to a definition and
+// makes the match string invalid here.
+ElementMatches match_definition_parameters(const ryml::Tree& t,
+                                           const std::vector<size_t>& entries,
+                                           const std::string& spec);
+
 #endif  // PALS_UTIL_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(tests
   test_expressions.cpp
   test_multipass.cpp
   test_controllers.cpp
+  test_sets.cpp
   test_bookkeeper.cpp
   test_check.cpp
   test_floor.cpp

--- a/tests/test_controllers.cpp
+++ b/tests/test_controllers.cpp
@@ -1,56 +1,125 @@
 #include "test_helpers.h"
 
+// Controllers: miscellaneous.md (s:controller) for what a Controller is, and
+// lattice-construction.md (s:lattice.expand) for where applying the ABSOLUTE
+// ones sits in lattice expansion.
+
+namespace {
+
+// Every problem message parse_and_expand_PALS reported, as strings.
+std::vector<std::string> problem_list(const struct lattices& lat) {
+    std::vector<std::string> msgs;
+    for (size_t i = 0; i < lat.problems.count; ++i)
+        msgs.emplace_back(lat.problems.items[i]);
+    return msgs;
+}
+
+// The problems as one string, so a failing REQUIRE shows what they were.
+std::string joined(const struct lattices& lat) {
+    std::string s;
+    for (const std::string& m : problem_list(lat)) s += m + "; ";
+    return s;
+}
+
+bool any_contains(const std::vector<std::string>& msgs, const char* needle) {
+    for (const std::string& m : msgs)
+        if (m.find(needle) != std::string::npos) return true;
+    return false;
+}
+
+void free_all(struct lattices& lat) {
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+// A one-branch lattice holding `body` elements, wrapped in the PALS/facility
+// boilerplate every controller test needs. `defs` is spliced in ahead of the
+// lattice. The BeginningEle (1 GeV electrons) is what lets the bookkeeper
+// compute reference parameters, so a test that drives a normalized strength can
+// check the unnormalized partner derived from it.
+std::string lattice_with(const std::string& defs, const std::string& body) {
+    return "PALS:\n"
+           "  facility:\n" +
+           defs +
+           "    - lat1:\n"
+           "        kind: Lattice\n"
+           "        branches:\n"
+           "          - main:\n"
+           "              kind: BeamLine\n"
+           "              line:\n"
+           "                - begin:\n"
+           "                    kind: BeginningEle\n"
+           "                    ReferenceP:\n"
+           "                      species_ref: \"electron\"\n"
+           "                      E_tot_ref: 1.0e9\n" +
+           body +
+           "                - fin:\n"
+           "                    kind: Marker\n"
+           "    - use: \"lat1\"\n";
+}
+
+// The value of `group.param` on the first element named `ele` in the expanded
+// lattice.
+double expanded_param(YAMLTreeHandle t, const char* ele, const char* group,
+                      const char* param) {
+    YAMLNodeId e = find_by_key(t, ele);
+    REQUIRE(e != YAML_NULL_ID);
+    YAMLNodeId g = get_child_by_key(t, e, group);
+    REQUIRE(g != YAML_NULL_ID);
+    return num_val(t, get_child_by_key(t, g, param));
+}
+
+}  // namespace
+
 TEST_CASE("parse_and_expand_PALS evaluates controller expressions",
           "[expr][lattices][controller]") {
     const char* path = "tmp_controller.pals.yaml";
     write_tmp(path,
-              "PALS:\n"
-              "  facility:\n"
-              "    - my_const:\n"
-              "        kind: constant\n"
-              "        value: 2.0\n"
-              "    - ps27:\n"
-              "        kind: Controller\n"
-              "        control_type: ABSOLUTE\n"
-              "        variables:\n"
-              "          cur1: 0.023\n"
-              "          cur2: cur1 / c_light\n"
-              "        controls:\n"
-              "          - parameter: Qa.*>MagneticMultipoleP.Ks2L\n"
-              "            expression: 0.075*sin(cur1) + 0.3*cur2\n"
-              "          - parameter: Qb>MagneticMultipoleP.Kn1L\n"
-              "            expression: cur1 * my_const\n"
-              "          - parameter: Qc>MagneticMultipoleP.Kn0\n"
-              "            expression: 0.01 + random_gauss()\n"
-              "    - chrom_a:\n"
-              "        kind: Controller\n"
-              "        control_type: RELATIVE\n"
-              "        variables:\n"
-              "          command: 0.4\n"
-              "          derived: ps27>cur1 * 2\n"
-              "        controls:\n"
-              "          - parameter: S1>MagneticMultipoleP.Kn2L\n"
-              "            expression: 5.62 * command + 0.02 * command^2\n"
-              "    - main_line:\n"
-              "        kind: BeamLine\n"
-              "        line:\n"
-              "          - my_const\n"
-              "    - lat1:\n"
-              "        kind: Lattice\n"
-              "        branches:\n"
-              "          - main_line\n"
-              "    - use: \"lat1\"\n");
+              lattice_with(
+                  "    - my_const:\n"
+                  "        kind: constant\n"
+                  "        value: 2.0\n"
+                  "    - ps27:\n"
+                  "        kind: Controller\n"
+                  "        control_type: ABSOLUTE\n"
+                  "        MetaP:\n"
+                  "          description: Model Mitsubishi 800KL\n"
+                  "        variables:\n"
+                  "          cur1: 0.023\n"
+                  "          cur2: 1e8 / c_light\n"
+                  "        controls:\n"
+                  "          - parameter: Qa.*>MagneticMultipoleP.Ks2L\n"
+                  "            expression: 0.075*sin(cur1) + 0.3*cur2\n"
+                  "          - parameter: Qb>MagneticMultipoleP.Kn1L\n"
+                  "            expression: cur1 * my_const\n"
+                  "          - parameter: Qc>MagneticMultipoleP.Kn0\n"
+                  "            expression: 0.01 + random_gauss()\n",
+                  "                - Qa1:\n"
+                  "                    kind: Sextupole\n"
+                  "                    MagneticMultipoleP:\n"
+                  "                      Ks2L: 0.0\n"
+                  "                - Qb:\n"
+                  "                    kind: Quadrupole\n"
+                  "                    MagneticMultipoleP:\n"
+                  "                      Kn1L: 0.0\n"
+                  "                - Qc:\n"
+                  "                    kind: Kicker\n"
+                  "                    MagneticMultipoleP:\n"
+                  "                      Kn0: 0.5\n"));
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(lat.leftover != nullptr);
 
     const double cur1 = 0.023;
-    const double cur2 = cur1 / 2.99792458e8;
+    const double cur2 = 1e8 / 2.99792458e8;
 
-    // Controllers are facility-level, so they are leftover rather than part
-    // of the lattice; their expressions are evaluated all the same.
-    // Controller variables are evaluated with the controller's own symbol
-    // table: cur2 references the earlier variable cur1 and the constant c_light.
+    // Controllers are facility-level, so they are leftover rather than part of
+    // the lattice; their expressions are evaluated all the same. An initial
+    // value is a constant expression -- it may use the built-in and user
+    // constants (c_light here) but no variable.
     YAMLNodeId ps27 = facility_param(lat.leftover, "ps27");
     REQUIRE(ps27 != YAML_NULL_ID);
     YAMLNodeId vars = get_child_by_key(lat.leftover, ps27, "variables");
@@ -74,24 +143,14 @@ TEST_CASE("parse_and_expand_PALS evaluates controller expressions",
     REQUIRE(val_eq(lat.leftover, get_child_by_key(lat.leftover, c2, "expression"),
                    "0.01 + random_gauss()"));
 
-    // The `parameter` target spec and `control_type` are names, left untouched.
+    // The `parameter` target spec and `control_type` are names, left untouched,
+    // and a MetaP rides along for documentation.
     REQUIRE(val_eq(lat.leftover, get_child_by_key(lat.leftover, c0, "parameter"),
                    "Qa.*>MagneticMultipoleP.Ks2L"));
     REQUIRE(val_eq(lat.leftover,
                    get_child_by_key(lat.leftover, ps27, "control_type"),
                    "ABSOLUTE"));
-
-    // A second controller may reference the first's variables via `name>var`.
-    YAMLNodeId chrom = facility_param(lat.leftover, "chrom_a");
-    YAMLNodeId cvars = get_child_by_key(lat.leftover, chrom, "variables");
-    REQUIRE(close(num_val(lat.leftover, get_child_by_key(lat.leftover, cvars,
-                                                         "derived")),
-                  cur1 * 2.0));
-    YAMLNodeId ccontrols = get_child_by_key(lat.leftover, chrom, "controls");
-    YAMLNodeId cc0 = get_child_by_index(lat.leftover, ccontrols, 0);
-    REQUIRE(close(num_val(lat.leftover,
-                          get_child_by_key(lat.leftover, cc0, "expression")),
-                  5.62 * 0.4 + 0.02 * 0.4 * 0.4));
+    REQUIRE(get_child_by_key(lat.leftover, ps27, "MetaP") != YAML_NULL_ID);
 
     // The combined tree keeps the original controller expression text.
     YAMLNodeId c_ps27 = facility_param(lat.combined, "ps27");
@@ -101,9 +160,503 @@ TEST_CASE("parse_and_expand_PALS evaluates controller expressions",
                    get_child_by_key(lat.combined, c_c0, "expression"),
                    "0.075*sin(cur1) + 0.3*cur2"));
 
-    delete_tree(lat.original);
-    delete_tree(lat.combined);
-    delete_tree(lat.expanded);
-    delete_tree(lat.leftover);
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("ABSOLUTE controllers drive the parameters they match",
+          "[expr][lattices][controller]") {
+    // The `parameter` target is a name-matching pattern, so one entry drives
+    // every element it matches; an element the pattern does not reach keeps its
+    // own value.
+    const char* path = "tmp_ctrl_absolute.pals.yaml";
+    write_tmp(path,
+              lattice_with(
+                  "    - ps1:\n"
+                  "        kind: Controller\n"
+                  "        variables:\n"
+                  "          cur: 0.4\n"
+                  "        controls:\n"
+                  "          - parameter: Qa.*>MagneticMultipoleP.Kn1L\n"
+                  "            expression: 2 * cur\n",
+                  "                - Qa1:\n"
+                  "                    kind: Quadrupole\n"
+                  "                    MagneticMultipoleP:\n"
+                  "                      Kn1L: 0.11\n"
+                  "                - Qa2:\n"
+                  "                    kind: Quadrupole\n"
+                  "                    MagneticMultipoleP:\n"
+                  "                      Kn1L: 0.22\n"
+                  "                - Qb1:\n"
+                  "                    kind: Quadrupole\n"
+                  "                    MagneticMultipoleP:\n"
+                  "                      Kn1L: 0.33\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    REQUIRE(close(expanded_param(lat.expanded, "Qa1", "MagneticMultipoleP",
+                                 "Kn1L"),
+                  0.8));
+    REQUIRE(close(expanded_param(lat.expanded, "Qa2", "MagneticMultipoleP",
+                                 "Kn1L"),
+                  0.8));
+    REQUIRE(close(expanded_param(lat.expanded, "Qb1", "MagneticMultipoleP",
+                                 "Kn1L"),
+                  0.33));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("several ABSOLUTE controllers on one parameter sum",
+          "[expr][lattices][controller]") {
+    // miscellaneous.md: "the value of the parameter is the sum of the values set
+    // by the individual controllers". The parameter's own value is replaced, not
+    // added to -- ABSOLUTE control completely determines it. `control_type` is
+    // omitted here, so it defaults to ABSOLUTE.
+    const char* path = "tmp_ctrl_sum.pals.yaml";
+    write_tmp(path,
+              lattice_with(
+                  "    - ps1:\n"
+                  "        kind: Controller\n"
+                  "        variables:\n"
+                  "          cur: 0.023\n"
+                  "        controls:\n"
+                  "          - parameter: a_kicker>MagneticMultipoleP.Kn0\n"
+                  "            expression: 0.075*sin(cur)\n"
+                  "    - ps2:\n"
+                  "        kind: Controller\n"
+                  "        control_type: ABSOLUTE\n"
+                  "        variables:\n"
+                  "          cur: 0.044\n"
+                  "        controls:\n"
+                  "          - parameter: a_kicker>MagneticMultipoleP.Kn0\n"
+                  "            expression: 0.123*cur\n",
+                  "                - a_kicker:\n"
+                  "                    kind: Kicker\n"
+                  "                    MagneticMultipoleP:\n"
+                  "                      Kn0: 9.9\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    REQUIRE(close(expanded_param(lat.expanded, "a_kicker", "MagneticMultipoleP",
+                                 "Kn0"),
+                  0.075 * std::sin(0.023) + 0.123 * 0.044));
+
+    // An omitted control_type is materialized as the ABSOLUTE default.
+    YAMLNodeId ps1 = facility_param(lat.leftover, "ps1");
+    REQUIRE(val_eq(lat.leftover,
+                   get_child_by_key(lat.leftover, ps1, "control_type"),
+                   "ABSOLUTE"));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("an ABSOLUTE controller creates the parameter it drives",
+          "[expr][lattices][controller]") {
+    // The element carries no MagneticMultipoleP at all: naming the parameter in
+    // a controller is what says it has a value, so the group is created and the
+    // bookkeeper then fills its defaults and derived partners in as usual.
+    const char* path = "tmp_ctrl_create.pals.yaml";
+    write_tmp(path,
+              lattice_with("    - ps1:\n"
+                           "        kind: Controller\n"
+                           "        controls:\n"
+                           "          - parameter: a_kicker>MagneticMultipoleP.Kn0L\n"
+                           "            expression: 0.25\n",
+                           "                - a_kicker:\n"
+                           "                    kind: Kicker\n"
+                           "                    length: 0.3\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+    REQUIRE(close(expanded_param(lat.expanded, "a_kicker", "MagneticMultipoleP",
+                                 "Kn0L"),
+                  0.25));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a driven parameter feeds the dependent-parameter bookkeeping",
+          "[expr][lattices][controller]") {
+    // lattice-construction.md orders lattice expansion so that the ABSOLUTE
+    // controllers are applied before the reference and dependent parameters are
+    // computed. Q1's Kn1L comes from a controller and Q2's is written out; the
+    // unnormalized Bn1L the bookkeeper derives from the reference momentum must
+    // come out the same for both.
+    const char* path = "tmp_ctrl_dependent.pals.yaml";
+    write_tmp(path,
+              lattice_with("    - ps1:\n"
+                           "        kind: Controller\n"
+                           "        controls:\n"
+                           "          - parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                           "            expression: 0.15 + 0.25\n",
+                           "                - Q1:\n"
+                           "                    kind: Quadrupole\n"
+                           "                    length: 0.5\n"
+                           "                    MagneticMultipoleP:\n"
+                           "                      Kn1L: 0.0\n"
+                           "                - Q2:\n"
+                           "                    kind: Quadrupole\n"
+                           "                    length: 0.5\n"
+                           "                    MagneticMultipoleP:\n"
+                           "                      Kn1L: 0.4\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    double b1 = expanded_param(lat.expanded, "Q1", "MagneticMultipoleP", "Bn1L");
+    double b2 = expanded_param(lat.expanded, "Q2", "MagneticMultipoleP", "Bn1L");
+    REQUIRE(b1 != 0.0);
+    REQUIRE(close_rel(b1, b2));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a RELATIVE controller leaves the lattice alone",
+          "[expr][lattices][controller]") {
+    // The chromaticity-knob example of miscellaneous.md: at read-in S1 keeps the
+    // Kn2L its own definition gives. The knob's expression is still evaluated,
+    // for the program that will vary `command` later.
+    const char* path = "tmp_ctrl_relative.pals.yaml";
+    write_tmp(path,
+              lattice_with(
+                  "    - chrom_a:\n"
+                  "        kind: Controller\n"
+                  "        control_type: RELATIVE\n"
+                  "        variables:\n"
+                  "          command: 0.4\n"
+                  "        controls:\n"
+                  "          - parameter: S1>MagneticMultipoleP.Kn2L\n"
+                  "            expression: 5.62 * command + 0.02 * command^2\n",
+                  "                - S1:\n"
+                  "                    kind: Sextupole\n"
+                  "                    MagneticMultipoleP:\n"
+                  "                      Kn2L: 0.33\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    REQUIRE(close(expanded_param(lat.expanded, "S1", "MagneticMultipoleP",
+                                 "Kn2L"),
+                  0.33));
+
+    YAMLNodeId chrom = facility_param(lat.leftover, "chrom_a");
+    YAMLNodeId cc0 = get_child_by_index(
+        lat.leftover, get_child_by_key(lat.leftover, chrom, "controls"), 0);
+    REQUIRE(close(num_val(lat.leftover,
+                          get_child_by_key(lat.leftover, cc0, "expression")),
+                  5.62 * 0.4 + 0.02 * 0.4 * 0.4));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a controller drives another controller's variable",
+          "[expr][lattices][controller]") {
+    // Controllers form a hierarchy and are evaluated from the top down, so
+    // `low>cur` holds what `high` set it to -- not its own initial value -- by
+    // the time `low` drives the lattice. The order they are written in does not
+    // matter: `low` comes first in the file here.
+    const char* path = "tmp_ctrl_hierarchy.pals.yaml";
+    write_tmp(path,
+              lattice_with(
+                  "    - low:\n"
+                  "        kind: Controller\n"
+                  "        variables:\n"
+                  "          cur: 0.1\n"
+                  "        controls:\n"
+                  "          - parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                  "            expression: 10 * cur\n"
+                  "    - high:\n"
+                  "        kind: Controller\n"
+                  "        variables:\n"
+                  "          knob: 3\n"
+                  "        controls:\n"
+                  "          - parameter: low>cur\n"
+                  "            expression: knob / 4\n",
+                  "                - Q1:\n"
+                  "                    kind: Quadrupole\n"
+                  "                    MagneticMultipoleP:\n"
+                  "                      Kn1L: 0.0\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    // low>cur becomes 3/4, so Q1's Kn1L is 10 * 0.75.
+    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+                                 "Kn1L"),
+                  7.5));
+    YAMLNodeId low = facility_param(lat.leftover, "low");
+    YAMLNodeId lvars = get_child_by_key(lat.leftover, low, "variables");
+    REQUIRE(close(num_val(lat.leftover,
+                          get_child_by_key(lat.leftover, lvars, "cur")),
+                  0.75));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a variable with no value defaults to zero",
+          "[expr][lattices][controller]") {
+    const char* path = "tmp_ctrl_default_var.pals.yaml";
+    write_tmp(path,
+              lattice_with("    - ps1:\n"
+                           "        kind: Controller\n"
+                           "        variables:\n"
+                           "          cur:\n"
+                           "        controls:\n"
+                           "          - parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                           "            expression: 5 + cur\n",
+                           "                - Q1:\n"
+                           "                    kind: Quadrupole\n"
+                           "                    MagneticMultipoleP:\n"
+                           "                      Kn1L: 0.0\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+                                 "Kn1L"),
+                  5.0));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("controller expressions may not reach outside their controller",
+          "[expr][lattices][controller][problems]") {
+    // Neither a lattice parameter nor another controller's variable may appear
+    // in an initial value or a control expression -- both are spelled with `>`,
+    // and both would make the evaluation order depend on more than the
+    // `controls` hierarchy.
+    const char* path = "tmp_ctrl_refs.pals.yaml";
+    write_tmp(path,
+              lattice_with(
+                  "    - ps1:\n"
+                  "        kind: Controller\n"
+                  "        variables:\n"
+                  "          cur: 0.5\n"
+                  "    - ps2:\n"
+                  "        kind: Controller\n"
+                  "        variables:\n"
+                  "          derived: ps1>cur * 2\n"
+                  "        controls:\n"
+                  "          - parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                  "            expression: Q1>length + 1\n",
+                  "                - Q1:\n"
+                  "                    kind: Quadrupole\n"
+                  "                    length: 0.5\n"
+                  "                    MagneticMultipoleP:\n"
+                  "                      Kn1L: 0.0\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    std::vector<std::string> msgs = problem_list(lat);
+    REQUIRE(any_contains(msgs, "variable 'derived' may not reference"));
+    REQUIRE(any_contains(msgs, "control expression may not reference"));
+
+    // Q1 keeps its own value: the rejected entry drives nothing.
+    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+                                 "Kn1L"),
+                  0.0));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a variable initial value may not reference a variable",
+          "[expr][lattices][controller][problems]") {
+    // An initial value is a constant expression: it may use the built-in and
+    // user constants but no variable, not even one of its own controller's, so
+    // that no initial value has to be evaluated before any other.
+    const char* path = "tmp_ctrl_var_ref.pals.yaml";
+    write_tmp(path,
+              lattice_with("    - ps1:\n"
+                           "        kind: Controller\n"
+                           "        variables:\n"
+                           "          cur1: 0.023\n"
+                           "          cur2: cur1 / c_light\n"
+                           "        controls:\n"
+                           "          - parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                           "            expression: cur1 + cur2\n",
+                           "                - Q1:\n"
+                           "                    kind: Quadrupole\n"
+                           "                    MagneticMultipoleP:\n"
+                           "                      Kn1L: 0.0\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(any_contains(problem_list(lat),
+                         "variable 'cur2': an initial value may not reference "
+                         "the variable 'cur1'"));
+
+    // The rejected initial value falls back to the default, zero, so the
+    // control expression is still evaluated: cur1 + 0.
+    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+                                 "Kn1L"),
+                  0.023));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a constant is not mistaken for a variable in an initial value",
+          "[expr][lattices][controller]") {
+    // The check is on whole identifiers: a variable named `light` must not make
+    // `c_light` look like a reference to it.
+    const char* path = "tmp_ctrl_var_substring.pals.yaml";
+    write_tmp(path,
+              lattice_with("    - ps1:\n"
+                           "        kind: Controller\n"
+                           "        variables:\n"
+                           "          light: 2\n"
+                           "          scaled: 1e8 / c_light\n"
+                           "        controls:\n"
+                           "          - parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                           "            expression: light * scaled\n",
+                           "                - Q1:\n"
+                           "                    kind: Quadrupole\n"
+                           "                    MagneticMultipoleP:\n"
+                           "                      Kn1L: 0.0\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+                                 "Kn1L"),
+                  2.0 * (1e8 / 2.99792458e8)));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a circular control hierarchy is reported",
+          "[expr][lattices][controller][problems]") {
+    const char* path = "tmp_ctrl_cycle.pals.yaml";
+    write_tmp(path, lattice_with("    - a:\n"
+                                 "        kind: Controller\n"
+                                 "        variables:\n"
+                                 "          va: 1\n"
+                                 "        controls:\n"
+                                 "          - parameter: b>vb\n"
+                                 "            expression: va\n"
+                                 "    - b:\n"
+                                 "        kind: Controller\n"
+                                 "        variables:\n"
+                                 "          vb: 2\n"
+                                 "        controls:\n"
+                                 "          - parameter: a>va\n"
+                                 "            expression: vb\n",
+                                 "                - Q1:\n"
+                                 "                    kind: Quadrupole\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(any_contains(problem_list(lat),
+                         "circular control hierarchy: 'a', 'b'"));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a parameter may not be driven by both controller types",
+          "[expr][lattices][controller][problems]") {
+    const char* path = "tmp_ctrl_mixed.pals.yaml";
+    write_tmp(path,
+              lattice_with(
+                  "    - ps1:\n"
+                  "        kind: Controller\n"
+                  "        control_type: ABSOLUTE\n"
+                  "        controls:\n"
+                  "          - parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                  "            expression: 0.5\n"
+                  "    - knob:\n"
+                  "        kind: Controller\n"
+                  "        control_type: RELATIVE\n"
+                  "        controls:\n"
+                  "          - parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                  "            expression: 0.25\n",
+                  "                - Q1:\n"
+                  "                    kind: Quadrupole\n"
+                  "                    MagneticMultipoleP:\n"
+                  "                      Kn1L: 0.11\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(any_contains(problem_list(lat),
+                         "Q1>MagneticMultipoleP.Kn1L is controlled by both an "
+                         "ABSOLUTE and a RELATIVE controller"));
+    // Neither is applied, so the element keeps its own value.
+    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+                                 "Kn1L"),
+                  0.11));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a controlled parameter may not also be delayed",
+          "[expr][lattices][controller][problems]") {
+    const char* path = "tmp_ctrl_delayed.pals.yaml";
+    write_tmp(path,
+              lattice_with("    - ps1:\n"
+                           "        kind: Controller\n"
+                           "        controls:\n"
+                           "          - parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                           "            expression: 0.5\n",
+                           "                - Q1:\n"
+                           "                    kind: Quadrupole\n"
+                           "                    MagneticMultipoleP:\n"
+                           "                      Kn1L: expr(0.1 + 0.2)\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(any_contains(problem_list(lat),
+                         "Q1>MagneticMultipoleP.Kn1L is both controlled and "
+                         "assigned a delayed evaluation expression"));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a controller target that matches nothing is reported",
+          "[expr][lattices][controller][problems]") {
+    const char* path = "tmp_ctrl_nomatch.pals.yaml";
+    write_tmp(path,
+              lattice_with("    - ps1:\n"
+                           "        kind: Controller\n"
+                           "        controls:\n"
+                           "          - parameter: nosuch>MagneticMultipoleP.Kn1L\n"
+                           "            expression: 0.5\n",
+                           "                - Q1:\n"
+                           "                    kind: Quadrupole\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(any_contains(problem_list(lat),
+                         "target 'nosuch>MagneticMultipoleP.Kn1L' matches "
+                         "nothing in the expanded lattice"));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("an unknown control_type is reported",
+          "[expr][lattices][controller][problems]") {
+    const char* path = "tmp_ctrl_badtype.pals.yaml";
+    write_tmp(path, lattice_with("    - ps1:\n"
+                                 "        kind: Controller\n"
+                                 "        control_type: SOMETHING\n"
+                                 "        controls:\n"
+                                 "          - parameter: Q1>length\n"
+                                 "            expression: 0.5\n",
+                                 "                - Q1:\n"
+                                 "                    kind: Quadrupole\n"
+                                 "                    length: 0.2\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(any_contains(problem_list(lat),
+                         "control_type must be ABSOLUTE or RELATIVE, not "
+                         "SOMETHING"));
+
+    free_all(lat);
     rm_tmp(path);
 }

--- a/tests/test_sets.cpp
+++ b/tests/test_sets.cpp
@@ -1,0 +1,553 @@
+#include "test_helpers.h"
+
+// `set` commands: miscellaneous.md (s:set) for the syntax, and
+// lattice-construction.md (s:lattice.expand, s:expand.lat) for where a set acts
+// depending on which side of `expand_lattice` it sits on.
+
+namespace {
+
+std::vector<std::string> problem_list(const struct lattices& lat) {
+    std::vector<std::string> msgs;
+    for (size_t i = 0; i < lat.problems.count; ++i)
+        msgs.emplace_back(lat.problems.items[i]);
+    return msgs;
+}
+
+std::string joined(const struct lattices& lat) {
+    std::string s;
+    for (const std::string& m : problem_list(lat)) s += m + "; ";
+    return s;
+}
+
+bool any_contains(const std::vector<std::string>& msgs, const char* needle) {
+    for (const std::string& m : msgs)
+        if (m.find(needle) != std::string::npos) return true;
+    return false;
+}
+
+void free_all(struct lattices& lat) {
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+}
+
+// A file whose `facility` list is exactly `body` (10-space indented entries),
+// followed by a lattice built from the beamline named `line_name` and a `use`.
+std::string facility_file(const std::string& body, const char* line_name) {
+    return "PALS:\n"
+           "  facility:\n" +
+           body + "    - lat1:\n"
+                  "        kind: Lattice\n"
+                  "        branches:\n"
+                  "          - " +
+           line_name +
+           "\n"
+           "    - use: \"lat1\"\n";
+}
+
+// The value of `group.param` on the `index`-th element named `ele` in the
+// expanded lattice (index 0 being the first).
+double nth_param(YAMLTreeHandle t, const char* ele, size_t index,
+                 const char* group, const char* param) {
+    std::vector<YAMLNodeId> hits;
+    std::vector<YAMLNodeId> stack{get_root(t)};
+    while (!stack.empty()) {
+        YAMLNodeId n = stack.back();
+        stack.pop_back();
+        char* k = get_node_key(t, n);
+        if (k && std::string(k) == ele) hits.push_back(n);
+        yaml_free_string(k);
+        // Push children in reverse so the walk visits them in document order.
+        size_t sz = get_size(t, n);
+        for (size_t i = sz; i-- > 0;) stack.push_back(get_child_by_index(t, n, i));
+    }
+    REQUIRE(hits.size() > index);
+    YAMLNodeId e = hits[index];
+    YAMLNodeId g = group ? get_child_by_key(t, e, group) : e;
+    REQUIRE(g != YAML_NULL_ID);
+    return num_val(t, get_child_by_key(t, g, param));
+}
+
+double one_param(YAMLTreeHandle t, const char* ele, const char* group,
+                 const char* param) {
+    return nth_param(t, ele, 0, group, param);
+}
+
+// A beamline holding one BeginningEle plus whatever `body` adds.
+const char* BEGIN_ENTRY =
+    "          - begin:\n"
+    "              kind: BeginningEle\n"
+    "              ReferenceP:\n"
+    "                species_ref: \"electron\"\n"
+    "                E_tot_ref: 1.0e9\n";
+
+}  // namespace
+
+TEST_CASE("a set writes every element its pattern matches",
+          "[expr][lattices][set]") {
+    // miscellaneous.md: `PARAMETER` is the current value of the parameter being
+    // written and `SELF` reaches the rest of the element.
+    const char* path = "tmp_set_basic.pals.yaml";
+    write_tmp(path,
+              facility_file(std::string(
+                                "    - main:\n"
+                                "        kind: BeamLine\n"
+                                "        line:\n") +
+                                BEGIN_ENTRY +
+                                "          - B1a:\n"
+                                "              kind: Bend\n"
+                                "              length: 1.0\n"
+                                "              BendP:\n"
+                                "                e1: 0.1\n"
+                                "                g_ref: 0.02\n"
+                                "          - B1b:\n"
+                                "              kind: Bend\n"
+                                "              length: 1.0\n"
+                                "              BendP:\n"
+                                "                e1: 0.3\n"
+                                "                g_ref: 0.02\n"
+                                "          - Q1:\n"
+                                "              kind: Quadrupole\n"
+                                "              length: 0.5\n"
+                                "    - set:\n"
+                                "        parameter: B1.*>BendP.e1\n"
+                                "        value: 2*PARAMETER + atan(SELF.BendP.g_ref)\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    REQUIRE(close(one_param(lat.expanded, "B1a", "BendP", "e1"),
+                  2 * 0.1 + std::atan(0.02)));
+    REQUIRE(close(one_param(lat.expanded, "B1b", "BendP", "e1"),
+                  2 * 0.3 + std::atan(0.02)));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a set only reaches elements defined before it",
+          "[expr][lattices][set]") {
+    // The example of lattice-construction.md, s:lattice.expand: Q2 is defined
+    // after the set, so the set does not touch it.
+    const char* path = "tmp_set_order.pals.yaml";
+    write_tmp(path,
+              facility_file("    - Q1:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "        MagneticMultipoleP:\n"
+                            "          Kn1L: 0.1\n"
+                            "    - set:\n"
+                            "        parameter: Q.*>MagneticMultipoleP.Kn1L\n"
+                            "        value: PARAMETER + 0.02\n"
+                            "    - Q2:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "        MagneticMultipoleP:\n"
+                            "          Kn1L: 0.1\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) +
+                                "          - Q1\n"
+                                "          - Q2\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    REQUIRE(close(one_param(lat.expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
+                  0.12));
+    REQUIRE(close(one_param(lat.expanded, "Q2", "MagneticMultipoleP", "Kn1L"),
+                  0.1));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a set creates a parameter that defaults to zero",
+          "[expr][lattices][set]") {
+    // s:lattice.expand: an unwritten parameter of a known element reads as zero,
+    // so `PARAMETER + 0.02` on an element with no MagneticMultipoleP is 0.02.
+    const char* path = "tmp_set_default.pals.yaml";
+    write_tmp(path,
+              facility_file("    - Q1:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "    - set:\n"
+                            "        parameter: Q1>MagneticMultipoleP.Kn0\n"
+                            "        value: PARAMETER + 0.02\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) + "          - Q1\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+    REQUIRE(close(one_param(lat.expanded, "Q1", "MagneticMultipoleP", "Kn0"),
+                  0.02));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("reading a not-yet-derived parameter in a set is an error",
+          "[expr][lattices][set][problems]") {
+    // The second example of s:lattice.expand: Q1's Bs1 will be derived from its
+    // Ks1 and the reference momentum, which is not known when the set runs, so
+    // reading Bs1 here is an error rather than reading zero.
+    const char* path = "tmp_set_pending.pals.yaml";
+    write_tmp(path,
+              facility_file("    - Q1:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "        MagneticMultipoleP:\n"
+                            "          Ks1: 0.34\n"
+                            "    - Q2:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "    - set:\n"
+                            "        parameter: Q2>MagneticMultipoleP.Bs1\n"
+                            "        value: Q1>MagneticMultipoleP.Bs1\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) +
+                                "          - Q1\n"
+                                "          - Q2\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(any_contains(problem_list(lat),
+                         "'Q1>MagneticMultipoleP.Bs1' has no value yet"));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("an unwritten parameter with no written family member reads as zero",
+          "[expr][lattices][set]") {
+    // The same shape as the error case, but with Ks1 left unset: nothing in the
+    // family is written, so Bs1 is simply zero and there is no error.
+    const char* path = "tmp_set_nopending.pals.yaml";
+    write_tmp(path,
+              facility_file("    - Q1:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "    - Q2:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "    - set:\n"
+                            "        parameter: Q2>MagneticMultipoleP.Kn1L\n"
+                            "        value: Q1>MagneticMultipoleP.Bs1 + 0.5\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) +
+                                "          - Q1\n"
+                                "          - Q2\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+    REQUIRE(close(one_param(lat.expanded, "Q2", "MagneticMultipoleP", "Kn1L"),
+                  0.5));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("the compact sets form writes each pair", "[expr][lattices][set]") {
+    const char* path = "tmp_sets_compact.pals.yaml";
+    write_tmp(path,
+              facility_file("    - Q1:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "    - D1:\n"
+                            "        kind: Drift\n"
+                            "        length: 1.0\n"
+                            "    - sets:\n"
+                            "        - Q1>MagneticMultipoleP.Kn1L: 0.25\n"
+                            "        - D1>length: 2 * 1.5\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) +
+                                "          - Q1\n"
+                                "          - D1\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+    REQUIRE(close(one_param(lat.expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
+                  0.25));
+    REQUIRE(close(one_param(lat.expanded, "D1", nullptr, "length"), 3.0));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("without expand_lattice a set writes the single definition",
+          "[expr][lattices][set]") {
+    // s:expand.lat: the repeated element has not been instantiated yet, so the
+    // set targets the one definition and all three copies inherit its value.
+    const char* path = "tmp_set_norepeat.pals.yaml";
+    write_tmp(path,
+              facility_file("    - q1:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "        MagneticMultipoleP:\n"
+                            "          Kn1L: 0.375\n"
+                            "    - set:\n"
+                            "        parameter: q1>MagneticMultipoleP.Kn1L\n"
+                            "        value: PARAMETER * 2\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) +
+                                "          - q1:\n"
+                                "              repeat: 3\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+    for (size_t i = 0; i < 3; ++i)
+        REQUIRE(close(nth_param(lat.expanded, "q1", i, "MagneticMultipoleP",
+                                "Kn1L"),
+                      0.75));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("after expand_lattice a set reaches each expanded copy",
+          "[expr][lattices][set]") {
+    // The point of `expand_lattice`: with the lattice built, the three copies of
+    // `q1` are separate elements and the set writes each of them. The value used
+    // here depends on the copy's own s_position, which only exists after
+    // expansion, so it also pins down that the bookkeeper has already run.
+    const char* path = "tmp_set_expanded.pals.yaml";
+    write_tmp(path,
+              facility_file("    - q1:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "        MagneticMultipoleP:\n"
+                            "          Kn1L: 0.375\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) +
+                                "          - q1:\n"
+                                "              repeat: 3\n"
+                                "    - expand_lattice\n"
+                                "    - set:\n"
+                                "        parameter: lat1>>>q1>MagneticMultipoleP.Kn1L\n"
+                                "        value: PARAMETER + SELF.s_position\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    // The copies sit at s = 0, 0.5 and 1.0.
+    for (size_t i = 0; i < 3; ++i)
+        REQUIRE(close(nth_param(lat.expanded, "q1", i, "MagneticMultipoleP",
+                                "Kn1L"),
+                      0.375 + 0.5 * static_cast<double>(i)));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a post-expansion set makes the bookkeeper redo the family",
+          "[expr][lattices][set]") {
+    // Writing Kn1L after the bookkeeper has already derived Bn1L from the old
+    // value must not leave the two inconsistent (nor be reported as such): the
+    // stale family members are dropped and the second bookkeeper pass rebuilds
+    // them. q2 is written out with the value the set gives q1, so the derived
+    // Bn1L must come out the same for both.
+    const char* path = "tmp_set_rederive.pals.yaml";
+    write_tmp(path,
+              facility_file("    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) +
+                                "          - q1:\n"
+                                "              kind: Quadrupole\n"
+                                "              length: 0.5\n"
+                                "              MagneticMultipoleP:\n"
+                                "                Kn1L: 0.375\n"
+                                "          - q2:\n"
+                                "              kind: Quadrupole\n"
+                                "              length: 0.5\n"
+                                "              MagneticMultipoleP:\n"
+                                "                Kn1L: 0.75\n"
+                                "    - expand_lattice\n"
+                                "    - set:\n"
+                                "        parameter: q1>MagneticMultipoleP.Kn1L\n"
+                                "        value: PARAMETER * 2\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    REQUIRE(close(one_param(lat.expanded, "q1", "MagneticMultipoleP", "Kn1L"),
+                  0.75));
+    double b1 = one_param(lat.expanded, "q1", "MagneticMultipoleP", "Bn1L");
+    double b2 = one_param(lat.expanded, "q2", "MagneticMultipoleP", "Bn1L");
+    REQUIRE(b1 != 0.0);
+    REQUIRE(close_rel(b1, b2));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a post-expansion set that changes a length moves the lattice",
+          "[expr][lattices][set]") {
+    // "Recalculate floor and reference parameters as needed": lengthening the
+    // drift after expansion has to move everything downstream of it.
+    const char* path = "tmp_set_length.pals.yaml";
+    write_tmp(path,
+              facility_file("    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) +
+                                "          - d1:\n"
+                                "              kind: Drift\n"
+                                "              length: 1.0\n"
+                                "          - m1:\n"
+                                "              kind: Marker\n"
+                                "    - expand_lattice\n"
+                                "    - set:\n"
+                                "        parameter: d1>length\n"
+                                "        value: 3.5\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+    REQUIRE(close(one_param(lat.expanded, "m1", nullptr, "s_position"), 3.5));
+    REQUIRE(close(one_param(lat.expanded, "m1", "FloorP", "z"), 3.5));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("controllers stay authoritative over a post-expansion set",
+          "[expr][lattices][set][controller]") {
+    // s:lattice.expand applies the ABSOLUTE controllers after the
+    // post-expansion list, so a controller-driven parameter keeps the
+    // controller's value even when a later set writes it.
+    const char* path = "tmp_set_controller.pals.yaml";
+    write_tmp(path,
+              facility_file("    - ps1:\n"
+                            "        kind: Controller\n"
+                            "        controls:\n"
+                            "          - parameter: q1>MagneticMultipoleP.Kn1L\n"
+                            "            expression: 0.9\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) +
+                                "          - q1:\n"
+                                "              kind: Quadrupole\n"
+                                "              length: 0.5\n"
+                                "              MagneticMultipoleP:\n"
+                                "                Kn1L: 0.1\n"
+                                "    - expand_lattice\n"
+                                "    - set:\n"
+                                "        parameter: q1>MagneticMultipoleP.Kn1L\n"
+                                "        value: 0.2\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+    REQUIRE(close(one_param(lat.expanded, "q1", "MagneticMultipoleP", "Kn1L"),
+                  0.9));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a set with an error term reports that it is not applied",
+          "[expr][lattices][set][problems]") {
+    // The standard gives the error magnitude but not its distribution, and this
+    // library never invents randomness, so the deterministic value is written
+    // and the error is flagged.
+    const char* path = "tmp_set_error.pals.yaml";
+    write_tmp(path,
+              facility_file("    - Q1:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "        MagneticMultipoleP:\n"
+                            "          Kn1L: 0.4\n"
+                            "    - set:\n"
+                            "        parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                            "        value: PARAMETER\n"
+                            "        relative_error: 1e-4\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) + "          - Q1\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(any_contains(problem_list(lat),
+                         "absolute_error/relative_error are not applied"));
+    REQUIRE(close(one_param(lat.expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
+                  0.4));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a set whose target matches nothing is reported",
+          "[expr][lattices][set][problems]") {
+    const char* path = "tmp_set_nomatch.pals.yaml";
+    write_tmp(path,
+              facility_file("    - set:\n"
+                            "        parameter: nosuch>length\n"
+                            "        value: 1.0\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY),
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(any_contains(problem_list(lat),
+                         "set 'nosuch>length': target matches nothing defined "
+                         "before it"));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a set with a random value is deferred", "[expr][lattices][set]") {
+    // random()/random_gauss() are deferred everywhere so the expanded tree stays
+    // reproducible; a set driven by one leaves its parameter alone.
+    const char* path = "tmp_set_random.pals.yaml";
+    write_tmp(path,
+              facility_file("    - Q1:\n"
+                            "        kind: Quadrupole\n"
+                            "        length: 0.5\n"
+                            "        MagneticMultipoleP:\n"
+                            "          Kn1L: 0.375\n"
+                            "    - set:\n"
+                            "        parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                            "        value: PARAMETER * (1 + 1e-4*random_gauss())\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) + "          - Q1\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+    REQUIRE(close(one_param(lat.expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
+                  0.375));
+
+    free_all(lat);
+    rm_tmp(path);
+}


### PR DESCRIPTION
Brings lattice expansion in line with [pals#237](https://github.com/pals-project/pals/pull/237) (`Controller`) and [pals#268](https://github.com/pals-project/pals/pull/268) (lattice expansion), plus the `set` and `expand_lattice` sections already on `pals` main.

## Controllers

Controllers were evaluated but never **applied** — `control_type` was read and ignored, so the lattice was untouched.

- ABSOLUTE controllers now drive the parameters their `parameter` pattern matches, each set to the **sum** over the controllers driving it, replacing the element's own value. A parameter the element does not carry is created.
- RELATIVE controllers take no part in expansion: the parameter keeps the value its element gives, and only the control expression is evaluated for the program that varies the knob later.
- Applied after branch/fork expansion and before the bookkeeper, so reference, floor and dependent parameters are computed from the driven values.
- Controllers driving another controller's variable form a hierarchy, evaluated top-down; cycles are reported. `control_type` defaults to `ABSOLUTE` and is materialized. A variable with no value is zero, and an initial value is a constant expression — neither it nor a control expression may reach outside its own controller.
- Reported: circular hierarchy, a parameter driven by both types, a parameter both controlled and `expr(...)`-delayed, a target matching nothing, an unknown `control_type`.

## `set` and `expand_lattice`

Both were absent entirely. An `expand_lattice` node now divides the `facility` list and the pipeline follows the documented order:

```
pre-expansion sets → branch/fork expansion → ABSOLUTE controllers → bookkeeper
  → post-expansion sets → ABSOLUTE controllers → bookkeeper
```

- **Before** `expand_lattice` a set writes the element *definitions*, and only those defined earlier in the list — so every expanded copy inherits one value.
- **After** it, a set writes each expanded element separately, and may use computed values (`SELF.s_position`).
- `value` expressions take `PARAMETER` (the value being replaced) and `SELF.<path>` (the owning element). The compact `sets:` form is supported.
- An unwritten parameter reads as **zero**, unless a member of its linked family is written — then its value is still to be derived and reading it is an error, per the `Bs1`/`Ks1` example.
- That same family notion lets a post-expansion set drop what it invalidated, so the second bookkeeper pass rebuilds it instead of flagging an inconsistency.

## Not implemented

`absolute_error`/`relative_error` are parsed and **reported rather than applied**: the standard gives the error magnitude (`absolute_error + relative_error * |value|`) but not its distribution, and this library defers randomness everywhere else so `expanded` stays reproducible.

## Tests

203 pass (was 174). New `tests/test_sets.cpp` (14 cases) and a rewritten `tests/test_controllers.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)