### PR TITLE
Handle load commands alongside includes in the combined tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Introduction
 Pals-cpp is the parser library for PALS accelerator lattice files. It uses rapidyaml https://github.com/biojppm/rapidyaml to read lattices into memory and provides additional capabilities like printing to console, writing to files, and searching for elements. One major component is performing lattice expansion following the PALS specifications:
 1. The lattice to be expanded can be specified by the user. If none is specified, the one in the last `use: root_lattice` statement will be expanded. If none exists, the last lattice in the file is expanded. 
-2. Content from other files can be brought into scope using `include: filename`
+2. Content from other files can be brought into scope in two ways. An `include: filename` splices that file's contents in verbatim at the point the `include` is written. A `load` list under the `PALS` node instead merges whole files subnode by subnode — list subnodes concatenate in load order, dictionary subnodes take the union, and `SELF` marks where the joining file's own contents belong — which is how a layout file and a settings file are composed into one lattice. Paths are relative to the file naming them, and both can nest to any depth.
 3. Elements that inherit parameters from other elements will have those properties brought into scope.
 4. Beamlines in a lattice with a `repeat: count` will have their contents repeated `count` times in the lattice.
 5. Elements in a lattice defined outside of it will have their definitions brought it.
@@ -84,9 +84,10 @@ This builds `libyaml_c_wrapper.dylib`, a shared object library that can interfac
 
 ### Example 2
 The program `examples/print_lattices` performs lattice expansion on a user-specified lattice. The first argument is the file name where the lattice is defined. It also takes an option argument using `-lat root_lattice` to specify a specific lattice to expand, otherwise it will choose a default (the lattice in the last `use` statement, or the last lattice in the file if none is present). The program will create and print a struct containing three lattices:
-- `original` is a map containing the base lattice as well as any lattices included
-in the base lattice.
-- `combined` is the base lattice but with all included files substituted in.
+- `original` is a map containing the base lattice as well as any file it reaches
+by `include` or `load`.
+- `combined` is the base lattice but with all included files substituted in and
+all loaded files merged in.
 - `expanded` is the base lattice after lattice expansion has been performed.
 To see the console output, in the build directory, run
 
@@ -116,7 +117,7 @@ The library sources live in `src/`, split by concern:
   low-level tree helpers (`ensure_capacity`, `deep_copy_recursive`).
 - `pals_expand.cpp` — the lattice expansion pipeline that builds the four-tree
   representation (`original` / `combined` / `expanded` / `leftover`): include
-  splicing, structural expansion (repeats, inherits, forks), expression,
+  splicing, `load` merging, structural expansion (repeats, inherits, forks), expression,
   controller and `set` evaluation, and the element bookkeeper that walks each
   branch
   filling in reference parameters, floor placement, s-positions and dependent

--- a/docs/src/guide/usage.md
+++ b/docs/src/guide/usage.md
@@ -19,8 +19,9 @@ tests. Put lattice files under `lattice_files/`.
 
 ## Expanding a lattice
 
-`parse_and_expand_PALS` reads a lattice file, resolves its includes, expands the
-selected lattice, and returns a `lattices` struct with four independent views —
+`parse_and_expand_PALS` reads a lattice file, resolves its includes and loads,
+expands the selected lattice, and returns a `lattices` struct with four
+independent views —
 `original`, `combined`, `expanded`, and `leftover` (see
 [What it does](../index.md)). Each is a `YAMLTreeHandle` and must be freed with
 `delete_tree`.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,10 +28,12 @@ api
 Lattice expansion follows the PALS specification and produces four views of a
 document:
 
-1. **`original`** — the raw tree mapping each file (including `include`d files)
-   to its unparsed contents.
+1. **`original`** — the raw tree mapping each file the document is built from —
+   the top-level file and every file it reaches by `include` or `load`, at any
+   depth — to its unparsed contents, keyed by path.
 2. **`combined`** — the tree with every `include` directive resolved and spliced
-   inline.
+   inline, and every `load`ed file merged in subnode by subnode under the `PALS`
+   root.
 3. **`expanded`** — the selected lattice fully expanded, and nothing else:
    elements substituted with their definitions, `repeat`ed beamlines unrolled,
    `inherit`ed ancestors merged, forks resolved, every mathematical expression

--- a/lattice_files/load_joiner.pals.yaml
+++ b/lattice_files/load_joiner.pals.yaml
@@ -1,0 +1,19 @@
+# A "joiner" file: the layout, then a settings file, then whatever this file
+# adds on top of both. `SELF` is where this file's own contents go -- here it is
+# last, which is also where they would go had it been left out.
+#
+#   ./print_lattices load_joiner.pals.yaml
+#
+PALS:
+  notes:
+    - "Nominal configuration, with Q1b tweaked for the day's running."
+
+  load:
+    - load_layout.pals.yaml
+    - load_settings.pals.yaml
+    - SELF
+
+  facility:
+    - set:
+        parameter: Q1b>MagneticMultipoleP.Kn1
+        value: -0.36

--- a/lattice_files/load_layout.pals.yaml
+++ b/lattice_files/load_layout.pals.yaml
@@ -1,0 +1,33 @@
+# Layout half of the load example: what the machine is made of.
+# See load_joiner.pals.yaml.
+PALS:
+  version: "0.1"
+
+  notes:
+    - "Layout only. Magnet settings live in load_settings.pals.yaml."
+
+  facility:
+    - main:
+        kind: BeamLine
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: "electron"
+                E_tot_ref: 1.0e9
+          - Q1a:
+              kind: Quadrupole
+              length: 0.5
+          - D1:
+              kind: Drift
+              length: 1.2
+          - Q1b:
+              kind: Quadrupole
+              length: 0.5
+
+    - lat1:
+        kind: Lattice
+        branches:
+          - main
+
+    - use: "lat1"

--- a/lattice_files/load_settings.pals.yaml
+++ b/lattice_files/load_settings.pals.yaml
@@ -1,0 +1,16 @@
+# Settings half of the load example: one configuration of the machine
+# load_layout.pals.yaml lays out. Several of these can share the one layout.
+PALS:
+  version: "0.1"
+
+  notes:
+    - "Settings for the nominal focusing configuration."
+
+  facility:
+    - set:
+        parameter: Q1a>MagneticMultipoleP.Kn1
+        value: 0.34
+
+    - set:
+        parameter: Q1b>MagneticMultipoleP.Kn1
+        value: -0.34

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -1,7 +1,8 @@
 // PALS lattice expansion pipeline: builds the four-tree representation
 // (original / combined / expanded / leftover) from a PALS YAML file. Splices
-// includes, expands the selected lattice (repeats, inherits, forks), evaluates
-// expressions into the expanded tree, and applies the controllers that drive
+// includes, merges `load`ed files, expands the selected lattice (repeats,
+// inherits, forks), evaluates expressions into the expanded tree, and applies
+// the controllers that drive
 // its parameters. Name matching and parameter lookup live in pals_match.cpp;
 // the generic YAML tree wrapper in yaml_c_wrapper.cpp.
 
@@ -771,14 +772,74 @@ static void number_multipass_branches(ryml::Tree& t, size_t lat_node,
     }
 }
 
+// ============================================================
+// FILE REFERENCE PATHS (include / load)
+// ============================================================
+//
+// A file named by an `include` or a `load` is located relative to the file that
+// names it, not to the process working directory, so a set of files that refer
+// to each other can be moved or checked out anywhere as a unit. Resolution is
+// purely lexical -- the naming file's directory is prepended and the result is
+// folded -- so one file reaches the `original` master tree under one key
+// whatever route led to it, and a reference cycle is recognisable by that key.
+
+// Everything up to the last '/' in `p`; empty when `p` names a bare file.
+static std::string path_dir(const std::string& p) {
+    size_t slash = p.find_last_of('/');
+    return (slash == std::string::npos) ? std::string() : p.substr(0, slash);
+}
+
+// Collapse "." and "x/.." segments and repeated separators. Leading ".." is
+// kept (there is no way to know what it resolves to without touching the
+// filesystem) except on an absolute path, where it cannot rise above "/".
+static std::string fold_path(const std::string& p) {
+    const bool absolute = !p.empty() && p[0] == '/';
+    std::vector<std::string> parts;
+    for (size_t i = 0; i < p.size();) {
+        size_t j = p.find('/', i);
+        if (j == std::string::npos) j = p.size();
+        std::string seg = p.substr(i, j - i);
+        i = j + 1;
+        if (seg.empty() || seg == ".") continue;
+        if (seg != "..") {
+            parts.push_back(seg);
+        } else if (!parts.empty() && parts.back() != "..") {
+            parts.pop_back();
+        } else if (!absolute) {
+            parts.push_back(seg);
+        }
+    }
+    std::string out = absolute ? "/" : "";
+    for (size_t k = 0; k < parts.size(); ++k) {
+        if (k) out += "/";
+        out += parts[k];
+    }
+    if (out.empty()) out = ".";
+    return out;
+}
+
+// The path of the file `ref` names, as named from inside the file at `from`.
+static std::string resolve_path(const std::string& from,
+                                const std::string& ref) {
+    if (!ref.empty() && ref[0] == '/') return fold_path(ref);
+    std::string dir = path_dir(from);
+    return fold_path(dir.empty() ? ref : dir + "/" + ref);
+}
+
 /**
  * Recursive helper for make_combined_from_original. Starting from `node` in the
  * combined tree `t`, replace every "include: filename" element with the
  * contents of that file, sourced from the already-parsed `original` tree so
  * provenance can be recorded. Also recurses into spliced content to handle
  * nested include statements.
+ *
+ * `path` is the resolved path of the file whose contents `node` sits in, which
+ * is what its include references are relative to. Spliced-in content is walked
+ * with the included file's own path, so a chain of includes each resolves
+ * against the file that wrote it.
  */
 static void make_combined_splice(ryml::Tree& t, size_t node, ParsedData* orig,
+                                 const std::string& path,
                                  std::map<size_t, size_t>& prov) {
     if (node == ryml::NONE) return;
 
@@ -805,10 +866,12 @@ static void make_combined_splice(ryml::Tree& t, size_t node, ParsedData* orig,
 
             if (is_include) {
                 // Look up the included file's raw contents in `original`. It is
-                // stored keyed by the exact filename string used in the include.
+                // stored keyed by its path resolved against the naming file --
+                // the same key make_original registered it under.
+                const std::string inc_path = resolve_path(path, filename);
                 ryml::Tree& ot = orig->tree;
                 size_t inc_root =
-                    ot.find_child(ot.root_id(), ryml::to_csubstr(filename));
+                    ot.find_child(ot.root_id(), ryml::to_csubstr(inc_path));
                 size_t after = child;
                 std::vector<size_t> inserted;
                 if (inc_root != ryml::NONE) {
@@ -832,35 +895,304 @@ static void make_combined_splice(ryml::Tree& t, size_t node, ParsedData* orig,
                         inserted.push_back(n);
                     }
                 }
-                // Recurse into inserted nodes to handle nested includes
-                for (size_t n : inserted) make_combined_splice(t, n, orig, prov);
+                // Recurse into inserted nodes to handle nested includes. Those
+                // are the included file's own, so they resolve against it.
+                for (size_t n : inserted)
+                    make_combined_splice(t, n, orig, inc_path, prov);
                 erase_prov_subtree(t, child, prov);
                 t.remove(child);
                 child = next;
                 continue;
             }
 
-            make_combined_splice(t, child, orig, prov);
+            make_combined_splice(t, child, orig, path, prov);
             child = next;
         }
         return;
     }
 
     for (size_t c = t.first_child(node); c != ryml::NONE; c = t.next_sibling(c))
-        make_combined_splice(t, c, orig, prov);
+        make_combined_splice(t, c, orig, path, prov);
+}
+
+// ============================================================
+// LOAD
+// ============================================================
+//
+// `load` and `include` both draw several files into the combined tree, but
+// where an include splices a file's contents in verbatim at the point it is
+// written, a load merges whole files subnode by subnode under the `PALS` root.
+// The typical use is a layout file plus one of several settings files, joined
+// by a small file that names both.
+//
+// Includes are resolved first, so each file is complete before files are
+// combined; loading is bottom-up, so a loaded file that loads further files is
+// itself a single merged file by the time it is merged into its joiner.
+
+// The `load` list entry standing for the joiner file's own contents. Absent
+// from the list, they are merged last.
+static const char* const LOAD_SELF = "SELF";
+
+// Structural equality of two subtrees: same shape, keys and values throughout.
+// `load` allows two files to supply the same dictionary entry only when they
+// agree on it, and this is what "agree" means.
+static bool nodes_equal(const ryml::Tree& t, size_t a, size_t b) {
+    if (a == ryml::NONE || b == ryml::NONE) return a == b;
+    if (t.is_map(a) != t.is_map(b) || t.is_seq(a) != t.is_seq(b)) return false;
+    if (t.has_key(a) != t.has_key(b)) return false;
+    if (t.has_key(a) && t.key(a) != t.key(b)) return false;
+    if (t.has_val(a) != t.has_val(b)) return false;
+    if (t.has_val(a) && t.val(a) != t.val(b)) return false;
+    size_t ca = t.first_child(a), cb = t.first_child(b);
+    for (; ca != ryml::NONE && cb != ryml::NONE;
+         ca = t.next_sibling(ca), cb = t.next_sibling(cb))
+        if (!nodes_equal(t, ca, cb)) return false;
+    return ca == ryml::NONE && cb == ryml::NONE;
+}
+
+// Combine two `version` strings. Files written against different versions of
+// the schema keep both on record rather than one silently winning, so the
+// combined value is the distinct versions in first-seen order, comma delimited.
+// `have` may already be such a list from an earlier merge.
+static std::string merge_versions(const std::string& have,
+                                  const std::string& add) {
+    std::vector<std::string> seen;
+    auto note = [&seen](const std::string& raw) {
+        size_t b = raw.find_first_not_of(" \t");
+        if (b == std::string::npos) return;
+        size_t e = raw.find_last_not_of(" \t");
+        std::string v = raw.substr(b, e - b + 1);
+        if (std::find(seen.begin(), seen.end(), v) == seen.end())
+            seen.push_back(v);
+    };
+    for (size_t i = 0; i <= have.size();) {
+        size_t j = have.find(',', i);
+        if (j == std::string::npos) j = have.size();
+        note(have.substr(i, j - i));
+        i = j + 1;
+    }
+    note(add);
+    std::string out;
+    for (size_t k = 0; k < seen.size(); ++k) {
+        if (k) out += ", ";
+        out += seen[k];
+    }
+    return out;
+}
+
+/**
+ * Merge one file's `PALS` subnodes into the accumulating `dest` map.
+ *
+ * A subnode `dest` does not have yet is copied in whole. Otherwise the two are
+ * combined by type: list subnodes (`notes`, `authors`, `facility`, ...)
+ * concatenate, so the combined list keeps the order of the `load` list and,
+ * within each file, the order written there; Dict subnodes
+ * (`extension_labels`) take the union, with a duplicate entry discarded when
+ * the two files agree on it and reported when they do not; and `version`
+ * collects the distinct version strings. Any other disagreement over a plain
+ * value is reported and the value already in `dest` -- the earlier file's --
+ * stands.
+ *
+ * `src_name` names the file `src` came from, for problem messages.
+ */
+static void merge_pals_into(ryml::Tree& t, size_t dest, size_t src,
+                            const std::string& src_name,
+                            std::map<size_t, size_t>& prov,
+                            ProblemList& problems) {
+    if (dest == ryml::NONE || src == ryml::NONE || !t.is_map(src)) return;
+
+    for (size_t sc = t.first_child(src); sc != ryml::NONE;
+         sc = t.next_sibling(sc)) {
+        if (!t.has_key(sc)) continue;
+        // Held as a std::string: writing into the tree's arena below can
+        // relocate it, and with it any csubstr pointing into it.
+        const std::string key(t.key(sc).str, t.key(sc).len);
+        const size_t dc = t.find_child(dest, ryml::to_csubstr(key));
+
+        if (dc == ryml::NONE) {
+            ensure_capacity(t, 2);
+            duplicate_tracked(t, sc, dest, t.last_child(dest), prov);
+            continue;
+        }
+
+        if (key == "version" && t.has_val(dc) && t.has_val(sc)) {
+            const std::string merged =
+                merge_versions(std::string(t.val(dc).str, t.val(dc).len),
+                               std::string(t.val(sc).str, t.val(sc).len));
+            t.set_val(dc, t.to_arena(ryml::to_csubstr(merged)));
+            continue;
+        }
+
+        if (t.is_seq(dc) && t.is_seq(sc)) {
+            size_t after = t.last_child(dc);
+            for (size_t e = t.first_child(sc); e != ryml::NONE;
+                 e = t.next_sibling(e)) {
+                ensure_capacity(t, 2);
+                after = duplicate_tracked(t, e, dc, after, prov);
+            }
+            continue;
+        }
+
+        if (t.is_map(dc) && t.is_map(sc)) {
+            size_t after = t.last_child(dc);
+            for (size_t e = t.first_child(sc); e != ryml::NONE;
+                 e = t.next_sibling(e)) {
+                if (!t.has_key(e)) continue;
+                const std::string sub(t.key(e).str, t.key(e).len);
+                size_t have = t.find_child(dc, ryml::to_csubstr(sub));
+                if (have == ryml::NONE) {
+                    ensure_capacity(t, 2);
+                    after = duplicate_tracked(t, e, dc, after, prov);
+                } else if (!nodes_equal(t, have, e)) {
+                    add_problem(problems, "load: '" + src_name +
+                                              "' disagrees on the value of '" +
+                                              key + "." + sub + "'");
+                }
+            }
+            continue;
+        }
+
+        if (t.has_val(dc) && t.has_val(sc) && t.val(dc) == t.val(sc)) continue;
+
+        add_problem(problems, "load: '" + src_name +
+                                  "' disagrees on the value of '" + key + "'");
+    }
+}
+
+/**
+ * Resolve one file's `load` list, in place, replacing its `PALS` node with the
+ * merge of every file it names.
+ *
+ * `pals` is the file's `PALS` node in the combined tree and `path` the resolved
+ * path of the file it came from, which its own load references are relative to.
+ * Each loaded file is staged under a scratch node: copied out of `original`,
+ * spliced for its own includes, then resolved for its own `load` -- so it is a
+ * single complete file before it takes part in this merge, and nesting works to
+ * any depth. The joiner's own contents are staged the same way, which is what
+ * lets `SELF` sit anywhere in the order: `pals` can then be emptied and refilled
+ * with the merge of every source, taken in load-list order.
+ *
+ * `active` holds the files whose loads are being resolved further up the
+ * recursion, so a cycle is reported rather than followed forever.
+ */
+static void resolve_loads(ryml::Tree& t, size_t pals, ParsedData* orig,
+                          const std::string& path,
+                          std::map<size_t, size_t>& prov,
+                          std::set<std::string>& active,
+                          ProblemList& problems) {
+    if (pals == ryml::NONE || !t.is_map(pals)) return;
+    size_t load = t.find_child(pals, ryml::to_csubstr("load"));
+    if (load == ryml::NONE) return;
+
+    std::vector<std::string> refs;
+    bool has_self = false;
+    if (t.is_seq(load)) {
+        for (size_t e = t.first_child(load); e != ryml::NONE;
+             e = t.next_sibling(e)) {
+            if (!t.has_val(e)) continue;
+            refs.push_back(std::string(t.val(e).str, t.val(e).len));
+            if (refs.back() == LOAD_SELF) has_self = true;
+        }
+    } else if (t.has_val(load)) {
+        // A lone filename, written without the list punctuation.
+        refs.push_back(std::string(t.val(load).str, t.val(load).len));
+    }
+    if (!has_self) refs.push_back(LOAD_SELF);
+
+    // The `load` node is a directive, not content: it takes no part in the
+    // merge and must not survive into the combined tree.
+    erase_prov_subtree(t, load, prov);
+    t.remove(load);
+
+    // Staging area. Keyed by the path each file came from, which makes a dumped
+    // intermediate tree readable; nothing looks these keys up.
+    ensure_capacity(t, 2);
+    size_t scratch = t.append_child(t.root_id());
+    t.to_map(scratch, t.to_arena(ryml::to_csubstr("__load")));
+
+    // The joiner's own contents, put aside before `pals` is emptied.
+    ensure_capacity(t, 2);
+    size_t self_node = t.append_child(scratch);
+    t.to_map(self_node, t.to_arena(ryml::to_csubstr(LOAD_SELF)));
+    {
+        size_t after = ryml::NONE;
+        for (size_t c = t.first_child(pals); c != ryml::NONE;
+             c = t.next_sibling(c)) {
+            ensure_capacity(t, 2);
+            after = duplicate_tracked(t, c, self_node, after, prov);
+        }
+    }
+
+    std::vector<size_t> sources;     // PALS nodes to merge, in load order
+    std::vector<std::string> names;  // where each came from, for messages
+
+    ryml::Tree& ot = orig->tree;
+    for (const std::string& ref : refs) {
+        if (ref == LOAD_SELF) {
+            sources.push_back(self_node);
+            names.push_back(path);
+            continue;
+        }
+
+        const std::string sub = resolve_path(path, ref);
+        if (active.count(sub)) {
+            add_problem(problems, "load: '" + path + "' loads '" + sub +
+                                      "', which is already being loaded");
+            continue;
+        }
+        size_t src_root = ot.find_child(ot.root_id(), ryml::to_csubstr(sub));
+        if (src_root == ryml::NONE) {
+            add_problem(problems, "load: could not read '" + sub +
+                                      "', loaded from '" + path + "'");
+            continue;
+        }
+
+        ensure_capacity(t, 2);
+        size_t stage = t.append_child(scratch);
+        deep_copy_tracked(t, stage, ot, src_root, prov);
+        make_combined_splice(t, stage, orig, sub, prov);
+
+        size_t sub_pals = t.find_child(stage, ryml::to_csubstr("PALS"));
+        if (sub_pals == ryml::NONE) {
+            add_problem(problems,
+                        "load: '" + sub + "' has no PALS node to load");
+            continue;
+        }
+        active.insert(sub);
+        resolve_loads(t, sub_pals, orig, sub, prov, active, problems);
+        active.erase(sub);
+
+        sources.push_back(sub_pals);
+        names.push_back(sub);
+    }
+
+    for (size_t c = t.first_child(pals); c != ryml::NONE;) {
+        size_t next = t.next_sibling(c);
+        erase_prov_subtree(t, c, prov);
+        t.remove(c);
+        c = next;
+    }
+
+    for (size_t i = 0; i < sources.size(); ++i)
+        merge_pals_into(t, pals, sources[i], names[i], prov, problems);
+
+    erase_prov_subtree(t, scratch, prov);
+    t.remove(scratch);
 }
 
 /**
  * Makes the combined lattice tree by deep-copying the top-level file's contents
- * out of the `original` tree and then splicing in every include (including
- * nested ones) from `original`. Records provenance mapping each combined node
- * to the original node it was copied from.
+ * out of the `original` tree, splicing in every include (including nested ones)
+ * from `original`, and then merging in every `load`ed file. Records provenance
+ * mapping each combined node to the original node it was copied from.
  *
  * @param orig     The already-built `original` tree (see make_original).
- * @param filename The top-level filename, used to find its entry in `original`.
+ * @param filename The top-level file's resolved path, used to find its entry in
+ *                 `original` and to resolve the references it makes.
  */
 static YAMLTreeHandle make_combined_from_original(ParsedData* orig,
-                                                  const char* filename) {
+                                                  const std::string& filename,
+                                                  ProblemList& problems) {
     if (!orig) return nullptr;
     ParsedData* data = new ParsedData();
     ryml::Tree& t = data->tree;
@@ -868,13 +1200,18 @@ static YAMLTreeHandle make_combined_from_original(ParsedData* orig,
     t.reserve_arena(t.arena_capacity() + 65536);
 
     ryml::Tree& ot = orig->tree;
-    // The top-level file is stored in `original` keyed by its filename.
+    // The top-level file is stored in `original` keyed by its path.
     size_t top = ot.find_child(ot.root_id(), ryml::to_csubstr(filename));
     if (top == ryml::NONE) top = ot.first_child(ot.root_id());
     if (top == ryml::NONE) return data;
 
     deep_copy_tracked(t, t.root_id(), ot, top, data->provenance);
-    make_combined_splice(t, t.root_id(), orig, data->provenance);
+    make_combined_splice(t, t.root_id(), orig, filename, data->provenance);
+
+    // Loads combine whole files, so they run once each file is itself complete.
+    std::set<std::string> active{filename};
+    resolve_loads(t, t.find_child(t.root_id(), ryml::to_csubstr("PALS")), orig,
+                  filename, data->provenance, active, problems);
     return data;
 }
 
@@ -3558,52 +3895,86 @@ static void make_expanded_and_leftover(ParsedData* comb,
 }
 
 /**
- * Recursive helper for make_original. For each included file in `src`:
- *  1. Load the file into a new temporary tree.
- *  2. Make a new key-value pair in `master` with key = file name and value =
- * file contents
- *  3. Delete the temporary tree.
+ * Recursive helper for make_original. Walks the contents of one already-parsed
+ * file and, for every file it references -- by `include` or by `load` -- adds
+ * that file to `master` under its resolved path, then walks it in turn.
+ *
+ * `src_path` is the resolved path of the file `src` holds, which is what its
+ * references are relative to.
  */
 static void add_to_master_tree(ryml::Tree& master, const ryml::Tree& src,
-                               size_t node) {
+                               size_t node, const std::string& src_path);
+
+/**
+ * Parse the file `ref` names as seen from `src_path`, store it in `master`
+ * keyed by its resolved path, and walk it for further references.
+ *
+ * A path already in `master` is left alone. That both keeps one copy of a file
+ * reached by several routes and stops a reference cycle: the key is stamped on
+ * before the file is walked, so a file that reaches itself finds itself there.
+ */
+static void add_referenced_file(ryml::Tree& master, const std::string& src_path,
+                                const std::string& ref) {
+    const std::string path = resolve_path(src_path, ref);
+    if (master.find_child(master.root_id(), ryml::to_csubstr(path)) !=
+        ryml::NONE)
+        return;
+
+    ParsedData* child = static_cast<ParsedData*>(parse_file(path.c_str()));
+    if (!child) return;  // reported where the reference is resolved
+    ensure_capacity(master, 2);
+    size_t dest = master.append_child(master.root_id());
+    deep_copy_recursive(master, dest, child->tree, child->tree.root_id());
+    // Root has no key, so stamp the path on after the copy
+    master.ref(dest) |= ryml::KEY;
+    master.set_key(dest, master.to_arena(ryml::to_csubstr(path)));
+    add_to_master_tree(master, child->tree, child->tree.root_id(), path);
+    delete child;
+}
+
+static void add_to_master_tree(ryml::Tree& master, const ryml::Tree& src,
+                               size_t node, const std::string& src_path) {
     if (node == ryml::NONE || src.is_val(node)) return;
     for (size_t c = src.first_child(node); c != ryml::NONE;
          c = src.next_sibling(c)) {
-        add_to_master_tree(master, src, c);
         if (src.has_key(c) && src.key(c) == "include" && src.has_val(c)) {
-            std::string filename(src.val(c).str, src.val(c).len);
-            ParsedData* child =
-                static_cast<ParsedData*>(parse_file(filename.c_str()));
-            if (child) {
-                ensure_capacity(master, 2);
-                size_t dest = master.append_child(master.root_id());
-                deep_copy_recursive(master, dest, child->tree,
-                                    child->tree.root_id());
-                // Root has no key, so stamp the filename on after the copy
-                master.ref(dest) |= ryml::KEY;
-                master.set_key(dest,
-                               master.to_arena(ryml::to_csubstr(filename)));
-                add_to_master_tree(master, child->tree, child->tree.root_id());
-                delete child;
+            add_referenced_file(master, src_path,
+                                std::string(src.val(c).str, src.val(c).len));
+        } else if (src.has_key(c) && src.key(c) == "load" && src.is_seq(c)) {
+            // A list of file names, with SELF standing for the naming file
+            // itself rather than for a file to read.
+            for (size_t e = src.first_child(c); e != ryml::NONE;
+                 e = src.next_sibling(e)) {
+                if (!src.has_val(e)) continue;
+                std::string ref(src.val(e).str, src.val(e).len);
+                if (ref != LOAD_SELF) add_referenced_file(master, src_path, ref);
             }
+        } else if (src.has_key(c) && src.key(c) == "load" && src.has_val(c)) {
+            std::string ref(src.val(c).str, src.val(c).len);
+            if (ref != LOAD_SELF) add_referenced_file(master, src_path, ref);
+        } else {
+            add_to_master_tree(master, src, c, src_path);
         }
     }
 }
 
 /**
- * Makes the original lattice. Creates a tree that maps included files to their
- * contents.
+ * Makes the original lattice. Creates a tree that maps every file the document
+ * is built from -- the top-level file and everything it reaches by `include` or
+ * `load`, at any depth -- to that file's contents, keyed by its resolved path.
  *
  * If the top-level file cannot be read or is not valid YAML, `parse_error` is
  * set to a human-readable description (with the offending line/column for a
  * syntax error) and the returned tree is an empty MAP. Callers treat a non-empty
- * `parse_error` as a fatal failure: there is no document to expand.
+ * `parse_error` as a fatal failure: there is no document to expand. A referenced
+ * file that cannot be read is not fatal: it is simply missing from the master
+ * tree, and reported when the reference to it is resolved.
  */
-static YAMLTreeHandle make_original(const char* filename,
+static YAMLTreeHandle make_original(const std::string& filename,
                                     std::string& parse_error) {
     ParsedData* master = new ParsedData();
     master->tree.rootref() |= ryml::MAP;
-    ParsedData* src = static_cast<ParsedData*>(parse_file(filename));
+    ParsedData* src = static_cast<ParsedData*>(parse_file(filename.c_str()));
     if (src) {
         ensure_capacity(master->tree, 2);
         size_t dest = master->tree.append_child(master->tree.root_id());
@@ -3612,7 +3983,8 @@ static YAMLTreeHandle make_original(const char* filename,
         master->tree.ref(dest) |= ryml::KEY;
         master->tree.set_key(dest,
                              master->tree.to_arena(ryml::to_csubstr(filename)));
-        add_to_master_tree(master->tree, src->tree, src->tree.root_id());
+        add_to_master_tree(master->tree, src->tree, src->tree.root_id(),
+                           filename);
         delete src;
     } else {
         // parse_file recorded why on this thread; nothing else has parsed since.
@@ -3629,10 +4001,15 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
     struct lattices lat = {};
     ProblemList problems;
     // Built as a derivation chain so provenance can be recorded at each step:
-    //   original --(splice includes)--> combined --(expand, split)--> expanded
-    //                                                              \-> leftover
+    //   original --(splice includes, merge loads)--> combined
+    //   combined  --(expand, split)--> expanded, leftover
+    //
+    // Every file is keyed in `original` by its folded path, so folding the
+    // top-level one here is what makes it agree with the paths the files
+    // themselves resolve to.
     std::string parse_error;
-    lat.original = make_original(filename, parse_error);
+    const std::string top_path = fold_path(filename ? filename : "");
+    lat.original = make_original(top_path, parse_error);
     if (!parse_error.empty()) {
         // The top-level file is not valid YAML: there is no tree to expand.
         // Free the empty stand-in, leave all four handles NULL, and report the
@@ -3643,7 +4020,7 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
                            "': " + parse_error);
     } else {
         lat.combined = make_combined_from_original(
-            static_cast<ParsedData*>(lat.original), filename);
+            static_cast<ParsedData*>(lat.original), top_path, problems);
 
         // Spell-check against combined, not expanded: every definition appears
         // there exactly once, as written, so each misspelling is reported once

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -90,10 +90,12 @@ struct string_list {
  * that can read the rest of this header.
  */
 struct lattices {
-    YAMLTreeHandle original;  ///< Raw tree mapping each file (including
-                              ///< includes) to its unparsed contents.
-    YAMLTreeHandle combined;  ///< Tree with all "include" directives resolved
-                              ///< and spliced inline.
+    YAMLTreeHandle original;  ///< Raw tree mapping each file the document is
+                              ///< built from -- the top-level file and every
+                              ///< file it reaches by "include" or "load" -- to
+                              ///< its unparsed contents, keyed by path.
+    YAMLTreeHandle combined;  ///< Tree with all "include" directives spliced
+                              ///< inline and all "load"ed files merged in.
     YAMLTreeHandle expanded;  ///< The expanded root lattice, and nothing else:
                               ///< a map holding the single `name: {kind:
                               ///< Lattice, ...}` entry, without the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(tests
   test_sets.cpp
   test_bookkeeper.cpp
   test_check.cpp
+  test_load.cpp
   test_floor.cpp
   # pals_floor.cpp carries hidden visibility in the shared library, so its
   # geometry symbols are compiled directly into the tests for test_floor.cpp.

--- a/tests/test_load.cpp
+++ b/tests/test_load.cpp
@@ -1,0 +1,479 @@
+#include "test_helpers.h"
+
+#include <filesystem>
+
+// `load` commands: fundamentals.md (s:load). A load merges whole files subnode
+// by subnode under the `PALS` root, where an include splices a file's contents
+// in verbatim where it is written. Both are resolved into the `combined` tree.
+
+namespace {
+
+// A set of files written into a scratch directory and parsed through one of
+// them. The directory is what makes the relative-path rule testable: the paths
+// inside the files are written relative to each other, not to wherever the
+// tests happen to run.
+struct LoadCase {
+    std::filesystem::path dir;
+    struct lattices lat = {};
+
+    explicit LoadCase(const std::string& name) : dir("tmp_load_" + name) {
+        std::filesystem::remove_all(dir);
+        std::filesystem::create_directories(dir);
+    }
+
+    ~LoadCase() {
+        free_lattice_problems(lat.problems);
+        delete_tree(lat.original);
+        delete_tree(lat.combined);
+        delete_tree(lat.expanded);
+        delete_tree(lat.leftover);
+        std::filesystem::remove_all(dir);
+    }
+
+    void write(const std::string& rel, const std::string& yaml) {
+        std::filesystem::path p = dir / rel;
+        std::filesystem::create_directories(p.parent_path());
+        write_tmp(p.string(), yaml);
+    }
+
+    void parse(const std::string& rel, const char* root_lattice = nullptr) {
+        lat = parse_and_expand_PALS((dir / rel).string().c_str(), root_lattice);
+    }
+
+    std::vector<std::string> problems() const {
+        std::vector<std::string> out;
+        for (size_t i = 0; i < lat.problems.count; ++i)
+            out.emplace_back(lat.problems.items[i]);
+        return out;
+    }
+
+    std::string joined_problems() const {
+        std::string s;
+        for (const std::string& p : problems()) s += p + "; ";
+        return s;
+    }
+
+    // Only the problems the load itself raised. Most files here are a `PALS`
+    // node and a few subnodes with no lattice in them at all, and the
+    // "no lattice found to expand" that draws says nothing about the merge.
+    std::string load_problems() const {
+        std::string s;
+        for (const std::string& p : problems())
+            if (p.rfind("load:", 0) == 0) s += p + "; ";
+        return s;
+    }
+};
+
+bool any_contains(const std::vector<std::string>& msgs, const char* needle) {
+    for (const std::string& m : msgs)
+        if (m.find(needle) != std::string::npos) return true;
+    return false;
+}
+
+YAMLNodeId pals_of(YAMLTreeHandle t) {
+    return get_child_by_key(t, get_root(t), "PALS");
+}
+
+// The scalar values of a PALS list subnode (`notes`, `reminders`, ...).
+std::vector<std::string> list_of(YAMLTreeHandle t, const char* key) {
+    YAMLNodeId n = get_child_by_key(t, pals_of(t), key);
+    std::vector<std::string> out;
+    for (size_t i = 0; i < get_size(t, n); i++) {
+        char* s = as_string(t, get_child_by_index(t, n, i));
+        if (s) out.emplace_back(s);
+        yaml_free_string(s);
+    }
+    return out;
+}
+
+// The names defined in `facility`, in order. Each entry is a single-key map
+// wrapper and the key is the name.
+std::vector<std::string> facility_names(YAMLTreeHandle t) {
+    YAMLNodeId fac = facility_of(t);
+    std::vector<std::string> out;
+    for (size_t i = 0; i < get_size(t, fac); i++) {
+        YAMLNodeId e = get_child_by_index(t, fac, i);
+        char* k = get_node_key(t, get_child_by_index(t, e, 0));
+        if (k) out.emplace_back(k);
+        yaml_free_string(k);
+    }
+    return out;
+}
+
+std::string scalar_of(YAMLTreeHandle t, const char* key) {
+    char* s = as_string(t, get_child_by_key(t, pals_of(t), key));
+    std::string out = s ? s : "";
+    yaml_free_string(s);
+    return out;
+}
+
+// The keys of a PALS subnode, in order.
+std::vector<std::string> keys_under(YAMLTreeHandle t, const char* key) {
+    YAMLNodeId n = get_child_by_key(t, pals_of(t), key);
+    std::vector<std::string> out;
+    for (size_t i = 0; i < get_size(t, n); i++) {
+        char* k = get_node_key(t, get_child_by_index(t, n, i));
+        if (k) out.emplace_back(k);
+        yaml_free_string(k);
+    }
+    return out;
+}
+
+// The layout/settings split fundamentals.md gives as the motivating use: one
+// file lays the machine out, another sets it up, a joiner names both.
+const char* LAYOUT =
+    "PALS:\n"
+    "  notes:\n"
+    "    - \"layout note\"\n"
+    "  facility:\n"
+    "    - main:\n"
+    "        kind: BeamLine\n"
+    "        line:\n"
+    "          - begin:\n"
+    "              kind: BeginningEle\n"
+    "              ReferenceP:\n"
+    "                species_ref: \"electron\"\n"
+    "                E_tot_ref: 1.0e9\n"
+    "          - Q1a:\n"
+    "              kind: Quadrupole\n"
+    "              length: 0.5\n"
+    "    - lat1:\n"
+    "        kind: Lattice\n"
+    "        branches:\n"
+    "          - main\n"
+    "    - use: \"lat1\"\n";
+
+const char* SETTINGS =
+    "PALS:\n"
+    "  notes:\n"
+    "    - \"settings note\"\n"
+    "  facility:\n"
+    "    - set:\n"
+    "        parameter: Q1a>MagneticMultipoleP.Kn1\n"
+    "        value: 0.34\n";
+
+}  // namespace
+
+TEST_CASE("load merges whole files subnode by subnode", "[load]") {
+    LoadCase c("basic");
+    c.write("layout.pals.yaml", LAYOUT);
+    c.write("settings.pals.yaml", SETTINGS);
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"joiner note\"\n"
+            "  load:\n"
+            "    - layout.pals.yaml\n"
+            "    - settings.pals.yaml\n"
+            "    - SELF\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(c.joined_problems() == "");
+
+    // List subnodes concatenate, keeping the order of the load list and, within
+    // each file, the order written there.
+    REQUIRE(list_of(c.lat.combined, "notes") ==
+            std::vector<std::string>{"layout note", "settings note",
+                                     "joiner note"});
+    REQUIRE(facility_names(c.lat.combined) ==
+            std::vector<std::string>{"main", "lat1", "use", "set"});
+
+    // The directive itself does not survive into the combined tree.
+    REQUIRE(get_child_by_key(c.lat.combined, pals_of(c.lat.combined), "load") ==
+            YAML_NULL_ID);
+}
+
+TEST_CASE("a loaded settings file drives the lattice the layout file defines",
+          "[load][lattices]") {
+    // The point of the split: the merged file expands as though it had been
+    // written as one, so the `set` from the settings file reaches the element
+    // the layout file defined.
+    LoadCase c("expand");
+    c.write("layout.pals.yaml", LAYOUT);
+    c.write("settings.pals.yaml", SETTINGS);
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  load:\n"
+            "    - layout.pals.yaml\n"
+            "    - settings.pals.yaml\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(c.joined_problems() == "");
+
+    YAMLNodeId q1a = find_by_key(c.lat.expanded, "Q1a");
+    REQUIRE(q1a != YAML_NULL_ID);
+    YAMLNodeId mult = get_child_by_key(c.lat.expanded, q1a, "MagneticMultipoleP");
+    REQUIRE(mult != YAML_NULL_ID);
+    REQUIRE(close(num_val(c.lat.expanded, get_child_by_key(c.lat.expanded, mult,
+                                                           "Kn1")),
+                  0.34));
+}
+
+TEST_CASE("SELF places the joiner's own contents in the load order", "[load]") {
+    LoadCase c("self");
+    c.write("a.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"a\"\n");
+    c.write("b.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"b\"\n");
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"joiner\"\n"
+            "  load:\n"
+            "    - a.pals.yaml\n"
+            "    - SELF\n"
+            "    - b.pals.yaml\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(c.load_problems() == "");
+    REQUIRE(list_of(c.lat.combined, "notes") ==
+            std::vector<std::string>{"a", "joiner", "b"});
+}
+
+TEST_CASE("without SELF the joiner's own contents are merged last", "[load]") {
+    LoadCase c("noself");
+    c.write("a.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"a\"\n");
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"joiner\"\n"
+            "  load:\n"
+            "    - a.pals.yaml\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(c.load_problems() == "");
+    REQUIRE(list_of(c.lat.combined, "notes") ==
+            std::vector<std::string>{"a", "joiner"});
+}
+
+TEST_CASE("load resolves nested loads bottom up", "[load]") {
+    // `inner` is a complete file -- a.pals.yaml already merged into it -- before
+    // it is merged into the joiner, and its own SELF refers to itself, not to
+    // the joiner that loads it.
+    LoadCase c("nested");
+    c.write("a.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"a\"\n");
+    c.write("inner.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"inner\"\n"
+            "  load:\n"
+            "    - SELF\n"
+            "    - a.pals.yaml\n");
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"joiner\"\n"
+            "  load:\n"
+            "    - inner.pals.yaml\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(c.load_problems() == "");
+    REQUIRE(list_of(c.lat.combined, "notes") ==
+            std::vector<std::string>{"inner", "a", "joiner"});
+}
+
+TEST_CASE("a loaded file's includes are resolved before it is merged",
+          "[load][include]") {
+    LoadCase c("include");
+    c.write("parts/extra.pals.yaml",
+            "- extra_ele:\n"
+            "    kind: Marker\n");
+    // The include is written relative to the file holding it, which sits a
+    // directory below the joiner.
+    c.write("sub/layout.pals.yaml",
+            "PALS:\n"
+            "  facility:\n"
+            "    - m1:\n"
+            "        kind: Marker\n"
+            "    - include: \"../parts/extra.pals.yaml\"\n");
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  load:\n"
+            "    - sub/layout.pals.yaml\n"
+            "  facility:\n"
+            "    - m2:\n"
+            "        kind: Marker\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(c.load_problems() == "");
+    REQUIRE(facility_names(c.lat.combined) ==
+            std::vector<std::string>{"m1", "extra_ele", "m2"});
+}
+
+TEST_CASE("a load path is relative to the file naming it", "[load]") {
+    // joiner reaches down into sub/, and sub/inner.pals.yaml reaches back up:
+    // both are written relative to themselves, so neither depends on where the
+    // process happens to be running.
+    LoadCase c("relative");
+    c.write("top.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"top\"\n");
+    c.write("sub/inner.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"inner\"\n"
+            "  load:\n"
+            "    - ../top.pals.yaml\n"
+            "    - SELF\n");
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  load:\n"
+            "    - sub/inner.pals.yaml\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(c.load_problems() == "");
+    REQUIRE(list_of(c.lat.combined, "notes") ==
+            std::vector<std::string>{"top", "inner"});
+}
+
+TEST_CASE("distinct versions collect into one comma delimited list", "[load]") {
+    LoadCase c("version");
+    c.write("a.pals.yaml", "PALS:\n  version: \"1.0\"\n");
+    c.write("b.pals.yaml", "PALS:\n  version: \"2.0\"\n");
+    c.write("c.pals.yaml", "PALS:\n  version: \"1.0\"\n");
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  load:\n"
+            "    - a.pals.yaml\n"
+            "    - b.pals.yaml\n"
+            "    - c.pals.yaml\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(c.load_problems() == "");
+    // "1.0" is contributed twice and appears once; the joiner itself has no
+    // version to add.
+    REQUIRE(scalar_of(c.lat.combined, "version") == "1.0, 2.0");
+}
+
+TEST_CASE("one version shared by every file stays a single version", "[load]") {
+    LoadCase c("version_same");
+    c.write("a.pals.yaml", "PALS:\n  version: \"1.0\"\n");
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  version: \"1.0\"\n"
+            "  load:\n"
+            "    - a.pals.yaml\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(c.load_problems() == "");
+    REQUIRE(scalar_of(c.lat.combined, "version") == "1.0");
+}
+
+TEST_CASE("Dict subnodes take the union and discard agreeing duplicates",
+          "[load]") {
+    LoadCase c("dict");
+    c.write("a.pals.yaml",
+            "PALS:\n"
+            "  extension_labels:\n"
+            "    from_a: \"A\"\n"
+            "    shared: \"same\"\n");
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  extension_labels:\n"
+            "    shared: \"same\"\n"
+            "    from_joiner: \"J\"\n"
+            "  load:\n"
+            "    - a.pals.yaml\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(c.load_problems() == "");
+    REQUIRE(keys_under(c.lat.combined, "extension_labels") ==
+            std::vector<std::string>{"from_a", "shared", "from_joiner"});
+}
+
+TEST_CASE("two files disagreeing over a Dict entry is reported", "[load]") {
+    LoadCase c("dict_clash");
+    c.write("a.pals.yaml",
+            "PALS:\n"
+            "  extension_labels:\n"
+            "    shared: \"one\"\n");
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  extension_labels:\n"
+            "    shared: \"other\"\n"
+            "  load:\n"
+            "    - a.pals.yaml\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(any_contains(c.problems(), "extension_labels.shared"));
+
+    // The earlier file in the load order keeps the value, so the disagreement
+    // is reported rather than resolved silently either way.
+    YAMLNodeId labels =
+        get_child_by_key(c.lat.combined, pals_of(c.lat.combined),
+                         "extension_labels");
+    REQUIRE(val_eq(c.lat.combined,
+                   get_child_by_key(c.lat.combined, labels, "shared"), "one"));
+}
+
+TEST_CASE("a load naming a file that cannot be read is reported", "[load]") {
+    LoadCase c("missing");
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"joiner\"\n"
+            "  load:\n"
+            "    - no_such_file.pals.yaml\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(any_contains(c.problems(), "no_such_file.pals.yaml"));
+    // The rest of the document still combines: one unreadable file is not
+    // grounds for throwing away the ones that were read.
+    REQUIRE(list_of(c.lat.combined, "notes") ==
+            std::vector<std::string>{"joiner"});
+}
+
+TEST_CASE("a cycle of loads is reported rather than followed", "[load]") {
+    LoadCase c("cycle");
+    c.write("a.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"a\"\n"
+            "  load:\n"
+            "    - b.pals.yaml\n"
+            "    - SELF\n");
+    c.write("b.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"b\"\n"
+            "  load:\n"
+            "    - a.pals.yaml\n"
+            "    - SELF\n");
+    c.parse("a.pals.yaml");
+    REQUIRE(any_contains(c.problems(), "already being loaded"));
+    // b's load of a is what closes the loop and is dropped; everything else
+    // still merges.
+    REQUIRE(list_of(c.lat.combined, "notes") ==
+            std::vector<std::string>{"b", "a"});
+}
+
+TEST_CASE("a file loaded by two routes is read once", "[load]") {
+    // `shared` is named by both branches. It is parsed once into `original`,
+    // but each branch merges its own copy, so it contributes twice -- the merge
+    // is over load lists, not over files.
+    LoadCase c("diamond");
+    c.write("shared.pals.yaml",
+            "PALS:\n"
+            "  notes:\n"
+            "    - \"shared\"\n");
+    c.write("left.pals.yaml",
+            "PALS:\n"
+            "  load:\n"
+            "    - shared.pals.yaml\n");
+    c.write("right.pals.yaml",
+            "PALS:\n"
+            "  load:\n"
+            "    - shared.pals.yaml\n");
+    c.write("joiner.pals.yaml",
+            "PALS:\n"
+            "  load:\n"
+            "    - left.pals.yaml\n"
+            "    - right.pals.yaml\n");
+    c.parse("joiner.pals.yaml");
+    REQUIRE(c.load_problems() == "");
+    REQUIRE(list_of(c.lat.combined, "notes") ==
+            std::vector<std::string>{"shared", "shared"});
+
+    // One entry in `original` per file, whatever route reached it: the four
+    // files here, no duplicate for the second route to `shared`.
+    REQUIRE(get_size(c.lat.original, get_root(c.lat.original)) == 4);
+}


### PR DESCRIPTION
Implements the `load` command defined by [pals#260](https://github.com/pals-project/pals/pull/260).

A `load` is a list under the `PALS` node naming files whose contents are merged, whole file by whole file, into one document. Where an `include` splices a file in verbatim at the point it is written, a `load` merges subnode by subnode under the `PALS` root — which is what lets a layout file and one of several settings files be composed by a small joiner file that names both. Both directives are resolved into the `combined` tree.

## Implementation

All in the `original -> combined` step of `src/pals_expand.cpp`:

- **`make_original`** walks `load` lists as well as `include` keys, so every file the document reaches by either route, at any depth, lands in the master tree keyed by its path. A path already registered is skipped, which both keeps one copy of a file reached twice and stops a reference cycle.
- **`resolve_loads`** resolves one file's `load` list in place. Each named file is staged, spliced for its *own* includes and resolved for its *own* `load`, so it is a single complete file before it takes part in the merge and nesting works bottom up to any depth. The joiner's own contents are staged the same way, which is what lets `SELF` sit anywhere in the order; absent, they merge last. The `load` node itself does not survive into `combined`.
- **`merge_pals_into`** combines the subnodes by type: list subnodes concatenate in load order, Dict subnodes take the union with an agreeing duplicate discarded and a disagreeing one reported, and `version` collects the distinct version strings. Only `version` is keyed to a subnode name, so `notes`, `authors`, `facility` and `extension_labels` fall out of the type rules.

A cycle, an unreadable file, or a loaded file with no `PALS` node is reported as a problem, and the rest of the document still combines.

## Path resolution

pals#260 also states that a path in an `include` is relative to the file containing it, so that rule is implemented for both directives (one lexical-folding helper, `resolve_path`). Paths are folded before use as master-tree keys, so one file gets one key whatever route reached it. The includes already under `lattice_files/` resolve to the same place under the old and new rules, so no existing test changes.

## Tests

`tests/test_load.cpp`, 14 cases: subnode-by-subnode merge, `SELF` placement and its default, nested loads, includes-before-merge, relative paths (including a loaded file in a subdirectory reaching back up), version merging both ways, Dict union and Dict conflict, missing file, cycle, diamond load, and an end-to-end check that a loaded settings file's `set` drives an element the layout file defined.

217/217 tests pass.

## Also

`lattice_files/load_{layout,settings,joiner}.pals.yaml` demonstrate the layout/settings split — `./print_lattices load_joiner.pals.yaml` shows all three trees. README, `docs/src/index.md`, `docs/src/guide/usage.md` and the `struct lattices` field comments updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
