### PR TITLE
Do not evaluate root prose as expressions

### DIFF
--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -1410,6 +1410,11 @@ static size_t find_lattice(ryml::Tree& t, const std::string& name) {
 // avoids a stray collision between such a name and a constant (e.g. an element
 // literally named `pi`).
 //
+// `authors`, `notes` and `reminders` are free-form prose (fundamentals.md,
+// s:palsroot), so nothing in them is an expression. Prose that happens to carry
+// a `/` (a file path) or parentheses would otherwise be taken for arithmetic by
+// looks_like_expression and reported as a broken expression.
+//
 // `destination_pointer` is here for a different reason: it is a node id, and a
 // node id is a number, so evaluating it "succeeds" and rewrites it through
 // format_double. That is lossless as a number but not as text -- an id of 110
@@ -1422,7 +1427,8 @@ static const std::set<std::string>& non_expr_keys() {
         "inherit",    "zero_point",  "to_line",
         "destination_element", "new_branch", "multipass",
         "propagate_reference", "name", "multipass_index",
-        "destination_pointer", "forked_to"};
+        "destination_pointer", "forked_to",
+        "authors",    "notes",       "reminders"};
     return keys;
 }
 
@@ -1630,11 +1636,15 @@ static void substitute_values(ryml::Tree& t, size_t node,
             std::string k(t.key(node).str, t.key(node).len);
             skip = non_expr_keys().count(k) != 0;
         } else {
-            // Bare sequence element: skip beamline `line:` name references.
+            // Bare sequence element: it has no key of its own, so the decision
+            // belongs to the key of the list it sits in -- the entries of
+            // `notes` are prose for the same reason the key is. Beamline
+            // `line:` name references are skipped the same way.
             size_t p = t.parent(node);
-            if (p != ryml::NONE && t.has_key(p) &&
-                t.key(p) == ryml::to_csubstr("line"))
-                skip = true;
+            if (p != ryml::NONE && t.has_key(p)) {
+                std::string pk(t.key(p).str, t.key(p).len);
+                skip = pk == "line" || non_expr_keys().count(pk) != 0;
+            }
         }
         if (!skip) {
             bool was_expr = false;

--- a/tests/test_expressions.cpp
+++ b/tests/test_expressions.cpp
@@ -366,3 +366,47 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
+
+TEST_CASE("parse_and_expand_PALS leaves root prose alone", "[expr][lattices]") {
+    // `authors`, `notes` and `reminders` are free-form prose (fundamentals.md,
+    // s:palsroot). Prose carrying a `/` or parentheses reads as arithmetic to
+    // looks_like_expression, so evaluating it at all would report a translated
+    // file's provenance note as a broken expression.
+    const char* path = "tmp_rootprose.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  authors:\n"
+              "    - \"D. Sagan (Cornell)\"\n"
+              "  notes:\n"
+              "    - \"Translated from /nfs/acc/user/lat.bmad\"\n"
+              "  reminders:\n"
+              "    - \"Phase the RF (west) before tracking\"\n"
+              "  facility:\n"
+              "    - DH1A:\n"
+              "        kind: Bend\n"
+              "        length: 0.2\n"
+              "        ReferenceP:\n"
+              "          species_ref: proton\n"
+              "          E_tot_ref: 1.0e9\n"
+              "    - main_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - DH1A\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - main_line\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.expanded != nullptr);
+
+    REQUIRE(lat.problems.count == 0);
+    free_lattice_problems(lat.problems);
+
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}


### PR DESCRIPTION
`authors`, `notes` and `reminders` are free-form prose (fundamentals.md, s:palsroot), but `substitute_values` evaluated their entries like any other scalar. Evaluation fails, and `looks_like_expression` then reads any `/` or parenthesis in the text as arithmetic, so a translated file's provenance note

```yaml
PALS:
  notes:
    - "Translated from Bmad lattice file: /nfs/acc/user/dcs16/.../lat.bmad"
```

was reported as `could not evaluate expression: ...`. The report was arbitrary — a note with no punctuation stayed silent — and `authors` and `reminders` were exposed the same way (`"D. Sagan (Cornell)"` would trip it via the parens).

The three keys are added to `non_expr_keys()`. That alone does not reach them: a `notes` entry is an *unkeyed* list item, so the key-based skip never sees it. The bare-sequence branch of `substitute_values` now takes its decision from the key of the list the entry sits in, instead of hard-coding the one case (`line`) it knew about.

Consequence worth noting: `inherit` was already in `non_expr_keys()`, so a list-valued `inherit: [a, b]` now skips its entries too. Same latent bug, now consistent with the scalar form.

Regression test in `test_expressions.cpp` covers all three keys with both shapes that trip `looks_like_expression` — a path and parentheses. It fails against the unmodified expander with `3 == 0` (one problem per prose line) and passes with the fix. Full suite: 1168 assertions in 225 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
