### PR TITLE
Say why an expression could not be evaluated

### DIFF
--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -1667,6 +1667,7 @@ static void substitute_values(ryml::Tree& t, size_t node,
                 std::string msg = "could not evaluate expression";
                 if (!loc.empty()) msg += " for " + loc;
                 msg += ": " + body;
+                if (!r.error.empty()) msg += " -- " + r.error;
                 add_problem(problems, msg);
             }
         }
@@ -1696,6 +1697,7 @@ struct CtrlVar {
     size_t ctrl = 0;           // index into the controllers vector
     std::string name;          // unqualified name, as used in the controller
     std::string text;          // initial-value expression ("" = the default, 0)
+    std::string error;         // why `text` did not evaluate, for the report
     bool done = false;
     // Set when an ABSOLUTE controller above this one in the hierarchy drives
     // this variable: the driving value replaces the initial value.
@@ -2055,15 +2057,19 @@ static void evaluate_controllers(ryml::Tree& t, size_t lat_node,
                 v.done = true;
             } else if (r.deferred) {
                 v.done = true;  // random(); leave the text untouched
+            } else {
+                v.error = r.error;
             }
         }
 
         for (size_t vi : c.vars)
-            if (!vars[vi].done)
-                add_problem(problems, "controller '" + c.name + "' variable '" +
-                                          vars[vi].name +
-                                          "': could not evaluate '" +
-                                          vars[vi].text + "'");
+            if (!vars[vi].done) {
+                std::string msg = "controller '" + c.name + "' variable '" +
+                                  vars[vi].name + "': could not evaluate '" +
+                                  vars[vi].text + "'";
+                if (!vars[vi].error.empty()) msg += " -- " + vars[vi].error;
+                add_problem(problems, msg);
+            }
 
         for (CtrlControl& cc : c.controls) {
             bool was_expr = false;
@@ -2074,9 +2080,11 @@ static void evaluate_controllers(ryml::Tree& t, size_t lat_node,
                 cc.value = r.value;
                 set_scalar_num(t, cc.expr_node, r.value);
             } else if (!r.deferred) {
-                add_problem(problems, "controller '" + c.name +
-                                          "' control expression could not be "
-                                          "evaluated: " + body);
+                std::string msg = "controller '" + c.name +
+                                  "' control expression could not be "
+                                  "evaluated: " + body;
+                if (!r.error.empty()) msg += " -- " + r.error;
+                add_problem(problems, msg);
             }
             // Deferred (random()) expressions keep their text, as everywhere
             // else, and so drive nothing: the expanded tree stays reproducible.
@@ -2654,8 +2662,9 @@ static void execute_set(ryml::Tree& t, const SetCommand& cmd,
         }
         if (r.deferred) continue;  // random(); leave the parameter alone
         if (!r.ok) {
-            add_problem(problems,
-                        where + ": could not evaluate value: " + cmd.value);
+            std::string msg = where + ": could not evaluate value: " + cmd.value;
+            if (!r.error.empty()) msg += " -- " + r.error;
+            add_problem(problems, msg);
             continue;
         }
 

--- a/src/pals_expression.cpp
+++ b/src/pals_expression.cpp
@@ -36,8 +36,19 @@ namespace {
 // std::numbers::pi is C++20; keep this a plain constant for C++17.
 constexpr double kPi = 3.14159265358979323846;
 
-// Thrown to abort a non-evaluable expression; caught at the top level.
-struct ParseError {};
+// Thrown to abort a non-evaluable expression; caught at the top level, where
+// `why` becomes EvalOutcome::error. Every throw site says what it saw, since
+// "could not evaluate" on its own leaves the reader to find the bad symbol.
+struct ParseError {
+  std::string why;
+};
+
+std::string lowered(const std::string& s) {
+  std::string out = s;
+  for (char& c : out)
+    if (c >= 'A' && c <= 'Z') c = static_cast<char>(c - 'A' + 'a');
+  return out;
+}
 
 class Parser {
  public:
@@ -47,7 +58,9 @@ class Parser {
 
   double parse() {
     double v = expr();
-    if (peek() != '\0') throw ParseError{};  // trailing junk
+    if (peek() != '\0')  // trailing junk
+      throw ParseError{"unexpected '" + s_.substr(pos_) +
+                       "' after the expression"};
     return v;
   }
 
@@ -141,12 +154,15 @@ class Parser {
     if (c == '(') {
       ++pos_;
       double v = expr();
-      if (!consume(')')) throw ParseError{};
+      if (!consume(')')) throw ParseError{"missing ')'"};
       return v;
     }
     if (std::isdigit(static_cast<unsigned char>(c)) || c == '.') return number();
     if (std::isalpha(static_cast<unsigned char>(c)) || c == '_') return name();
-    throw ParseError{};
+    throw ParseError{c == '\0'
+                         ? "expression ends where a number or name is expected"
+                         : "expected a number or name, found '" +
+                               std::string(1, c) + "'"};
   }
 
   double number() {
@@ -154,7 +170,7 @@ class Parser {
     const char* start = s_.c_str() + pos_;
     char* end = nullptr;
     double v = std::strtod(start, &end);
-    if (end == start) throw ParseError{};
+    if (end == start) throw ParseError{"expected a number"};
     pos_ += static_cast<size_t>(end - start);
     return v;
   }
@@ -206,7 +222,7 @@ class Parser {
       out.push_back(c);
       ++pos_;
     }
-    if (depth != 0) throw ParseError{};
+    if (depth != 0) throw ParseError{"missing ')'"};
     size_t a = out.find_first_not_of(" \t");
     size_t b = out.find_last_not_of(" \t");
     return (a == std::string::npos) ? "" : out.substr(a, b - a + 1);
@@ -225,7 +241,8 @@ class Parser {
       }
     }
     if (!core.empty() && std::isdigit(static_cast<unsigned char>(core.front())))
-      throw ParseError{};
+      throw ParseError{"species '" + name +
+                       "' needs a leading '#' on its mass number"};
   }
 
   // Reads the species-name argument of a particle-data function. It is either a
@@ -241,7 +258,9 @@ class Parser {
     } else if (!species_ || !species_(arg, name)) {
       // Not quoted and not a known species symbol: an unquoted literal name is
       // an error, and an unknown symbol cannot be resolved.
-      throw ParseError{};
+      throw ParseError{"'" + arg +
+                       "' is neither a quoted species name nor a symbol naming "
+                       "one"};
     }
     check_mass_number(name);
     return name;
@@ -256,7 +275,26 @@ class Parser {
     double v;
     if (builtin_constant(id, v)) return v;
     if (lookup_ && lookup_(id, v)) return v;
-    throw ParseError{};  // unknown identifier
+    // A `>` in the name makes it a reference to a controller variable or an
+    // element parameter rather than a plain constant, so say which is missing.
+    std::string what = id.find('>') == std::string::npos
+                           ? "unknown constant or variable '"
+                           : "unknown reference '";
+    throw ParseError{what + id + "'" + case_hint(id)};
+  }
+
+  // "; did you mean 'c_light'?" when `id` differs from a name that does resolve
+  // only in case. Every built-in constant is lower case, so lowering `id` and
+  // retrying is the whole test -- no second table to drift out of step. The
+  // same retry catches a user constant written `MY_CONST` but defined
+  // `my_const`.
+  std::string case_hint(const std::string& id) const {
+    std::string low = lowered(id);
+    if (low == id) return "";
+    double v;
+    if (builtin_constant(low, v) || (lookup_ && lookup_(low, v)))
+      return "; did you mean '" + low + "'?";
+    return "";
   }
 
   std::vector<double> arg_list() {
@@ -270,7 +308,7 @@ class Parser {
       ++pos_;
       args.push_back(expr());
     }
-    if (!consume(')')) throw ParseError{};
+    if (!consume(')')) throw ParseError{"missing ')' after the arguments"};
     return args;
   }
 
@@ -284,7 +322,7 @@ class Parser {
         if (fn == "charge_of") return apc::charge_of(sp);
         return apc::anomalous_moment_of(sp);
       } catch (const std::exception&) {
-        throw ParseError{};  // unknown species
+        throw ParseError{"unknown species '" + sp + "'"};
       }
     }
     // random()/random_gauss() cannot be evaluated reproducibly: mark deferred
@@ -299,11 +337,15 @@ class Parser {
 
   static double apply(const std::string& fn, const std::vector<double>& a) {
     auto unary = [&]() -> double {
-      if (a.size() != 1) throw ParseError{};
+      if (a.size() != 1)
+        throw ParseError{"'" + fn + "' takes one argument, got " +
+                         std::to_string(a.size())};
       return a[0];
     };
     auto binary = [&](int i) -> double {
-      if (a.size() != 2) throw ParseError{};
+      if (a.size() != 2)
+        throw ParseError{"'" + fn + "' takes two arguments, got " +
+                         std::to_string(a.size())};
       return a[i];
     };
 
@@ -338,7 +380,21 @@ class Parser {
       double x = binary(0), p = binary(1);
       return x - std::floor(x / p) * p;
     }
-    throw ParseError{};  // unknown function
+    // Whether the lower-case spelling is a function is settled by trying it:
+    // the names live in the chain above and nowhere else, so probing keeps the
+    // hint from going stale. The result is thrown away -- a miscased name is
+    // still an error, not a silent correction -- and the recursion stops
+    // because a lowered name lowers to itself.
+    std::string hint;
+    std::string low = lowered(fn);
+    if (low != fn) {
+      try {
+        apply(low, a);
+        hint = "; did you mean '" + low + "'?";
+      } catch (const ParseError&) {
+      }
+    }
+    throw ParseError{"unknown function '" + fn + "'" + hint};
   }
 };
 
@@ -384,11 +440,17 @@ EvalOutcome eval_expression(const std::string& text, const SymbolLookup& lookup,
       r.deferred = true;
       return r;
     }
-    if (!std::isfinite(v)) return r;  // ok stays false
+    if (!std::isfinite(v)) {  // ok stays false
+      r.error = "the result is not a finite number";
+      return r;
+    }
     r.ok = true;
     r.value = v;
+  } catch (const ParseError& e) {
+    r.error = e.why;
   } catch (...) {
     // Not an evaluable expression; r.ok stays false.
+    r.error = "not a valid expression";
   }
   return r;
 }

--- a/src/pals_expression.h
+++ b/src/pals_expression.h
@@ -32,12 +32,20 @@ namespace pals {
  *     tree reproducible. `value` is unspecified.
  *   - `ok=false, deferred=false` -> not a (valid) evaluable expression: parse
  *     error, unknown identifier, unknown species, or a non-finite result. The
- *     caller should leave the original text untouched.
+ *     caller should leave the original text untouched, and @ref error says
+ *     which of those it was.
  */
 struct EvalOutcome {
   bool ok = false;        ///< True when @ref value holds a finite result.
   bool deferred = false;  ///< True when evaluation was deferred (random()).
   double value = 0.0;     ///< The result; valid only when @ref ok is true.
+  /**
+   * Why evaluation failed, naming the offending symbol -- "unknown constant or
+   * variable 'C_LIGHT'; did you mean 'c_light'?". A lower-case sentence
+   * fragment, meant to be appended to a caller's own message. Empty when @ref
+   * ok or @ref deferred.
+   */
+  std::string error;
 };
 
 /**

--- a/tests/test_expressions.cpp
+++ b/tests/test_expressions.cpp
@@ -410,3 +410,132 @@ TEST_CASE("parse_and_expand_PALS leaves root prose alone", "[expr][lattices]") {
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
+
+namespace {
+
+// Every problem reported for a one-element lattice whose `h1` is `value`.
+std::vector<std::string> problems_for_value(const char* path,
+                                            const std::string& value) {
+    write_tmp(path, "PALS:\n"
+                    "  facility:\n"
+                    "    - DH1A:\n"
+                    "        kind: Bend\n"
+                    "        length: 0.2\n"
+                    "        ReferenceP:\n"
+                    "          species_ref: proton\n"
+                    "          E_tot_ref: 1.0e9\n"
+                    "        BendP:\n"
+                    "          h1: " + value + "\n"
+                    "    - main_line:\n"
+                    "        kind: BeamLine\n"
+                    "        line:\n"
+                    "          - DH1A\n"
+                    "    - lat1:\n"
+                    "        kind: Lattice\n"
+                    "        branches:\n"
+                    "          - main_line\n"
+                    "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    std::vector<std::string> out;
+    for (size_t i = 0; i < lat.problems.count; ++i)
+        out.push_back(lat.problems.items[i]);
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+    return out;
+}
+
+bool any_has(const std::vector<std::string>& ps, const char* needle) {
+    for (const std::string& p : ps)
+        if (p.find(needle) != std::string::npos) return true;
+    return false;
+}
+
+}  // namespace
+
+TEST_CASE("an expression that fails to evaluate says why", "[expr][lattices]") {
+    const char* path = "tmp_evalwhy.pals.yaml";
+
+    // The offending symbol is named. Without it the reader is left to find it
+    // in the expression themselves, which is the whole difficulty when the
+    // expression came out of a translator.
+    std::vector<std::string> ps = problems_for_value(path, "1.0 / C_LIGHT");
+    REQUIRE(any_has(ps, "unknown constant or variable 'C_LIGHT'"));
+    // Every built-in constant is lower case, so a miscased one is a spelling
+    // the reader can act on.
+    REQUIRE(any_has(ps, "did you mean 'c_light'?"));
+
+    // A name that is nothing like a constant gets no invented suggestion.
+    ps = problems_for_value(path, "1.0 / bogus_thing");
+    REQUIRE(any_has(ps, "unknown constant or variable 'bogus_thing'"));
+    REQUIRE(!any_has(ps, "did you mean"));
+
+    ps = problems_for_value(path, "SQRT(2.0)");
+    REQUIRE(any_has(ps, "unknown function 'SQRT'; did you mean 'sqrt'?"));
+
+    // Arity is reported against the function, not as an unknown name.
+    ps = problems_for_value(path, "atan2(1.0)");
+    REQUIRE(any_has(ps, "'atan2' takes two arguments, got 1"));
+
+    ps = problems_for_value(path, "mass_of(\"bogusium\")");
+    REQUIRE(any_has(ps, "unknown species 'bogusium'"));
+
+    ps = problems_for_value(path, "mass_of(\"3He\")");
+    REQUIRE(any_has(ps, "needs a leading '#' on its mass number"));
+
+    ps = problems_for_value(path, "2.0 * (3.0 + 4.0");
+    REQUIRE(any_has(ps, "missing ')'"));
+}
+
+TEST_CASE("a controller says why an expression failed", "[expr][controllers]") {
+    // The reason reaches the controller messages too, which is where a
+    // translated lattice tends to put its expressions.
+    const char* path = "tmp_ctrlwhy.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - oo:\n"
+              "        kind: Controller\n"
+              "        control_type: ABSOLUTE\n"
+              "        variables:\n"
+              "          vv: -1.0 / C_LIGHT\n"
+              "        controls:\n"
+              "          - parameter: q1>MagneticMultipoleP.Kn1\n"
+              "            expression: 4 ^ PI\n"
+              "    - q1:\n"
+              "        kind: Quadrupole\n"
+              "        length: 0.2\n"
+              "        ReferenceP:\n"
+              "          species_ref: proton\n"
+              "          E_tot_ref: 1.0e9\n"
+              "    - main_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - q1\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - main_line\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    std::vector<std::string> ps;
+    for (size_t i = 0; i < lat.problems.count; ++i)
+        ps.push_back(lat.problems.items[i]);
+
+    REQUIRE(any_has(ps, "variable 'vv': could not evaluate"));
+    REQUIRE(any_has(ps, "unknown constant or variable 'C_LIGHT'"));
+    REQUIRE(any_has(ps, "control expression could not be evaluated"));
+    REQUIRE(any_has(ps, "unknown constant or variable 'PI'; did you mean 'pi'?"));
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}


### PR DESCRIPTION
A failed expression reported only that it failed:

```
controller 'oo' variable 'vv': could not evaluate '-1.00000000000000000E+000 / C_LIGHT'
```

leaving the reader to find the bad symbol themselves — hardest to do on the long expressions a translator emits. It now says which symbol and how to spell it:

```
controller 'oo' variable 'vv': could not evaluate '-1.00000000000000000E+000 / C_LIGHT'
  -- unknown constant or variable 'C_LIGHT'; did you mean 'c_light'?
```

## What changed

`ParseError` was an empty struct thrown from fourteen places in the evaluator, so every failure arrived at the caller as an undifferentiated "not evaluable". It now carries a `why`, and each throw site fills it in: unknown constant/variable, unknown function, unknown species, a mass number missing its `#`, wrong argument count (named against the function rather than reported as an unknown name), missing `)`, trailing text, and a non-finite result. `EvalOutcome` gained an `error` field to carry it out.

`pals_expand.cpp` appends the reason after ` -- ` at the four sites that report an expression failure: element values (`substitute_values`), controller initial values, controller control expressions, and `set` command values. Controller variables needed a field on `CtrlVar`, since the report happens in a later pass than the evaluation.

## Suggestions without a second table

Every built-in constant is lower case, so `case_hint` lowers the name and retries `builtin_constant` and the user symbol table — no list to drift out of step, and it also catches a user constant written `MY_CONST` but defined `my_const`. Function names live only in `apply`'s dispatch chain, so the lowered spelling is probed there and the result discarded: a miscased function is still an error, not a silent correction, and the recursion terminates because a lowered name lowers to itself.

## Tests

Two cases in `test_expressions.cpp`: the element path (miscased constant with suggestion, an unknown name that gets *no* invented suggestion, miscased function, arity, unknown species, missing `#`, unbalanced parens) and the controller path. Full suite: 1181 assertions in 227 cases.

## Not in this PR

- A variable whose initial value fails now cascades into a second message that blames the variable (`unknown constant or variable 'vv'`) though it is declared and merely valueless. Fixing that means the controller pass telling the evaluator "declared but unevaluated"; the shortcut of defaulting a failed variable to zero would turn a loud error into a silently wrong number.
- The C entry point `evaluate_pals_expression(expr, ok)` still reports only a boolean, so PALSJulia raises with the text alone. Widening it is an ABI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
