### PR TITLE
Default a branch's inherit to its own name; report empty branches

### DIFF
--- a/src/pals_check.cpp
+++ b/src/pals_check.cpp
@@ -390,14 +390,14 @@ void add(std::vector<std::string>& problems, const std::string& msg) {
 }
 
 // "element 'q1': " when the map is keyed, "" when it is not. `group` names the
-// parameter group being looked at, and is empty at element level:
-// "element 'q1' ForkP: ".
+// parameter group being looked at, and is empty at element level; it joins the
+// element name with the same `>` the parameter paths use: "element 'q1>ForkP': ".
 std::string where(const ryml::Tree& t, size_t node, const std::string& group) {
-    std::string s;
-    if (t.has_key(node))
-        s = "element '" + std::string(t.key(node).str, t.key(node).len) + "'";
-    if (!group.empty()) s += (s.empty() ? "" : " ") + group;
-    return s.empty() ? "" : s + ": ";
+    std::string name;
+    if (t.has_key(node)) name = std::string(t.key(node).str, t.key(node).len);
+    if (name.empty()) return group.empty() ? "" : group + ": ";
+    if (!group.empty()) name += ">" + group;
+    return "element '" + name + "': ";
 }
 
 void report(std::vector<std::string>& problems, const ryml::Tree& t,

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -694,6 +694,99 @@ static void expand(ryml::Tree& t, size_t node,
 }
 
 /**
+ * Give every root branch written as `- name: {...}` the `inherit` it implies.
+ *
+ * A branch's `inherit` names its root BeamLine and is optional: "Default is the
+ * name of the Branch" (lattice-construction.md, s:lattice.construct). So
+ *
+ *     branches:
+ *       - ln:
+ *           periodic: false
+ *
+ * is the branch `ln` built from the BeamLine `ln`, overriding its `periodic`.
+ * Expansion reaches a definition only through a bare name or an explicit
+ * `inherit`, so the default is supplied here, before expand() runs, by writing
+ * the key back out as an `inherit`. Appending it leaves the entry's own keys
+ * ahead of the inherited ones, which is what makes `periodic` an override.
+ *
+ * Only root branches are written this way; a Fork builds its branch by copying
+ * the `to_line` definition outright and never arrives here.
+ */
+static void default_branch_inherit(ryml::Tree& t, size_t lat_node,
+                                   const std::map<std::string, size_t>& emap) {
+    size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
+    if (branches == ryml::NONE || !t.is_seq(branches)) return;
+
+    for (size_t entry = t.first_child(branches); entry != ryml::NONE;
+         entry = t.next_sibling(entry)) {
+        // A bare `- this_line` is a scalar and needs nothing: name substitution
+        // already brings the definition in.
+        if (!t.is_map(entry)) continue;
+        size_t branch = t.first_child(entry);
+        if (branch == ryml::NONE || !t.is_map(branch) || !t.has_key(branch))
+            continue;
+        // An explicit `inherit` is the root line, and a branch carrying its own
+        // `line` is already the finished article; neither wants a default.
+        if (t.find_child(branch, ryml::to_csubstr("inherit")) != ryml::NONE)
+            continue;
+        if (t.find_child(branch, ryml::to_csubstr("line")) != ryml::NONE)
+            continue;
+        std::string name(t.key(branch).str, t.key(branch).len);
+        // A name that is not defined is left alone: the empty branch it produces
+        // is reported by check_branches_expanded, which says so in those terms
+        // rather than as a failed inherit.
+        if (emap.find(name) == emap.end()) continue;
+
+        ensure_capacity(t, 2);
+        size_t inh = t.append_child(branch);
+        t.ref(inh) |= ryml::KEY | ryml::VAL;
+        t.set_key(inh, t.to_arena(ryml::to_csubstr("inherit")));
+        t.set_val(inh, t.to_arena(ryml::to_csubstr(name)));
+    }
+}
+
+/**
+ * Report every branch that came out of expansion holding no elements.
+ *
+ * A branch is the ordered element list its root BeamLine expands to, so an
+ * empty one is always a mistake in the file -- most often a root line that was
+ * never defined. Without this the emptiness is silent, and surfaces only
+ * indirectly, as whatever downstream check first goes looking for an element
+ * that should have been there.
+ */
+static void check_branches_expanded(const ryml::Tree& t, size_t lat_node,
+                                    const std::map<std::string, size_t>& emap,
+                                    ProblemList& problems) {
+    size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
+    if (branches == ryml::NONE || !t.is_seq(branches)) return;
+
+    for (size_t entry = t.first_child(branches); entry != ryml::NONE;
+         entry = t.next_sibling(entry)) {
+        if (!t.is_map(entry)) continue;
+        size_t branch = t.first_child(entry);
+        if (branch == ryml::NONE || !t.is_map(branch) || !t.has_key(branch))
+            continue;
+        size_t line = t.find_child(branch, ryml::to_csubstr("line"));
+        if (line != ryml::NONE && t.is_seq(line) && t.num_children(line) > 0)
+            continue;
+
+        std::string name(t.key(branch).str, t.key(branch).len);
+        // With no `inherit` the root line is the branch's own name. An explicit
+        // `inherit` that names nothing is already reported by expand(), so only
+        // the defaulted name is diagnosed here.
+        bool defaulted =
+            t.find_child(branch, ryml::to_csubstr("inherit")) == ryml::NONE;
+        if (defaulted && emap.find(name) == emap.end())
+            add_problem(problems, "branch '" + name +
+                                      "': no root BeamLine '" + name +
+                                      "' is defined");
+        else
+            add_problem(problems,
+                        "branch '" + name + "': expanded to no elements");
+    }
+}
+
+/**
  * Drop `kind: BeamLine` from every branch of the expanded lattice `lat_node`.
  *
  * A `branches:` entry is a branch, not a BeamLine. It is instantiated from a
@@ -3803,6 +3896,10 @@ static void make_expanded_and_leftover(ParsedData* comb,
                                   ? "no lattice found to expand"
                                   : "lattice '" + name_str + "' not found");
     } else {
+        // Before expand, so the root line a branch names only by its own key is
+        // in place as an `inherit` for expansion to follow.
+        default_branch_inherit(t, lat_node, emap);
+
         size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
         std::map<size_t, int> mp_pass;  // multipass line def -> traversals so far
         std::set<size_t> done;  // branches a Fork already expanded
@@ -3812,6 +3909,10 @@ static void make_expanded_and_leftover(ParsedData* comb,
         // Runs after expand, not inside it: a Fork appends branches as it goes,
         // so only once expand has returned does `branches` hold them all.
         strip_branch_kinds(t, lat_node, work.provenance);
+
+        // Likewise after expand, so every branch -- root and forked alike -- has
+        // had its chance to fill in, and an empty one really is empty.
+        check_branches_expanded(t, lat_node, emap, problems);
 
         // A branch whose root line is itself `multipass` numbers its elements
         // here — the branch line is not reached through a sub-line flatten, so

--- a/tests/test_check.cpp
+++ b/tests/test_check.cpp
@@ -110,11 +110,11 @@ TEST_CASE("a misspelled parameter inside a group is reported",
                            "          edge_int2: 0.02\n"
                            "          e1: 0.1\n");
 
-    REQUIRE(has(ps, "element 'f1' ForkP: unknown parameter 'xxx'"));
+    REQUIRE(has(ps, "element 'f1>ForkP': unknown parameter 'xxx'"));
     // `edge_int2` is Bmad's spelling of what bend.md calls `edge2_int`. It is
     // reported without a guess: two edits from `edge2_int` and equally two from
     // `edge1_int`, and a tie is not worth resolving by coin toss.
-    REQUIRE(has(ps, "element 'b1' BendP: unknown parameter 'edge_int2'"));
+    REQUIRE(has(ps, "element 'b1>BendP': unknown parameter 'edge_int2'"));
     REQUIRE(!has(ps, "'edge_int2'; did you mean"));
     // Correct names are left alone.
     REQUIRE(!has(ps, "'to_line'"));
@@ -138,9 +138,9 @@ TEST_CASE("the retired actual-field bend parameters are reported",
                            "          g_actual: 0.12\n"
                            "          bend_field_actual: 1.4\n");
 
-    REQUIRE(has(ps, "element 'b1' BendP: unknown parameter 'g_actual'"));
+    REQUIRE(has(ps, "element 'b1>BendP': unknown parameter 'g_actual'"));
     REQUIRE(
-        has(ps, "element 'b1' BendP: unknown parameter 'bend_field_actual'"));
+        has(ps, "element 'b1>BendP': unknown parameter 'bend_field_actual'"));
     REQUIRE(!has(ps, "unknown parameter 'g_ref'"));
 }
 
@@ -170,11 +170,11 @@ TEST_CASE("multipole component names are accepted by shape, not by list",
                            "          Bn3: 4\n");
 
     REQUIRE(count_with(ps, "unknown parameter") == 3);
-    REQUIRE(has(ps, "MagneticMultipoleP: unknown parameter 'Kn_bogus'"));
+    REQUIRE(has(ps, "MagneticMultipoleP': unknown parameter 'Kn_bogus'"));
     // `tilt` has no length-integrated form, so the trailing `L` is not one.
-    REQUIRE(has(ps, "MagneticMultipoleP: unknown parameter 'tiltL'"));
+    REQUIRE(has(ps, "MagneticMultipoleP': unknown parameter 'tiltL'"));
     // A magnetic component in the electric group is not an electric one.
-    REQUIRE(has(ps, "ElectricMultipoleP: unknown parameter 'Bn3'"));
+    REQUIRE(has(ps, "ElectricMultipoleP': unknown parameter 'Bn3'"));
     // No suggestion is offered: the nearest listed name would be a guess at a
     // different multipole order.
     REQUIRE(!has(ps, "'Kn_bogus'; did you mean"));
@@ -315,7 +315,7 @@ TEST_CASE("a parameter group defined on its own is checked as a group",
 
     REQUIRE(!has(ps, "unknown kind 'ApertureP'"));
     REQUIRE(has(ps,
-                "element 'ap1' ApertureP: unknown parameter 'x_mim'; did you "
+                "element 'ap1>ApertureP': unknown parameter 'x_mim'; did you "
                 "mean 'x_min'?"));
     // `inherit` is a group's own key, not one of ApertureP's components.
     REQUIRE(!has(ps, "'inherit'"));

--- a/tests/test_controllers.cpp
+++ b/tests/test_controllers.cpp
@@ -639,6 +639,55 @@ TEST_CASE("a controller target that matches nothing is reported",
     rm_tmp(path);
 }
 
+// A branch written as `- ln:` with no `inherit` used not to expand at all, so
+// every element in it was missing and the first sign of it was the controller
+// target failing to match. The target resolves, and drives its element.
+TEST_CASE("a controller reaches an element in a branch named by its key",
+          "[expr][lattices][controller][problems]") {
+    const char* path = "tmp_ctrl_default_branch.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - begin:\n"
+              "        kind: BeginningEle\n"
+              "        ReferenceP:\n"
+              "          species_ref: \"electron\"\n"
+              "          E_tot_ref: 1.0e9\n"
+              "    - q:\n"
+              "        kind: Quadrupole\n"
+              "        length: 1\n"
+              "        MagneticMultipoleP:\n"
+              "          Kn1: 256\n"
+              "    - ln:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - begin\n"
+              "          - q\n"
+              "    - machine:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - ln:\n"
+              "              periodic: false\n"
+              "    - oo:\n"
+              "        kind: Controller\n"
+              "        control_type: ABSOLUTE\n"
+              "        variables:\n"
+              "          vv: 2\n"
+              "        controls:\n"
+              "          - parameter: q>MagneticMultipoleP.Kn1\n"
+              "            expression: 4^vv\n"
+              "    - use: \"machine\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE_FALSE(any_contains(problem_list(lat), "matches nothing"));
+    REQUIRE(joined(lat).find("branch 'ln'") == std::string::npos);
+    REQUIRE(close(expanded_param(lat.expanded, "q", "MagneticMultipoleP", "Kn1"),
+                  16.0));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
 TEST_CASE("an unknown control_type is reported",
           "[expr][lattices][controller][problems]") {
     const char* path = "tmp_ctrl_badtype.pals.yaml";

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -211,6 +211,197 @@ TEST_CASE("Expansion drops `kind: BeamLine` from every branch", "[lattices]") {
     rm_tmp(path);
 }
 
+// A branch's `inherit` is optional and defaults to the branch's own name
+// (lattice-construction.md, s:lattice.construct), so `- ln:` with nothing but a
+// `periodic` under it is the branch `ln` built from the BeamLine `ln`.
+TEST_CASE("A branch with no inherit takes its root BeamLine from its name",
+          "[lattices]") {
+    const char* path = "tmp_branch_default_inherit.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - begin:\n"
+              "        kind: BeginningEle\n"
+              "        ReferenceP:\n"
+              "          species_ref: \"electron\"\n"
+              "          E_tot_ref: 1.0e9\n"
+              "    - q:\n"
+              "        kind: Quadrupole\n"
+              "        length: 1\n"
+              "    - ln:\n"
+              "        kind: BeamLine\n"
+              "        periodic: true\n"
+              "        line:\n"
+              "          - begin\n"
+              "          - q\n"
+              "    - machine:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - ln:\n"
+              "              periodic: false\n"
+              "    - use: \"machine\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+
+    YAMLNodeId machine =
+        get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
+    YAMLNodeId branch = get_child_by_index(
+        lat.expanded,
+        get_child_by_index(lat.expanded,
+                           get_child_by_key(lat.expanded, machine, "branches"),
+                           0),
+        0);
+    REQUIRE(key_eq(lat.expanded, branch, "ln"));
+
+    // The root line's contents are here, not just the two keys the file wrote.
+    YAMLNodeId line = get_child_by_key(lat.expanded, branch, "line");
+    REQUIRE(line != YAML_NULL_ID);
+    REQUIRE(get_size(lat.expanded, line) >= 2);
+    REQUIRE(key_eq(lat.expanded,
+                   get_child_by_index(
+                       lat.expanded, get_child_by_index(lat.expanded, line, 1), 0),
+                   "q"));
+
+    // The branch's own `periodic` still overrides the root BeamLine's, so the
+    // defaulted inherit is merged on the same terms as a written one.
+    REQUIRE(val_eq(lat.expanded,
+                   get_child_by_key(lat.expanded, branch, "periodic"), "false"));
+
+    // Nothing about the branch is a problem.
+    for (size_t i = 0; i < lat.problems.count; ++i)
+        REQUIRE(std::string(lat.problems.items[i]).find("branch 'ln'") ==
+                std::string::npos);
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}
+
+// A written `inherit` names the root BeamLine outright, and the default must not
+// displace it even when the branch's own name is also a defined BeamLine.
+TEST_CASE("An explicit branch inherit wins over the branch name", "[lattices]") {
+    const char* path = "tmp_branch_explicit_inherit.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - begin:\n"
+              "        kind: BeginningEle\n"
+              "        ReferenceP:\n"
+              "          species_ref: \"electron\"\n"
+              "          E_tot_ref: 1.0e9\n"
+              "    - q_named:\n"
+              "        kind: Quadrupole\n"
+              "        length: 1\n"
+              "    - s_wanted:\n"
+              "        kind: Sextupole\n"
+              "        length: 2\n"
+              "    - alt:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - begin\n"
+              "          - q_named\n"
+              "    - ring:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - begin\n"
+              "          - s_wanted\n"
+              "    - machine:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - alt:\n"
+              "              inherit: ring\n"
+              "    - use: \"machine\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+
+    YAMLNodeId machine =
+        get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
+    YAMLNodeId branch = get_child_by_index(
+        lat.expanded,
+        get_child_by_index(lat.expanded,
+                           get_child_by_key(lat.expanded, machine, "branches"),
+                           0),
+        0);
+    YAMLNodeId line = get_child_by_key(lat.expanded, branch, "line");
+    REQUIRE(line != YAML_NULL_ID);
+    // `ring`'s element, not `alt`'s.
+    REQUIRE(key_eq(lat.expanded,
+                   get_child_by_index(
+                       lat.expanded, get_child_by_index(lat.expanded, line, 1), 0),
+                   "s_wanted"));
+    REQUIRE(val_eq(lat.expanded,
+                   get_child_by_key(lat.expanded, branch, "inherit"), "ring"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}
+
+// A branch that comes out of expansion with no elements is reported in its own
+// right, rather than being left for some later check to trip over.
+TEST_CASE("An empty branch is reported", "[lattices][problems]") {
+    auto problems_for = [](const char* path, const std::string& yaml) {
+        write_tmp(path, yaml);
+        struct lattices lat = parse_and_expand_PALS(path, nullptr);
+        std::vector<std::string> msgs;
+        for (size_t i = 0; i < lat.problems.count; ++i)
+            msgs.emplace_back(lat.problems.items[i]);
+        free_lattice_problems(lat.problems);
+        delete_tree(lat.original);
+        delete_tree(lat.combined);
+        delete_tree(lat.expanded);
+        delete_tree(lat.leftover);
+        rm_tmp(path);
+        return msgs;
+    };
+    auto has = [](const std::vector<std::string>& msgs, const char* needle) {
+        for (const std::string& m : msgs)
+            if (m.find(needle) != std::string::npos) return true;
+        return false;
+    };
+
+    // No BeamLine named `ln` at all: the branch names its root line by its own
+    // key, and that key resolves to nothing.
+    SECTION("root BeamLine is not defined") {
+        auto msgs = problems_for("tmp_branch_no_root.pals.yaml",
+                                 "PALS:\n"
+                                 "  facility:\n"
+                                 "    - machine:\n"
+                                 "        kind: Lattice\n"
+                                 "        branches:\n"
+                                 "          - ln:\n"
+                                 "              periodic: false\n"
+                                 "    - use: \"machine\"\n");
+        REQUIRE(has(msgs, "branch 'ln': no root BeamLine 'ln' is defined"));
+    }
+
+    // The root line is defined, and empty. The name resolves, so the message is
+    // about the branch's contents rather than about a missing definition.
+    SECTION("root BeamLine has an empty line") {
+        auto msgs = problems_for("tmp_branch_empty_line.pals.yaml",
+                                 "PALS:\n"
+                                 "  facility:\n"
+                                 "    - ln:\n"
+                                 "        kind: BeamLine\n"
+                                 "        line: []\n"
+                                 "    - machine:\n"
+                                 "        kind: Lattice\n"
+                                 "        branches:\n"
+                                 "          - ln\n"
+                                 "    - use: \"machine\"\n");
+        REQUIRE(has(msgs, "branch 'ln': expanded to no elements"));
+        REQUIRE_FALSE(has(msgs, "no root BeamLine"));
+    }
+}
+
 TEST_CASE("parse_and_expand_PALS reports expansion problems",
           "[expr][lattices][problems]") {
     // Every silent failure of expansion/evaluation is surfaced in the


### PR DESCRIPTION
## The bug

A branch's `inherit` is optional and *"Default is the name of the Branch"* (`lattice-construction.md`, s:lattice.construct). So

```yaml
branches:
  - ln:
      periodic: false
```

is the branch `ln` built from the BeamLine `ln`, overriding its `periodic`. Expansion reached a definition only through a bare `- ln` or an explicit `inherit:`, and never consulted the entry's own key — so this form expanded to nothing at all, silently.

The missing elements then surfaced somewhere unrelated. On a real file the only sign was:

```
controller 'oo': target 'q>MagneticMultipoleP.Kn1' matches nothing in the expanded lattice
```

which is true but says nothing useful, and it also masked a genuine error in the file (a line referring to an element that did not exist).

## The fix

- **`default_branch_inherit`** runs before `expand()` and writes a keyed branch entry's own key back out as an `inherit`, when the branch has neither an explicit `inherit` nor a `line` of its own and the name is defined. Appending it leaves the branch's own keys ahead of the inherited ones, which is what keeps `periodic` an override. Fork-built branches copy their `to_line` outright and never pass through here.

- **`check_branches_expanded`** runs after expansion — so root and forked branches alike have had their chance to fill in — and reports any branch holding no elements:
  - `branch 'ln': no root BeamLine 'ln' is defined` when the name was defaulted from the key and resolves to nothing;
  - `branch 'ln': expanded to no elements` otherwise. An explicit `inherit` naming nothing is left to expand()'s existing `inherit: 'x' is not defined`.

Without this, an empty branch is diagnosed only wherever some later check first trips over it.

## Also

`where()` in `pals_check.cpp` now joins an element with its parameter group using the same `>` the parameter paths use:

```
element 'beginning_b1>ReferenceP': unknown parameter 'species_ref:'; did you mean 'species_ref'?
```

rather than `element 'beginning_b1' ReferenceP: ...`. A group with no owning element still renders bare.

## Tests

Four new cases (suite: 221 cases / 1162 assertions, all passing):

- `test_expansion.cpp` — a branch with no `inherit` picks up its named root line and keeps its `periodic` override; an explicit `inherit` still wins over the branch key; an empty branch is reported, both the undefined-root and empty-line variants.
- `test_controllers.cpp` — the reported shape end to end: `q>MagneticMultipoleP.Kn1` resolves and drives the parameter.

Verified as real regressions by stubbing out both new calls: 3 of the 4 fail without the fix. The explicit-`inherit` case is a guard against the default overreaching, so it passes either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
