### PR TITLE
Return the expanded lattice with and without the computed parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,17 @@ This builds `libyaml_c_wrapper.dylib`, a shared object library that can interfac
 ```
 
 ### Example 2
-The program `examples/print_lattices` performs lattice expansion on a user-specified lattice. The first argument is the file name where the lattice is defined. It also takes an option argument using `-lat root_lattice` to specify a specific lattice to expand, otherwise it will choose a default (the lattice in the last `use` statement, or the last lattice in the file if none is present). The program will create and print a struct containing three lattices:
+The program `examples/print_lattices` performs lattice expansion on a user-specified lattice. The first argument is the file name where the lattice is defined. It also takes an option argument using `-lat root_lattice` to specify a specific lattice to expand, otherwise it will choose a default (the lattice in the last `use` statement, or the last lattice in the file if none is present). The program will create and print a struct containing the lattice views:
 - `original` is a map containing the base lattice as well as any file it reaches
 by `include` or `load`.
 - `combined` is the base lattice but with all included files substituted in and
 all loaded files merged in.
-- `expanded` is the base lattice after lattice expansion has been performed.
+- `expanded` is the base lattice after lattice expansion has been performed, holding
+the parameters the author wrote and nothing derived from them. Values are the
+finished ones, so a parameter in both trees has the same value in both.
+- `full_expanded` is the same lattice with every dependent parameter computed:
+reference parameters, floor placement, s-positions, and the derived members of each
+parameter family.
 To see the console output, in the build directory, run
 
 ```console
@@ -115,8 +120,9 @@ The library sources live in `src/`, split by concern:
 - `yaml_tree.h` — internal declarations shared between the wrapper and the PALS
   code: the tree representation behind `YAMLTreeHandle` (`ParsedData`) plus the
   low-level tree helpers (`ensure_capacity`, `deep_copy_recursive`).
-- `pals_expand.cpp` — the lattice expansion pipeline that builds the four-tree
-  representation (`original` / `combined` / `expanded` / `leftover`): include
+- `pals_expand.cpp` — the lattice expansion pipeline that builds the five-tree
+  representation (`original` / `combined` / `expanded` / `full_expanded` /
+  `leftover`): include
   splicing, `load` merging, structural expansion (repeats, inherits, forks), expression,
   controller and `set` evaluation, and the element bookkeeper that walks each
   branch

--- a/docs/src/guide/usage.md
+++ b/docs/src/guide/usage.md
@@ -20,9 +20,9 @@ tests. Put lattice files under `lattice_files/`.
 ## Expanding a lattice
 
 `parse_and_expand_PALS` reads a lattice file, resolves its includes and loads,
-expands the selected lattice, and returns a `lattices` struct with four
+expands the selected lattice, and returns a `lattices` struct with five
 independent views —
-`original`, `combined`, `expanded`, and `leftover` (see
+`original`, `combined`, `expanded`, `full_expanded`, and `leftover` (see
 [What it does](../index.md)). Each is a `YAMLTreeHandle` and must be freed with
 `delete_tree`.
 
@@ -31,7 +31,7 @@ independent views —
 
 struct lattices lat = parse_and_expand_PALS("ex.pals.yaml", nullptr);
 
-char* s = tree_to_string(lat.expanded);
+char* s = tree_to_string(lat.full_expanded);
 std::puts(s);
 yaml_free_string(s);
 
@@ -43,6 +43,7 @@ free_lattice_problems(lat.problems);
 delete_tree(lat.original);
 delete_tree(lat.combined);
 delete_tree(lat.expanded);
+delete_tree(lat.full_expanded);
 delete_tree(lat.leftover);
 ```
 
@@ -75,8 +76,10 @@ and `deep_copy_children`. Serialize with `node_to_string` / `tree_to_string`, or
 
 Three more entry points build on the expanded tree:
 
-- `build_correspondence_map` links a node across the four views (their
-  provenance is recorded as the trees are derived from one another).
+- `build_correspondence_map` links a node across the derivation chain — `original`,
+  `combined`, `full_expanded` and `leftover` (their provenance is recorded as the
+  trees are derived from one another). `expanded` takes no part: it is a pruned
+  copy of `full_expanded`, so its nodes are found by path.
 - `match_names` finds every named construct that a PALS *Name Matching* string
   refers to.
 - `get_parameter_value` looks up a single parameter value by a *Name Matching*
@@ -85,7 +88,7 @@ Three more entry points build on the expanded tree:
   The value is returned as stored, **not** evaluated: a plain number comes back as
   `PARAM_VALUE_NUMBER`, while an expression (e.g. `0.3 * 5`), a species name such
   as `#3He`, or other text comes back verbatim as a string (evaluating is the job
-  of expansion — the `expanded` tree already holds numbers). An unset element
+  of expansion — the expanded trees already hold numbers). An unset element
   parameter yields its default (`0` for now); and a string that identifies no
   single value — no matching element/constant/variable, a bare element name, a
   path stopping on a whole group, or matches that disagree — yields
@@ -93,15 +96,17 @@ Three more entry points build on the expanded tree:
   `string` with `yaml_free_string`.
 
   ```c
-  struct param_value v = get_parameter_value(expanded, "lat1>>>B1a>BendP.e1");
+  struct param_value v = get_parameter_value(full_expanded, "lat1>>>B1a>BendP.e1");
   if (v.kind == PARAM_VALUE_NUMBER) printf("%g\n", v.number);
   else if (v.kind == PARAM_VALUE_STRING) { puts(v.string); yaml_free_string(v.string); }
   ```
-- `get_lattice_parameter_value` is the whole-lattice form: pass the `expanded` and
-  `leftover` handles from one `parse_and_expand_PALS()` result and it looks in
-  `expanded` first (element parameters), then `leftover` (constants, variables,
+- `get_lattice_parameter_value` is the whole-lattice form: pass the `full_expanded`
+  and `leftover` handles from one `parse_and_expand_PALS()` result and it looks in
+  `full_expanded` first (element parameters), then `leftover` (constants, variables,
   and unused definitions) — never in the raw `original`/`combined` trees. Values
-  therefore come back already evaluated.
+  therefore come back already evaluated. Pass `full_expanded` rather than
+  `expanded`: a dependent parameter is a legitimate thing to ask for, and only the
+  former carries one.
 
 ## Examples
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,7 +25,7 @@ api
 
 ## What it does
 
-Lattice expansion follows the PALS specification and produces four views of a
+Lattice expansion follows the PALS specification and produces five views of a
 document:
 
 1. **`original`** — the raw tree mapping each file the document is built from —
@@ -34,13 +34,24 @@ document:
 2. **`combined`** — the tree with every `include` directive resolved and spliced
    inline, and every `load`ed file merged in subnode by subnode under the `PALS`
    root.
-3. **`expanded`** — the selected lattice fully expanded, and nothing else:
+3. **`full_expanded`** — the selected lattice fully expanded, and nothing else:
    elements substituted with their definitions, `repeat`ed beamlines unrolled,
    `inherit`ed ancestors merged, forks resolved, every mathematical expression
    evaluated to a number, `set` commands executed, and the ABSOLUTE controllers
    applied to the parameters they drive. It is rooted at the lattice entry
-   itself, without the `PALS`/`facility` scaffolding it was defined under.
-4. **`leftover`** — everything the expanded tree does not carry, keeping that
+   itself, without the `PALS`/`facility` scaffolding it was defined under. Every
+   dependent parameter has been computed: each element carries its `ReferenceP`,
+   `FloorP` and `s_position`, the derived members of every parameter family it
+   uses, and the non-zero defaults of the groups it carries; each branch is
+   capped with a `branch_end` Placeholder holding its final reference and floor.
+4. **`expanded`** — the same lattice with all of that removed. What the author
+   wrote decides which parameters stay; the values are the finished ones. It is
+   `full_expanded` with nodes removed rather than an earlier snapshot, so a
+   parameter present in both trees holds the same value in both, with every
+   `set` and ABSOLUTE controller applied. Use it to see the inputs rather than
+   their consequences, or to write a lattice back out without the computed
+   values.
+5. **`leftover`** — everything the expanded trees do not carry, keeping that
    scaffolding: element and beamline definitions, `use` statements, constants,
    controllers, `set` commands, and any lattice that was not the one expanded.
    A definition substituted into the lattice is copied, so it appears in both
@@ -63,10 +74,12 @@ This builds `libyaml_c_wrapper`, a shared library other languages can load.
 #include "yaml_c_wrapper.h"
 
 struct lattices lat = parse_and_expand_PALS("ex.pals.yaml", nullptr);
-char* s = tree_to_string(lat.expanded);   // the expanded lattice as YAML
+char* s = tree_to_string(lat.full_expanded);  // the expanded lattice as YAML
 // ... use it ...
 yaml_free_string(s);
 delete_tree(lat.original);
 delete_tree(lat.combined);
 delete_tree(lat.expanded);
+delete_tree(lat.full_expanded);
+delete_tree(lat.leftover);
 ```

--- a/examples/print_lattices.cpp
+++ b/examples/print_lattices.cpp
@@ -40,6 +40,9 @@ int main(int argc, char* argv[]) {
     std::cout << "========== Printing expanded lattice ==========" << std::endl;
     std::cout << tree_to_string(lat.expanded) << std::endl << "\n\n";
 
+    std::cout << "========== Printing full expanded lattice ==========" << std::endl;
+    std::cout << tree_to_string(lat.full_expanded) << std::endl << "\n\n";
+
     std::cout << "========== Printing leftover ==========" << std::endl;
     std::cout << tree_to_string(lat.leftover) << std::endl;
     return 0;

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -2560,11 +2560,16 @@ struct SetCommand {
 // a pre-expansion set (acting on definitions, where a derived value is not yet
 // available) from a post-expansion one (acting on the expanded lattice, where
 // writing a parameter makes its family stale).
+//
+// `written`, when given, collects one target per parameter actually written --
+// what the `expanded` tree needs in order to tell a post-expansion set's input
+// apart from a value the bookkeeper derived from it (see AuthoredParams).
 static void execute_set(ryml::Tree& t, const SetCommand& cmd,
                         const ElementMatches& matches, bool pre,
                         const pals::SymbolLookup& resolve,
                         const pals::SpeciesLookup& species,
-                        std::map<size_t, size_t>& prov, ProblemList& problems) {
+                        std::map<size_t, size_t>& prov, ProblemList& problems,
+                        std::vector<SetTarget>* written = nullptr) {
     std::string what = "set '" + cmd.param + "'";
 
     if (!matches.valid) {
@@ -2672,6 +2677,7 @@ static void execute_set(ryml::Tree& t, const SetCommand& cmd,
         for (size_t i = 0; i + 1 < tg.path.size(); ++i)
             parent = find_or_add_map_child(t, parent, tg.path[i].c_str());
         set_num_child(t, parent, tg.key.c_str(), r.value);
+        if (written) written->push_back(tg);
         // After the bookkeeper has run the rest of the family holds values
         // derived from the old one; drop them so the next pass rebuilds them.
         if (!pre) invalidate_family(t, tg, prov);
@@ -2806,7 +2812,8 @@ static void run_pre_expansion_sets(ryml::Tree& t,
 static void run_post_expansion_sets(ryml::Tree& t, size_t lat_node,
                                     const std::vector<size_t>& entries,
                                     std::map<size_t, size_t>& prov,
-                                    ProblemList& problems) {
+                                    ProblemList& problems,
+                                    std::vector<SetTarget>* written = nullptr) {
     if (lat_node == ryml::NONE) return;
     for (size_t e : entries) {
         for (const SetCommand& cmd : entry_set_commands(t, e, problems)) {
@@ -2815,7 +2822,7 @@ static void run_post_expansion_sets(ryml::Tree& t, size_t lat_node,
             make_expression_context(t, resolve, species);
             execute_set(t, cmd,
                         match_element_parameters(t, lat_node, cmd.param), false,
-                        resolve, species, prov, problems);
+                        resolve, species, prov, problems, written);
         }
     }
 }
@@ -3825,6 +3832,194 @@ static void link_fork_connections(ryml::Tree& t, size_t lat_node) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// The `expanded` tree: the finished lattice minus everything the bookkeeper
+// computed.
+//
+// What counts as computed is recorded as the set of *authored* parameter paths,
+// taken before any bookkeeping runs, rather than as a list of what the
+// bookkeeper writes. Node ids cannot serve: a post-expansion `set` invalidates a
+// parameter family with t.remove(), ryml recycles the freed ids, and a recorded
+// id would then name a different node -- the hazard invalidate_family already
+// guards provenance against. And recording writes would be wrong even so:
+// set_num_child overwrites an existing key in place, so write_ref writes an
+// author's `E_tot_ref` without creating it, and it would be lost.
+//
+// A path is `branch-index/line-index/key` for an element's own parameter and
+// `branch-index/line-index/group/key` for one inside a parameter group, which is
+// as deep as a PALS element nests. Positions rather than names because names
+// repeat: one definition used three times gives three elements called `q1`.
+// Positions survive bookkeeping -- forks append their branches during expand(),
+// before the snapshot, and the only element the bookkeeper adds is the
+// `branch_end` it appends after the last one of a branch.
+
+// The authored shape of a lattice: which elements it held, and which parameters
+// each of those carried.
+struct AuthoredParams {
+    std::set<std::string> elements;  // "branch/line"
+    std::set<std::string> params;    // "branch/line[/group]/key"
+};
+
+static std::string ele_path(size_t branch, size_t line) {
+    return std::to_string(branch) + "/" + std::to_string(line);
+}
+
+// Visit every element definition of every branch line, in the order the paths
+// number them. `fn(branch_index, line_index, def, entry)` receives the element
+// definition and the anonymous seq-entry map wrapping it. The callback must not
+// add or remove nodes: the walk holds sibling ids across the call.
+template <typename F>
+static void for_each_line_element(ryml::Tree& t, size_t lat_node, F fn) {
+    size_t branches = t.find_child(lat_node, ryml::to_csubstr("branches"));
+    if (branches == ryml::NONE || !t.is_seq(branches)) return;
+
+    size_t b = 0;
+    for (size_t entry = t.first_child(branches); entry != ryml::NONE;
+         entry = t.next_sibling(entry), ++b) {
+        if (!t.is_map(entry)) continue;
+        size_t branch = t.first_child(entry);
+        if (branch == ryml::NONE || !t.is_map(branch)) continue;
+        size_t line = t.find_child(branch, ryml::to_csubstr("line"));
+        if (line == ryml::NONE || !t.is_seq(line)) continue;
+
+        size_t l = 0;
+        for (size_t le = t.first_child(line); le != ryml::NONE;
+             le = t.next_sibling(le), ++l) {
+            // A line entry is a wrapper map whose first child is the keyed
+            // element definition; bare unresolved references have no parameters.
+            if (!t.is_map(le)) continue;
+            size_t def = t.first_child(le);
+            if (def == ryml::NONE || !t.has_key(def)) continue;
+            fn(b, l, def, le);
+        }
+    }
+}
+
+// Record the lattice's authored shape. Run after expansion and expression
+// evaluation but before the bookkeeper, so what it sees is the author's inputs,
+// resolved: substituted, unrolled, evaluated, and driven by any ABSOLUTE
+// controller.
+static void collect_authored(ryml::Tree& t, size_t lat_node,
+                             AuthoredParams& out) {
+    for_each_line_element(
+        t, lat_node, [&](size_t b, size_t l, size_t ele, size_t) {
+            const std::string ep = ele_path(b, l);
+            out.elements.insert(ep);
+            for (size_t c = t.first_child(ele); c != ryml::NONE;
+                 c = t.next_sibling(c)) {
+                if (!t.has_key(c)) continue;
+                const std::string key(t.key(c).str, t.key(c).len);
+                if (!t.is_map(c)) {
+                    // A scalar (`length`) or a sequence (`ForkFromP`), held or
+                    // dropped whole.
+                    out.params.insert(ep + "/" + key);
+                    continue;
+                }
+                // The group is recorded in its own right as well as by its
+                // members: writing the group is meaningful even when it holds
+                // nothing the author set, since presence is what makes the
+                // bookkeeper materialize its defaults.
+                out.params.insert(ep + "/" + key);
+                for (size_t g = t.first_child(c); g != ryml::NONE;
+                     g = t.next_sibling(g))
+                    if (t.has_key(g))
+                        out.params.insert(ep + "/" + key + "/" +
+                                          std::string(t.key(g).str,
+                                                      t.key(g).len));
+            }
+        });
+}
+
+// Fold the parameters a post-expansion `set` wrote into the authored set. Those
+// sets run after the first bookkeeper pass, so the snapshot taken before it has
+// not seen them -- without this, `expanded` would drop the very value the set
+// wrote and keep what the second pass derived from it. The targets name their
+// element by node id, which is still live (nothing removes an element), so the
+// branch/line position is read back off the tree.
+static void add_set_targets(ryml::Tree& t, size_t lat_node,
+                            const std::vector<SetTarget>& writes,
+                            AuthoredParams& out) {
+    if (writes.empty()) return;
+
+    std::map<size_t, std::string> where;
+    for_each_line_element(
+        t, lat_node, [&](size_t b, size_t l, size_t ele, size_t) {
+            where[ele] = ele_path(b, l);
+        });
+
+    for (const SetTarget& tg : writes) {
+        auto it = where.find(tg.ele);
+        if (it == where.end() || tg.path.empty()) continue;
+        // `path` is the parameter's route within the element: [key] for one of
+        // the element's own, [group, key] for one inside a group.
+        std::string p = it->second;
+        for (const std::string& step : tg.path) p += "/" + step;
+        out.params.insert(p);
+        if (tg.path.size() >= 2) out.params.insert(it->second + "/" + tg.path[0]);
+    }
+}
+
+// Cut every computed parameter out of a copy of the finished lattice, leaving
+// the authored inputs. Nodes are gathered first and removed afterwards: removal
+// frees ids, which would invalidate the walk that is still using them.
+static void prune_computed_params(ryml::Tree& t, size_t lat_node,
+                                  const AuthoredParams& authored,
+                                  std::map<size_t, size_t>& prov) {
+    std::vector<size_t> drop;
+
+    for_each_line_element(
+        t, lat_node, [&](size_t b, size_t l, size_t ele, size_t entry) {
+            const std::string ep = ele_path(b, l);
+            if (!authored.elements.count(ep)) {
+                // An element the bookkeeper added: the `branch_end` Placeholder
+                // capping the branch, which exists only to carry the final
+                // reference and floor. Drop the seq entry rather than just the
+                // definition, so the line is not left holding an empty slot.
+                drop.push_back(entry);
+                return;
+            }
+            for (size_t c = t.first_child(ele); c != ryml::NONE;
+                 c = t.next_sibling(c)) {
+                if (!t.has_key(c)) continue;
+                const std::string key(t.key(c).str, t.key(c).len);
+                // `kind` says what the element is rather than how it is set up;
+                // it is held whatever the snapshot saw.
+                if (key == "kind") continue;
+
+                const std::string path = ep + "/" + key;
+                if (!t.is_map(c)) {
+                    if (!authored.params.count(path)) drop.push_back(c);
+                    continue;
+                }
+
+                std::vector<size_t> stale;
+                bool any_authored = false;
+                for (size_t g = t.first_child(c); g != ryml::NONE;
+                     g = t.next_sibling(g)) {
+                    if (!t.has_key(g)) continue;
+                    if (authored.params.count(
+                            path + "/" +
+                            std::string(t.key(g).str, t.key(g).len)))
+                        any_authored = true;
+                    else
+                        stale.push_back(g);
+                }
+                // A group with nothing authored left in it goes too -- unless
+                // the author wrote the group itself, in which case it stays,
+                // empty, as written.
+                if (!any_authored && !authored.params.count(path))
+                    drop.push_back(c);
+                else
+                    drop.insert(drop.end(), stale.begin(), stale.end());
+            }
+        });
+
+    for (size_t n : drop) {
+        erase_prov_subtree(t, n, prov);
+        t.remove(n);
+    }
+}
+
 // Rewrite the `destination_pointer` scalars of a freshly split-out tree.
 // handle_fork stores the raw node id of the fork's destination element, but it
 // runs while expansion is still on the work tree; cutting the lattice out into
@@ -3862,20 +4057,52 @@ static void remap_destination_pointers(ryml::Tree& t, size_t node,
         remap_destination_pointers(t, c, from_work, problems);
 }
 
-// Builds the `expanded` and `leftover` trees from `combined`.
+// Copy the lattice out of the work tree into a tree of its own: a map holding
+// the single `name: {...}` entry. The root is synthesised (a ryml root cannot
+// itself carry a key), so it has no counterpart in combined and no provenance
+// entry. When there is no lattice the tree stays an empty map.
+static ParsedData* split_out_lattice(ryml::Tree& t, size_t lat_node,
+                                     const std::map<size_t, size_t>& work_prov,
+                                     ProblemList& problems) {
+    ParsedData* out = new ParsedData();
+    out->tree.reserve(out->tree.capacity() + t.capacity() + 16);
+    out->tree.reserve_arena(out->tree.arena_capacity() + t.arena_capacity());
+    out->tree.ref(out->tree.root_id()) |= ryml::MAP;
+    if (lat_node == ryml::NONE) return out;
+
+    ensure_capacity(out->tree);
+    size_t entry = out->tree.append_child(out->tree.root_id());
+    deep_copy_tracked(out->tree, entry, t, lat_node, out->provenance);
+
+    // Before provenance is chained up to combined it still reads
+    // this-tree->work, which inverts into exactly the renaming the fork
+    // pointers need.
+    std::map<size_t, size_t> from_work;
+    for (const auto& kv : out->provenance) from_work[kv.second] = kv.first;
+    remap_destination_pointers(out->tree, out->tree.root_id(), from_work,
+                               problems);
+
+    chain_prov(out->provenance, work_prov);
+    return out;
+}
+
+// Builds the `expanded`, `full_expanded` and `leftover` trees from `combined`.
 //
 // Expansion has to run on the whole document at once — the lattice pulls in
 // element and beamline definitions from the rest of the file — so it happens on
-// a single throwaway work tree, which is then cut in two: `expanded` takes the
-// root lattice and nothing else, `leftover` takes everything the lattice left
-// behind. Both record provenance straight back to `combined`, so the work tree
-// can be discarded.
+// a single throwaway work tree, which is then cut up: the root lattice is taken
+// twice, once whole as `full_expanded` and once pruned back to the author's
+// inputs as `expanded`, and `leftover` takes everything the lattice left behind.
+// All three record provenance straight back to `combined`, so the work tree can
+// be discarded.
 static void make_expanded_and_leftover(ParsedData* comb,
                                        const char* root_lattice,
                                        ProblemList& problems,
                                        YAMLTreeHandle& expanded_out,
+                                       YAMLTreeHandle& full_expanded_out,
                                        YAMLTreeHandle& leftover_out) {
     expanded_out = nullptr;
+    full_expanded_out = nullptr;
     leftover_out = nullptr;
     if (!comb) return;
 
@@ -3909,6 +4136,10 @@ static void make_expanded_and_leftover(ParsedData* comb,
     // an empty entry. A lattice that is not a lone entry under a wrapper (e.g.
     // one keyed directly into a map) is skipped on its own.
     size_t skip = ryml::NONE;
+
+    // What the author asked for, against which the bookkeeper's output is told
+    // apart further down; filled in just before the bookkeeper runs.
+    AuthoredParams authored;
 
     if (lat_node == ryml::NONE) {
         add_problem(problems, name_str.empty()
@@ -3947,6 +4178,12 @@ static void make_expanded_and_leftover(ParsedData* comb,
         // creates is new and simply has no provenance, like ReferenceP/FloorP.
         evaluate_expressions(t, lat_node, problems);
 
+        // The last point at which the lattice holds the author's inputs and
+        // nothing else. Record their paths now; everything the finished lattice
+        // carries that is not among them was computed, and is what tells
+        // `expanded` apart from `full_expanded`.
+        collect_authored(t, lat_node, authored);
+
         // With every input now a plain number, walk each branch element-by-
         // element to fill in the reference, floor, s-position, and field-
         // dependent output parameters. This adds new ReferenceP/FloorP nodes,
@@ -3961,8 +4198,13 @@ static void make_expanded_and_leftover(ParsedData* comb,
         // second time to recompute what those writes invalidated -- reference
         // and floor parameters, and the family members execute_set dropped.
         if (!facility.post.empty()) {
+            std::vector<SetTarget> set_writes;
             run_post_expansion_sets(t, lat_node, facility.post, work.provenance,
-                                    problems);
+                                    problems, &set_writes);
+            // These writes are inputs like any other, but they land after the
+            // snapshot above; join them to it before the second bookkeeper pass
+            // derives their families again.
+            add_set_targets(t, lat_node, set_writes, authored);
             evaluate_expressions(t, lat_node, problems);
             run_element_bookkeeper(t, lat_node, problems);
         }
@@ -3978,31 +4220,23 @@ static void make_expanded_and_leftover(ParsedData* comb,
                    : lat_node;
     }
 
-    // expanded: a map holding just the lattice entry, keyed by its name. The
-    // root is synthesised (a ryml root cannot itself carry a key), so it has no
-    // counterpart in combined and no provenance entry. When no lattice was
-    // found the tree stays an empty map.
-    ParsedData* exp = new ParsedData();
-    exp->tree.reserve(exp->tree.capacity() + t.capacity() + 16);
-    exp->tree.reserve_arena(exp->tree.arena_capacity() + t.arena_capacity());
-    exp->tree.ref(exp->tree.root_id()) |= ryml::MAP;
+    // full_expanded: the lattice as the bookkeeper left it, everything computed.
+    ParsedData* full = split_out_lattice(t, lat_node, work.provenance, problems);
+
+    // expanded: the same lattice, pruned back to what the author wrote. It is
+    // cut from the same work tree rather than from `full`, so the two are
+    // independent -- freeing one leaves the other whole. Its faults are `full`'s
+    // faults and have just been reported, so the second split's problems are
+    // dropped rather than said twice.
+    ProblemList said_already;
+    ParsedData* mini =
+        split_out_lattice(t, lat_node, work.provenance, said_already);
     if (lat_node != ryml::NONE) {
-        ensure_capacity(exp->tree);
-        size_t entry = exp->tree.append_child(exp->tree.root_id());
-        deep_copy_tracked(exp->tree, entry, t, lat_node, exp->provenance);
-
-        // Before provenance is chained up to combined it still reads
-        // expanded->work, which inverts into exactly the renaming the fork
-        // pointers need.
-        std::map<size_t, size_t> from_work;
-        for (const auto& kv : exp->provenance) from_work[kv.second] = kv.first;
-        remap_destination_pointers(exp->tree, exp->tree.root_id(), from_work,
-                                   problems);
-
-        chain_prov(exp->provenance, work.provenance);
+        size_t entry = mini->tree.first_child(mini->tree.root_id());
+        prune_computed_params(mini->tree, entry, authored, mini->provenance);
     }
 
-    // leftover: the whole document minus what went to expanded.
+    // leftover: the whole document minus what went to the expanded trees.
     ParsedData* left = new ParsedData();
     left->tree.reserve(left->tree.capacity() + t.capacity() + 16);
     left->tree.reserve_arena(left->tree.arena_capacity() + t.arena_capacity());
@@ -4010,7 +4244,8 @@ static void make_expanded_and_leftover(ParsedData* comb,
                              skip, left->provenance);
     chain_prov(left->provenance, work.provenance);
 
-    expanded_out = exp;
+    expanded_out = mini;
+    full_expanded_out = full;
     leftover_out = left;
 }
 
@@ -4122,7 +4357,7 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
     ProblemList problems;
     // Built as a derivation chain so provenance can be recorded at each step:
     //   original --(splice includes, merge loads)--> combined
-    //   combined  --(expand, split)--> expanded, leftover
+    //   combined  --(expand, split)--> expanded, full_expanded, leftover
     //
     // Every file is keyed in `original` by its folded path, so folding the
     // top-level one here is what makes it agree with the paths the files
@@ -4132,7 +4367,7 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
     lat.original = make_original(top_path, parse_error);
     if (!parse_error.empty()) {
         // The top-level file is not valid YAML: there is no tree to expand.
-        // Free the empty stand-in, leave all four handles NULL, and report the
+        // Free the empty stand-in, leave all five handles NULL, and report the
         // location as the single problem so the caller can pinpoint the fault.
         delete_tree(lat.original);
         lat.original = nullptr;
@@ -4150,7 +4385,7 @@ YAML_API struct lattices parse_and_expand_PALS(const char* filename,
 
         make_expanded_and_leftover(static_cast<ParsedData*>(lat.combined),
                                    root_lattice, problems, lat.expanded,
-                                   lat.leftover);
+                                   lat.full_expanded, lat.leftover);
     }
 
     // Hand the problem list to the caller as an owning C string array (freed
@@ -4184,11 +4419,11 @@ YAML_API double evaluate_pals_expression(const char* expr, bool* ok) {
 }
 
 YAML_API struct correspondence_map build_correspondence_map(
-    YAMLTreeHandle original, YAMLTreeHandle combined, YAMLTreeHandle expanded,
-    YAMLTreeHandle leftover) {
-    (void)original;  // provenance is stored in combined, expanded & leftover
+    YAMLTreeHandle original, YAMLTreeHandle combined,
+    YAMLTreeHandle full_expanded, YAMLTreeHandle leftover) {
+    (void)original;  // provenance is in combined, full_expanded & leftover
     struct correspondence_map out = {nullptr, 0};
-    if (!combined || (!expanded && !leftover)) return out;
+    if (!combined || (!full_expanded && !leftover)) return out;
 
     ParsedData* comb = static_cast<ParsedData*>(combined);
     const std::map<size_t, size_t>& c2o = comb->provenance;  // combined->original
@@ -4212,7 +4447,7 @@ YAML_API struct correspondence_map build_correspondence_map(
             stack.pop_back();
 
             struct node_link link;
-            link.expanded = is_leftover ? YAML_NULL_ID : n;
+            link.full_expanded = is_leftover ? YAML_NULL_ID : n;
             link.leftover = is_leftover ? n : YAML_NULL_ID;
             auto dc = d2c.find(n);
             if (dc != d2c.end()) {
@@ -4231,7 +4466,7 @@ YAML_API struct correspondence_map build_correspondence_map(
         }
     };
 
-    walk(expanded, false);
+    walk(full_expanded, false);
     walk(leftover, true);
 
     out.count = links.size();

--- a/src/pals_match.cpp
+++ b/src/pals_match.cpp
@@ -517,9 +517,10 @@ YAML_API struct param_value get_parameter_value(YAMLTreeHandle tree,
 }
 
 YAML_API struct param_value get_lattice_parameter_value(
-    YAMLTreeHandle expanded, YAMLTreeHandle leftover, const char* match_string) {
+    YAMLTreeHandle full_expanded, YAMLTreeHandle leftover,
+    const char* match_string) {
     // Element parameters live in the expanded lattice; look there first.
-    struct param_value v = get_parameter_value(expanded, match_string);
+    struct param_value v = get_parameter_value(full_expanded, match_string);
     if (v.kind != PARAM_VALUE_MISSING) return v;
     // Constants, variables and unused definitions live in the facility
     // scaffolding kept by the leftover tree.

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -21,7 +21,7 @@
  *        representations.
  *
  * @defgroup correspond Node correspondence
- * @brief Map a single logical node across the original, combined, expanded and
+ * @brief Map a single logical node across the original, combined, full_expanded
  *        leftover trees.
  *
  * @defgroup namematch Name matching
@@ -72,7 +72,7 @@ typedef size_t YAMLNodeId;
  * @ingroup parse
  *
  * Used to return the human-readable problems encountered while building the
- * `expanded` tree (undefined lattice, dangling element/line references,
+ * `full_expanded` tree (undefined lattice, dangling element/line references,
  * undefined `inherit`/`repeat`/`Fork` targets, expressions that could not be
  * evaluated, ...). Free with free_lattice_problems().
  */
@@ -82,7 +82,7 @@ struct string_list {
 };
 
 /**
- * @brief The four trees parse_and_expand_PALS() produces, plus the problems
+ * @brief The five trees parse_and_expand_PALS() produces, plus the problems
  *        found on the way.
  * @ingroup parse
  *
@@ -96,18 +96,24 @@ struct lattices {
                               ///< its unparsed contents, keyed by path.
     YAMLTreeHandle combined;  ///< Tree with all "include" directives spliced
                               ///< inline and all "load"ed files merged in.
-    YAMLTreeHandle expanded;  ///< The expanded root lattice, and nothing else:
-                              ///< a map holding the single `name: {kind:
-                              ///< Lattice, ...}` entry, without the
-                              ///< PALS/facility scaffolding it was defined
-                              ///< under.
-    YAMLTreeHandle leftover;  ///< Everything the expanded tree does not carry —
+    YAMLTreeHandle expanded;  ///< @ref full_expanded minus every parameter the
+                              ///< bookkeeper computed. Values are the finished
+                              ///< ones: a parameter in both trees holds the
+                              ///< same value in both.
+    YAMLTreeHandle full_expanded;  ///< The expanded root lattice, and nothing
+                                   ///< else: a map holding the single `name:
+                                   ///< {kind: Lattice, ...}` entry, without the
+                                   ///< PALS/facility scaffolding it was defined
+                                   ///< under. Every dependent parameter is
+                                   ///< computed and present.
+    YAMLTreeHandle leftover;  ///< Everything the expanded trees do not carry —
                               ///< the whole PALS/facility document minus the
                               ///< root lattice, so element/beamline
                               ///< definitions, `use` statements, constants and
                               ///< any non-root Lattice.
-    struct string_list problems;  ///< Problems found while building `expanded`;
-                                  ///< free with free_lattice_problems().
+    struct string_list problems;  ///< Problems found while building
+                                  ///< `full_expanded`; free with
+                                  ///< free_lattice_problems().
 };
 
 /**
@@ -115,28 +121,32 @@ struct lattices {
  *        parse_and_expand_PALS().
  * @ingroup correspond
  *
- * The trees are built as a derivation chain (original -> combined -> expanded
- * and leftover), and provenance is recorded at every copy, so each link records
- * which node in each tree a single logical entity maps to.
+ * The trees are built as a derivation chain (original -> combined ->
+ * full_expanded and leftover), and provenance is recorded at every copy, so each
+ * link records which node in each tree a single logical entity maps to.
  *
- * The mapping is functional per link: one expanded (or leftover) node maps to at
- * most one combined node, which maps to at most one original node. Because
+ * The mapping is functional per link: one full_expanded (or leftover) node maps
+ * to at most one combined node, which maps to at most one original node. Because
  * expansion can duplicate nodes (scalar substitution, `repeat`, `inherit`,
  * forks), a single combined/original node may appear in several links — one per
  * copy. A field is YAML_NULL_ID when no corresponding node exists (e.g. the
  * `destination_pointer` scalars synthesised during expansion have no original
  * source).
  *
- * Expansion splits the document, so a link carries either an `expanded` id or a
- * `leftover` id, never both; the two are tied together through the `combined`
- * id they share. A definition that was substituted into the lattice therefore
- * yields links on both sides: one for the copy in `expanded`, one for the
- * definition still standing in `leftover`.
+ * Expansion splits the document, so a link carries either a `full_expanded` id
+ * or a `leftover` id, never both; the two are tied together through the
+ * `combined` id they share. A definition that was substituted into the lattice
+ * therefore yields links on both sides: one for the copy in `full_expanded`, one
+ * for the definition still standing in `leftover`.
+ *
+ * The `expanded` tree is not mapped: it is a pruned copy of `full_expanded`, so
+ * a node in it is found by the path it sits at, not by a recorded link.
  */
 struct node_link {
     YAMLNodeId original;  ///< Node in the `original` tree, or YAML_NULL_ID.
     YAMLNodeId combined;  ///< Node in the `combined` tree, or YAML_NULL_ID.
-    YAMLNodeId expanded;  ///< Node in the `expanded` tree, or YAML_NULL_ID.
+    YAMLNodeId full_expanded;  ///< Node in the `full_expanded` tree, or
+                               ///< YAML_NULL_ID.
     YAMLNodeId leftover;  ///< Node in the `leftover` tree, or YAML_NULL_ID.
 };
 
@@ -144,7 +154,7 @@ struct node_link {
  * @brief A flat list of node_links.
  * @ingroup correspond
  *
- * One link is emitted per node of the expanded tree and one per node of the
+ * One link is emitted per node of the full_expanded tree and one per node of the
  * leftover tree. Free with free_correspondence_map().
  */
 struct correspondence_map {
@@ -179,12 +189,12 @@ extern "C" {
  * statement, or
  *                       - expands the last lattice defined in the file if no
  * "use" is present.
- * @return A `lattices` struct containing four handles:
+ * @return A `lattices` struct containing five handles:
  *           - `original`: raw tree mapping each file (including includes) to
  * its unparsed contents.
  *           - `combined`: tree with all "include" directives resolved and
  * spliced inline.
- *           - `expanded`: the selected lattice fully expanded — scalars
+ *           - `full_expanded`: the selected lattice fully expanded — scalars
  * substituted, repeats unrolled, inherits merged, and forks resolved — and
  * nothing else. Rooted at a map holding the single `name: {kind: Lattice, ...}`
  * entry, stripped of the PALS/facility scaffolding it was defined under. Its
@@ -193,20 +203,36 @@ extern "C" {
  * contents are spliced directly into the enclosing line, so no nested BeamLine
  * survives. Elements of a `multipass` line carry a `multipass_index` giving
  * their pass number — how many times a particle will have travelled through
- * that physical element by that point.
+ * that physical element by that point. Every dependent parameter has been
+ * computed: each element carries its `ReferenceP`, `FloorP` and `s_position`,
+ * the derived members of every parameter family it uses (`Kn1L` alongside
+ * `Kn1`, `voltage` alongside `gradient`, ...), the non-zero defaults of the
+ * groups it carries, and each branch is capped with a `branch_end` Placeholder
+ * holding its final reference and floor.
+ *           - `expanded`: the same lattice with all of that removed. Which
+ * parameters it keeps is decided by what the author wrote: one is held when it
+ * was present before bookkeeping ran or was written by a post-`expand_lattice`
+ * `set`, and everything else the bookkeeper computed is pruned, along with any
+ * group left empty and the `branch_end` elements. The *values* it holds are the
+ * finished ones — this is `full_expanded` with nodes removed, not an earlier
+ * snapshot, so a parameter present in both trees carries the same value in
+ * both, with every `set` and ABSOLUTE controller applied. Use it to see what
+ * was asked for rather than what it implies, or to write a lattice back out
+ * without the derived values.
  *           - `leftover`: the rest of the document, keeping its PALS/facility
  * scaffolding: element and beamline definitions, `use` statements, constants,
  * and any Lattice that was not the one expanded. Definitions substituted into
  * the lattice are copies, so they appear in both trees.
- *         All four handles must be freed individually with delete_tree().
+ *         All five handles must be freed individually with delete_tree().
  *
  *         The returned struct also carries `problems`: an owning list of
  *         human-readable messages for every issue met while building the
- *         `expanded` tree (undefined lattice, dangling element/line references,
- *         undefined `inherit`/`repeat`/`Fork` targets, and expressions that
- *         could not be evaluated). It is empty when expansion was clean. The
- *         caller owns it and must release it with free_lattice_problems(). The
- *         library does not print — the caller decides whether to report.
+ *         `full_expanded` tree (undefined lattice, dangling element/line
+ *         references, undefined `inherit`/`repeat`/`Fork` targets, and
+ *         expressions that could not be evaluated). It is empty when expansion
+ *         was clean. The caller owns it and must release it with
+ *         free_lattice_problems(). The library does not print — the caller
+ *         decides whether to report.
  */
 YAML_API struct lattices parse_and_expand_PALS(const char* filename,
                                       const char* root_lattice);
@@ -247,33 +273,38 @@ YAML_API void free_lattice_problems(struct string_list problems);
 YAML_API double evaluate_pals_expression(const char* expr, bool* ok);
 
 /**
- * Builds the node correspondence between the four trees of a `lattices` value.
+ * Builds the node correspondence between the derivation-chain trees of a
+ * `lattices` value.
  * @ingroup correspond
  *
- * Returns a flat list containing one `node_link` per node of the `expanded`
- * tree and one per node of the `leftover` tree. Each link gives the
- * corresponding `combined` and `original` node ids (or YAML_NULL_ID where none
- * exists). Grouping the links by shared combined / original ids recovers, for
- * any node in any of the four trees, the set of nodes it corresponds to in the
+ * Returns a flat list containing one `node_link` per node of the
+ * `full_expanded` tree and one per node of the `leftover` tree. Each link gives
+ * the corresponding `combined` and `original` node ids (or YAML_NULL_ID where
+ * none exists). Grouping the links by shared combined / original ids recovers,
+ * for any node in any of those trees, the set of nodes it corresponds to in the
  * others.
+ *
+ * The `expanded` tree takes no part: it is a pruned copy of `full_expanded`
+ * rather than a step in the derivation chain, and its nodes are located by path.
  *
  * The handles must come from the same parse_and_expand_PALS() call — the
  * provenance recorded during that call is what makes the mapping exact. The
  * `original` handle is accepted for API symmetry; the mapping is derived from
- * the provenance stored in `combined`, `expanded` and `leftover`.
+ * the provenance stored in `combined`, `full_expanded` and `leftover`.
  *
- * @param original Handle to the `original` tree.
- * @param combined Handle to the `combined` tree.
- * @param expanded Handle to the `expanded` tree.
- * @param leftover Handle to the `leftover` tree. May be NULL, in which case only
- *                 the expanded tree is walked.
+ * @param original      Handle to the `original` tree.
+ * @param combined      Handle to the `combined` tree.
+ * @param full_expanded Handle to the `full_expanded` tree.
+ * @param leftover      Handle to the `leftover` tree. May be NULL, in which case
+ *                      only the full_expanded tree is walked.
  * @return A correspondence_map. The caller must free it with
  *         free_correspondence_map(). `links` is NULL and `count` is 0 if
- *         `combined` is NULL, or if both `expanded` and `leftover` are NULL.
+ *         `combined` is NULL, or if both `full_expanded` and `leftover` are
+ *         NULL.
  */
 YAML_API struct correspondence_map build_correspondence_map(
-    YAMLTreeHandle original, YAMLTreeHandle combined, YAMLTreeHandle expanded,
-    YAMLTreeHandle leftover);
+    YAMLTreeHandle original, YAMLTreeHandle combined,
+    YAMLTreeHandle full_expanded, YAMLTreeHandle leftover);
 
 /**
  * Frees the link array owned by a correspondence_map. Passing a map with a NULL
@@ -311,7 +342,7 @@ YAML_API void free_correspondence_map(struct correspondence_map map);
  * `{e1}:{e2}` ranges, `,` unions, and `&` intersections.
  *
  * Because beamlines and elements are only fully realised after expansion, this
- * is normally run on the `expanded` tree of a parse_and_expand_PALS() result,
+ * is normally run on the `full_expanded` tree of a parse_and_expand_PALS() result,
  * but it works on any tree. Results are de-duplicated and returned in
  * document order.
  *
@@ -370,17 +401,17 @@ struct param_value {
  * element parameter (with a `>{group}.{sub}. ... .{param}` path) or, as a bare
  * name (no lattice/branch/kind qualifier and no path), a constant or variable —
  * the same constructs match_names() resolves. Run an element-parameter query on
- * the `expanded` tree of a parse_and_expand_PALS() result, where constants and
+ * the `full_expanded` tree of a parse_and_expand_PALS() result, where constants and
  * variables referenced by a value have already been substituted; constants and
  * variables themselves live in the facility scaffolding, so look them up in any
  * view that keeps it — `original`, `combined`, or `leftover` — but not
- * `expanded`, which drops it (exactly as with match_names()).
+ * the expanded trees, which drop it (exactly as with match_names()).
  *
  * The value is returned as stored; it is NOT evaluated. A plain numeric literal
  * comes back as a number (PARAM_VALUE_NUMBER); anything else — an expression such
  * as "0.3 * 5", a species name like "#3He", or any other text — comes back
  * verbatim as a string (PARAM_VALUE_STRING). Evaluation is the job of lattice
- * expansion (the `expanded` tree already holds numbers) or
+ * expansion (the expanded trees already hold numbers) or
  * evaluate_pals_expression, not of this accessor.
  *
  * Resolution, and the resulting `kind`:
@@ -406,30 +437,33 @@ YAML_API struct param_value get_parameter_value(YAMLTreeHandle tree,
 
 /**
  * Looks up a parameter value across the two trees of an expanded lattice that
- * carry live values: the `expanded` lattice (element parameters, already
+ * carry live values: the `full_expanded` lattice (element parameters, already
  * evaluated) and the `leftover` facility scaffolding (constants, variables, and
  * any element/beamline definitions not spliced into the lattice).
  * @ingroup param
  *
  * This is the whole-lattice form of get_parameter_value(): the caller passes the
  * two relevant handles from a parse_and_expand_PALS() result instead of picking a
- * tree by hand. `expanded` is consulted first; only if it does not identify the
- * parameter is `leftover` tried. The `original` and `combined` trees are
+ * tree by hand. `full_expanded` is consulted first; only if it does not identify
+ * the parameter is `leftover` tried. The `original` and `combined` trees are
  * deliberately not consulted — they hold raw, pre-expansion text, so a value read
- * from them would be unevaluated and, for reused definitions, duplicated.
+ * from them would be unevaluated and, for reused definitions, duplicated. Pass
+ * `full_expanded` rather than `expanded`: a dependent parameter is a legitimate
+ * thing to ask for, and only the former carries one.
  *
  * Either handle may be NULL (treated as "no match" for that tree). The value's
  * `kind`, string ownership, and the number/string/missing rules are exactly
  * those of get_parameter_value().
  *
- * @param expanded     Handle to the `expanded` tree (element parameters).
- * @param leftover     Handle to the `leftover` tree (constants/variables).
- * @param match_string Null-terminated name-matching string.
+ * @param full_expanded Handle to the `full_expanded` tree (element parameters).
+ * @param leftover      Handle to the `leftover` tree (constants/variables).
+ * @param match_string  Null-terminated name-matching string.
  * @return A param_value. If `kind` is PARAM_VALUE_STRING the caller must free
  *         `string` with yaml_free_string().
  */
 YAML_API struct param_value get_lattice_parameter_value(
-    YAMLTreeHandle expanded, YAMLTreeHandle leftover, const char* match_string);
+    YAMLTreeHandle full_expanded, YAMLTreeHandle leftover,
+    const char* match_string);
 
 /**
  * Parses a YAML file from disk into an opaque tree handle.

--- a/src/yaml_tree.h
+++ b/src/yaml_tree.h
@@ -20,11 +20,11 @@
 // size_t within its tree.
 //
 // `provenance` links this tree back to the one it was derived from in the
-// original -> combined -> (expanded, leftover) chain: it maps a node id in
-// *this* tree to the node id in the *source* tree it was copied from. It is
-// empty for trees that are not derived from another (e.g. `original`). For
-// `combined` it maps combined ids -> original ids; for `expanded` and
-// `leftover` alike it maps their ids -> combined ids.
+// original -> combined -> (expanded, full_expanded, leftover) chain: it maps a
+// node id in *this* tree to the node id in the *source* tree it was copied from.
+// It is empty for trees that are not derived from another (e.g. `original`). For
+// `combined` it maps combined ids -> original ids; for the two expanded trees
+// and `leftover` alike it maps their ids -> combined ids.
 struct ParsedData {
     ryml::Tree tree;
     std::string buffer;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(tests
   test_controllers.cpp
   test_sets.cpp
   test_bookkeeper.cpp
+  test_expanded_minus_dependent.cpp
   test_check.cpp
   test_load.cpp
   test_floor.cpp

--- a/tests/test_bookkeeper.cpp
+++ b/tests/test_bookkeeper.cpp
@@ -75,7 +75,7 @@ struct lattices expand_bookkeeper() {
 TEST_CASE("Bookkeeper fills reference energy, momentum, and time",
           "[bookkeeper]") {
     struct lattices lat = expand_bookkeeper();
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     // pc = sqrt(E^2 - m^2) with the electron rest energy ~0.511 MeV; every
     // element downstream carries the same species and (drifts don't change it)
@@ -101,13 +101,14 @@ TEST_CASE("Bookkeeper fills reference energy, momentum, and time",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
 TEST_CASE("Bookkeeper accumulates s_position from element lengths",
           "[bookkeeper]") {
     struct lattices lat = expand_bookkeeper();
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     // s_position is the upstream end of each element: 0, then the running sum of
     // the preceding element lengths (0, 2, 0.5, 1.5, 1).
@@ -122,12 +123,13 @@ TEST_CASE("Bookkeeper accumulates s_position from element lengths",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
 TEST_CASE("Bookkeeper derives the normalized multipole strength", "[bookkeeper]") {
     struct lattices lat = expand_bookkeeper();
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     // Kn1 = (q / P0) Bn1 = (charge * c_light / pc) * Bn1, with charge = -1 for
     // the electron, referenced to q1's upstream momentum.
@@ -143,13 +145,14 @@ TEST_CASE("Bookkeeper derives the normalized multipole strength", "[bookkeeper]"
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
 TEST_CASE("Bookkeeper caps each branch with a branch_end Placeholder",
           "[bookkeeper]") {
     struct lattices lat = expand_bookkeeper();
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     // The branch gains a trailing element named `branch_end` of kind Placeholder.
     YAMLNodeId be = find_by_key(t, "branch_end");
@@ -176,6 +179,7 @@ TEST_CASE("Bookkeeper caps each branch with a branch_end Placeholder",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -266,7 +270,7 @@ TEST_CASE("Bookkeeper derives RF voltage from gradient and active length",
     // Only the gradient is given; L_active defaults to the element length 0.4, so
     // voltage = gradient * L_active = 1e8 * 0.4 = 4e7. No inconsistency reported.
     struct lattices lat = expand_rf("                gradient: 1.0e8\n");
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close_rel(param_num(t, "cav", "RFP", "voltage"), 4.0e7));
     REQUIRE(close(param_num(t, "cav", "RFP", "gradient"), 1.0e8));
@@ -276,6 +280,7 @@ TEST_CASE("Bookkeeper derives RF voltage from gradient and active length",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -283,7 +288,7 @@ TEST_CASE("Bookkeeper derives RF gradient from voltage and active length",
           "[bookkeeper]") {
     // Only the voltage is given; gradient = voltage / L_active = 8e6 / 0.4 = 2e7.
     struct lattices lat = expand_rf("                voltage: 8.0e6\n");
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close_rel(param_num(t, "cav", "RFP", "gradient"), 2.0e7));
     REQUIRE(close(param_num(t, "cav", "RFP", "voltage"), 8.0e6));
@@ -293,6 +298,7 @@ TEST_CASE("Bookkeeper derives RF gradient from voltage and active length",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -302,7 +308,7 @@ TEST_CASE("Bookkeeper accepts consistent RF voltage and gradient",
     struct lattices lat =
         expand_rf("                gradient: 2.0e7\n"
                   "                voltage: 8.0e6\n");
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close(param_num(t, "cav", "RFP", "gradient"), 2.0e7));
     REQUIRE(close(param_num(t, "cav", "RFP", "voltage"), 8.0e6));
@@ -312,6 +318,7 @@ TEST_CASE("Bookkeeper accepts consistent RF voltage and gradient",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -329,6 +336,7 @@ TEST_CASE("Bookkeeper flags inconsistent RF voltage and gradient",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -339,7 +347,7 @@ TEST_CASE("Bookkeeper honors an explicit L_active for RF derivation",
     struct lattices lat =
         expand_rf("                gradient: 1.0e8\n"
                   "                L_active: 0.25\n");
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close_rel(param_num(t, "cav", "RFP", "voltage"), 2.5e7));
     REQUIRE_FALSE(any_problem_contains(lat, "inconsistent"));
@@ -348,13 +356,14 @@ TEST_CASE("Bookkeeper honors an explicit L_active for RF derivation",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
 TEST_CASE("Bookkeeper propagates floor coordinates through a bend",
           "[bookkeeper]") {
     struct lattices lat = expand_bookkeeper();
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     // Everything up to the bend lies along +Z at the origin, unrotated.
     REQUIRE(close(param_num(t, "b1", "FloorP", "z"), 2.5));
@@ -381,6 +390,7 @@ TEST_CASE("Bookkeeper propagates floor coordinates through a bend",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -390,7 +400,7 @@ TEST_CASE("Bookkeeper derives all bend strength forms from the angle",
     // every equivalent form: g_ref = angle/length = 0.1, radius_ref = 1/g_ref =
     // 10, and Bn0_ref = g_ref / factor (factor = -c/pc for the electron).
     struct lattices lat = expand_bookkeeper();
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close(param_num(t, "b1", "BendP", "angle_ref"), 0.15));
     REQUIRE(close(param_num(t, "b1", "BendP", "g_ref"), 0.1));
@@ -418,6 +428,7 @@ TEST_CASE("Bookkeeper derives all bend strength forms from the angle",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -427,7 +438,7 @@ TEST_CASE("Bookkeeper derives integrated and normalized multipole forms",
     // equivalent forms: the field (Bn1), its length integral (Bn1L = L*Bn1), the
     // normalized value (Kn1 = factor*Bn1), and the normalized integral (Kn1L).
     struct lattices lat = expand_bookkeeper();
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
     const double f = electron_factor();
 
     REQUIRE(close(param_num(t, "q1", "MagneticMultipoleP", "Bn1"), 1.2));
@@ -439,6 +450,7 @@ TEST_CASE("Bookkeeper derives integrated and normalized multipole forms",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -451,7 +463,7 @@ TEST_CASE("Bookkeeper derives the integrated electric multipole", "[bookkeeper]"
         "              length: 0.5\n"
         "              ElectricMultipoleP:\n"
         "                En2: 5.0\n"));
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close(param_num(t, "em", "ElectricMultipoleP", "En2"), 5.0));
     REQUIRE(close(param_num(t, "em", "ElectricMultipoleP", "En2L"), 2.5));
@@ -461,6 +473,7 @@ TEST_CASE("Bookkeeper derives the integrated electric multipole", "[bookkeeper]"
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -477,7 +490,7 @@ TEST_CASE("Bookkeeper derives the bend length from its angle and radius",
         "                radius_ref: 5.0\n"
         "          - after:\n"
         "              kind: Marker\n"));
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close(param_num(t, "bnd", nullptr, "length"), 1.0));
     // The derived length carries downstream: the marker sits at the far end.
@@ -495,6 +508,7 @@ TEST_CASE("Bookkeeper derives the bend length from its angle and radius",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -507,7 +521,7 @@ TEST_CASE("Bookkeeper derives the bend angle from its chord", "[bookkeeper]") {
         "              BendP:\n"
         "                g_ref: 0.25\n"
         "                L_chord: 1.9\n"));
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
     const double angle = 2.0 * std::asin(0.25 * 1.9 / 2.0);
 
     REQUIRE(close_rel(param_num(t, "bnd", "BendP", "angle_ref"), angle));
@@ -519,6 +533,7 @@ TEST_CASE("Bookkeeper derives the bend angle from its chord", "[bookkeeper]") {
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -532,7 +547,7 @@ TEST_CASE("Bookkeeper gives a straight bend three equal lengths",
         "              length: 0.8\n"
         "              BendP:\n"
         "                e1: 0.01\n"));
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close(param_num(t, "bnd", "BendP", "L_chord"), 0.8));
     REQUIRE(close(param_num(t, "bnd", "BendP", "L_rectangle"), 0.8));
@@ -543,6 +558,7 @@ TEST_CASE("Bookkeeper gives a straight bend three equal lengths",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -558,7 +574,7 @@ TEST_CASE("Bookkeeper keeps the sagitta of a nearly straight bend",
         "              length: 2.0\n"
         "              BendP:\n"
         "                g_ref: 1.0e-12\n"));
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close(param_num(t, "bnd", "BendP", "angle_ref"), 2.0e-12));
     REQUIRE(close(param_num(t, "bnd", "BendP", "L_chord"), 2.0));
@@ -569,6 +585,7 @@ TEST_CASE("Bookkeeper keeps the sagitta of a nearly straight bend",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -585,12 +602,13 @@ TEST_CASE("Bookkeeper flags a chord that disagrees with the bend geometry",
         "                L_chord: 1.8\n"));
 
     REQUIRE(any_problem_contains(lat, "'L_chord' is inconsistent"));
-    REQUIRE(close(param_num(lat.expanded, "bnd", "BendP", "L_chord"), 1.8));
+    REQUIRE(close(param_num(lat.full_expanded, "bnd", "BendP", "L_chord"), 1.8));
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -610,6 +628,7 @@ TEST_CASE("Bookkeeper flags an inconsistent bend strength", "[bookkeeper]") {
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -626,7 +645,7 @@ TEST_CASE("Bookkeeper defaults the bend actual field from g_ref",
         "              length: 2.0\n"
         "              BendP:\n"
         "                g_ref: 0.1\n"));
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0"), 0.1));
     REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0L"), 0.2));
@@ -644,6 +663,7 @@ TEST_CASE("Bookkeeper defaults the bend actual field from g_ref",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -658,7 +678,7 @@ TEST_CASE("Bookkeeper writes no actual field when Kn0_from_g_ref is false",
         "              BendP:\n"
         "                g_ref: 0.1\n"
         "                Kn0_from_g_ref: false\n"));
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(get_child_by_key(t, find_by_key(t, "bnd"),
                              "MagneticMultipoleP") == YAML_NULL_ID);
@@ -669,6 +689,7 @@ TEST_CASE("Bookkeeper writes no actual field when Kn0_from_g_ref is false",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -685,7 +706,7 @@ TEST_CASE("Bookkeeper keeps an actual bend field the author set",
         "                g_ref: 0.1\n"
         "              MagneticMultipoleP:\n"
         "                Kn0: 0.3\n"));
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0"), 0.3));
     REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0L"), 0.6));
@@ -696,6 +717,7 @@ TEST_CASE("Bookkeeper keeps an actual bend field the author set",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -712,7 +734,7 @@ TEST_CASE("Bookkeeper counts an integrated actual field as set",
         "                g_ref: 0.1\n"
         "              MagneticMultipoleP:\n"
         "                Kn0L: 0.6\n"));
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0"), 0.3));
     REQUIRE_FALSE(any_problem_contains(lat, "inconsistent"));
@@ -721,6 +743,7 @@ TEST_CASE("Bookkeeper counts an integrated actual field as set",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -736,7 +759,7 @@ TEST_CASE("Bookkeeper adds the actual field to a group of other multipoles",
         "                g_ref: 0.1\n"
         "              MagneticMultipoleP:\n"
         "                Kn1: 0.5\n"));
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn0"), 0.1));
     REQUIRE(close(param_num(t, "bnd", "MagneticMultipoleP", "Kn1"), 0.5));
@@ -745,6 +768,7 @@ TEST_CASE("Bookkeeper adds the actual field to a group of other multipoles",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -757,7 +781,7 @@ TEST_CASE("Bookkeeper gives a straight bend no actual field", "[bookkeeper]") {
         "              length: 2.0\n"
         "              BendP:\n"
         "                e1: 0.01\n"));
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     REQUIRE(get_child_by_key(t, find_by_key(t, "bnd"),
                              "MagneticMultipoleP") == YAML_NULL_ID);
@@ -766,6 +790,7 @@ TEST_CASE("Bookkeeper gives a straight bend no actual field", "[bookkeeper]") {
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -786,6 +811,7 @@ TEST_CASE("Bookkeeper flags an inconsistent multipole component",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -794,7 +820,7 @@ TEST_CASE("Bookkeeper materializes RF enum defaults and L_active",
     // A present RFP group gains its non-zero enum defaults and an explicit
     // L_active (= element length 0.4), alongside the derived voltage.
     struct lattices lat = expand_rf("                gradient: 1.0e8\n");
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
 
     YAMLNodeId rfp = get_child_by_key(t, find_by_key(t, "cav"), "RFP");
     REQUIRE(val_eq(t, get_child_by_key(t, rfp, "cavity_type"), "STANDING_WAVE"));
@@ -805,6 +831,7 @@ TEST_CASE("Bookkeeper materializes RF enum defaults and L_active",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -813,7 +840,7 @@ TEST_CASE("Bookkeeper leaves absent parameter groups alone", "[bookkeeper]") {
     // BendP/RFP/multipole groups. Only ReferenceP and FloorP are parser-added,
     // and MagneticMultipoleP on a curved bend, which has an actual field to hold.
     struct lattices lat = expand_bookkeeper();
-    YAMLTreeHandle t = lat.expanded;
+    YAMLTreeHandle t = lat.full_expanded;
     YAMLNodeId d1 = find_by_key(t, "d1");
 
     REQUIRE(get_child_by_key(t, d1, "BendP") == YAML_NULL_ID);
@@ -826,5 +853,6 @@ TEST_CASE("Bookkeeper leaves absent parameter groups alone", "[bookkeeper]") {
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }

--- a/tests/test_check.cpp
+++ b/tests/test_check.cpp
@@ -17,6 +17,7 @@ std::vector<std::string> problems_for(const char* path, const char* yaml) {
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
     return out;

--- a/tests/test_controllers.cpp
+++ b/tests/test_controllers.cpp
@@ -32,6 +32,7 @@ void free_all(struct lattices& lat) {
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -195,13 +196,13 @@ TEST_CASE("ABSOLUTE controllers drive the parameters they match",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
 
-    REQUIRE(close(expanded_param(lat.expanded, "Qa1", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "Qa1", "MagneticMultipoleP",
                                  "Kn1L"),
                   0.8));
-    REQUIRE(close(expanded_param(lat.expanded, "Qa2", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "Qa2", "MagneticMultipoleP",
                                  "Kn1L"),
                   0.8));
-    REQUIRE(close(expanded_param(lat.expanded, "Qb1", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "Qb1", "MagneticMultipoleP",
                                  "Kn1L"),
                   0.33));
 
@@ -241,7 +242,7 @@ TEST_CASE("several ABSOLUTE controllers on one parameter sum",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
 
-    REQUIRE(close(expanded_param(lat.expanded, "a_kicker", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "a_kicker", "MagneticMultipoleP",
                                  "Kn0"),
                   0.075 * std::sin(0.023) + 0.123 * 0.044));
 
@@ -273,7 +274,7 @@ TEST_CASE("an ABSOLUTE controller creates the parameter it drives",
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
-    REQUIRE(close(expanded_param(lat.expanded, "a_kicker", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "a_kicker", "MagneticMultipoleP",
                                  "Kn0L"),
                   0.25));
 
@@ -309,8 +310,8 @@ TEST_CASE("a driven parameter feeds the dependent-parameter bookkeeping",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
 
-    double b1 = expanded_param(lat.expanded, "Q1", "MagneticMultipoleP", "Bn1L");
-    double b2 = expanded_param(lat.expanded, "Q2", "MagneticMultipoleP", "Bn1L");
+    double b1 = expanded_param(lat.full_expanded, "Q1", "MagneticMultipoleP", "Bn1L");
+    double b2 = expanded_param(lat.full_expanded, "Q2", "MagneticMultipoleP", "Bn1L");
     REQUIRE(b1 != 0.0);
     REQUIRE(close_rel(b1, b2));
 
@@ -342,7 +343,7 @@ TEST_CASE("a RELATIVE controller leaves the lattice alone",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
 
-    REQUIRE(close(expanded_param(lat.expanded, "S1", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "S1", "MagneticMultipoleP",
                                  "Kn2L"),
                   0.33));
 
@@ -389,7 +390,7 @@ TEST_CASE("a controller drives another controller's variable",
     REQUIRE(joined(lat) == "");
 
     // low>cur becomes 3/4, so Q1's Kn1L is 10 * 0.75.
-    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "Q1", "MagneticMultipoleP",
                                  "Kn1L"),
                   7.5));
     YAMLNodeId low = facility_param(lat.leftover, "low");
@@ -420,7 +421,7 @@ TEST_CASE("a variable with no value defaults to zero",
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
-    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "Q1", "MagneticMultipoleP",
                                  "Kn1L"),
                   5.0));
 
@@ -460,7 +461,7 @@ TEST_CASE("controller expressions may not reach outside their controller",
     REQUIRE(any_contains(msgs, "control expression may not reference"));
 
     // Q1 keeps its own value: the rejected entry drives nothing.
-    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "Q1", "MagneticMultipoleP",
                                  "Kn1L"),
                   0.0));
 
@@ -495,7 +496,7 @@ TEST_CASE("a variable initial value may not reference a variable",
 
     // The rejected initial value falls back to the default, zero, so the
     // control expression is still evaluated: cur1 + 0.
-    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "Q1", "MagneticMultipoleP",
                                  "Kn1L"),
                   0.023));
 
@@ -524,7 +525,7 @@ TEST_CASE("a constant is not mistaken for a variable in an initial value",
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
-    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "Q1", "MagneticMultipoleP",
                                  "Kn1L"),
                   2.0 * (1e8 / 2.99792458e8)));
 
@@ -587,7 +588,7 @@ TEST_CASE("a parameter may not be driven by both controller types",
                          "Q1>MagneticMultipoleP.Kn1L is controlled by both an "
                          "ABSOLUTE and a RELATIVE controller"));
     // Neither is applied, so the element keeps its own value.
-    REQUIRE(close(expanded_param(lat.expanded, "Q1", "MagneticMultipoleP",
+    REQUIRE(close(expanded_param(lat.full_expanded, "Q1", "MagneticMultipoleP",
                                  "Kn1L"),
                   0.11));
 
@@ -681,7 +682,7 @@ TEST_CASE("a controller reaches an element in a branch named by its key",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE_FALSE(any_contains(problem_list(lat), "matches nothing"));
     REQUIRE(joined(lat).find("branch 'ln'") == std::string::npos);
-    REQUIRE(close(expanded_param(lat.expanded, "q", "MagneticMultipoleP", "Kn1"),
+    REQUIRE(close(expanded_param(lat.full_expanded, "q", "MagneticMultipoleP", "Kn1"),
                   16.0));
 
     free_all(lat);

--- a/tests/test_correspondence.cpp
+++ b/tests/test_correspondence.cpp
@@ -14,7 +14,7 @@ TEST_CASE("build_correspondence_map is empty for null handles", "[correspondence
 TEST_CASE("build_correspondence_map links the document roots", "[correspondence]") {
     struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", nullptr);
     struct correspondence_map m =
-        build_correspondence_map(lat.original, lat.combined, lat.expanded,
+        build_correspondence_map(lat.original, lat.combined, lat.full_expanded,
                                  lat.leftover);
 
     REQUIRE(m.count > 0);
@@ -36,7 +36,7 @@ TEST_CASE("build_correspondence_map links the document roots", "[correspondence]
             REQUIRE(is_map(lat.original, m.links[i].original));
         }
         // A link names a node in exactly one of the two derived trees.
-        REQUIRE((m.links[i].expanded == YAML_NULL_ID) !=
+        REQUIRE((m.links[i].full_expanded == YAML_NULL_ID) !=
                 (m.links[i].leftover == YAML_NULL_ID));
     }
     REQUIRE(found_root);
@@ -45,6 +45,7 @@ TEST_CASE("build_correspondence_map links the document roots", "[correspondence]
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -55,7 +56,7 @@ TEST_CASE("build_correspondence_map ties the two trees through combined",
           "[correspondence]") {
     struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", "lat1");
     struct correspondence_map m =
-        build_correspondence_map(lat.original, lat.combined, lat.expanded,
+        build_correspondence_map(lat.original, lat.combined, lat.full_expanded,
                                  lat.leftover);
 
     // inj_line is defined at facility level and used by lat1's branches, so it
@@ -64,7 +65,7 @@ TEST_CASE("build_correspondence_map ties the two trees through combined",
     for (size_t i = 0; i < m.count; i++) {
         if (m.links[i].combined == YAML_NULL_ID) continue;
         sides[m.links[i].combined] |=
-            (m.links[i].expanded != YAML_NULL_ID) ? 1 : 2;
+            (m.links[i].full_expanded != YAML_NULL_ID) ? 1 : 2;
     }
 
     bool found_both = false;
@@ -76,6 +77,7 @@ TEST_CASE("build_correspondence_map ties the two trees through combined",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     free_lattice_problems(lat.problems);
 }
@@ -106,7 +108,7 @@ TEST_CASE("build_correspondence_map connects a node across trees by value",
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     struct correspondence_map m =
-        build_correspondence_map(lat.original, lat.combined, lat.expanded,
+        build_correspondence_map(lat.original, lat.combined, lat.full_expanded,
                                  lat.leftover);
 
     // Locate a_const in the leftover tree: facility[0] -> constants -> a_const.
@@ -135,7 +137,7 @@ TEST_CASE("build_correspondence_map connects a node across trees by value",
     for (size_t i = 0; i < m.count; i++) {
         if (m.links[i].leftover != l_a_const) continue;
         found = true;
-        REQUIRE(m.links[i].expanded == YAML_NULL_ID);
+        REQUIRE(m.links[i].full_expanded == YAML_NULL_ID);
         REQUIRE(m.links[i].combined != YAML_NULL_ID);
         REQUIRE(m.links[i].original != YAML_NULL_ID);
         REQUIRE(val_eq(lat.combined, m.links[i].combined, "0.3 * r_electron"));
@@ -147,6 +149,7 @@ TEST_CASE("build_correspondence_map connects a node across trees by value",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -179,7 +182,7 @@ TEST_CASE("build_correspondence_map maps one source to many expanded copies",
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     struct correspondence_map m =
-        build_correspondence_map(lat.original, lat.combined, lat.expanded,
+        build_correspondence_map(lat.original, lat.combined, lat.full_expanded,
                                  lat.leftover);
 
     // Unrolling `repeat: 3` over a one-element cell produces three keyless `d1`
@@ -189,9 +192,9 @@ TEST_CASE("build_correspondence_map maps one source to many expanded copies",
     std::map<YAMLNodeId, int> combined_hits;
     for (size_t i = 0; i < m.count; i++) {
         // Skip the leftover half of the map: those ids index a different tree.
-        if (m.links[i].expanded == YAML_NULL_ID) continue;
-        if (!is_scalar(lat.expanded, m.links[i].expanded)) continue;
-        if (!val_eq(lat.expanded, m.links[i].expanded, "d1")) continue;
+        if (m.links[i].full_expanded == YAML_NULL_ID) continue;
+        if (!is_scalar(lat.full_expanded, m.links[i].full_expanded)) continue;
+        if (!val_eq(lat.full_expanded, m.links[i].full_expanded, "d1")) continue;
         REQUIRE(m.links[i].combined != YAML_NULL_ID);  // has a source
         combined_hits[m.links[i].combined]++;
     }
@@ -203,6 +206,7 @@ TEST_CASE("build_correspondence_map maps one source to many expanded copies",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }

--- a/tests/test_expanded_minus_dependent.cpp
+++ b/tests/test_expanded_minus_dependent.cpp
@@ -1,0 +1,457 @@
+#include "test_helpers.h"
+
+// ============================================================
+// THE `expanded` TREE: full_expanded MINUS THE COMPUTED PARAMETERS
+// ============================================================
+//
+// parse_and_expand_PALS returns the expanded lattice twice. `full_expanded` is
+// what the bookkeeper leaves behind, every dependent parameter computed;
+// `expanded` is the same lattice pruned back to the author's inputs. These tests
+// pin the boundary between the two — which is decided by what the lattice held
+// at the moment before run_element_bookkeeper first ran, plus whatever a
+// post-`expand_lattice` `set` wrote afterwards.
+
+namespace {
+
+// A branch exercising each way a parameter can arrive:
+//   begin  — an authored ReferenceP, which the bookkeeper then completes
+//   q1     — one authored member of a multipole family, the rest derived
+//   rf1    — an authored RFP gradient, plus defaults the bookkeeper materializes
+//   mark   — an element with nothing but its kind
+const char* SPLIT_YAML =
+    "PALS:\n"
+    "  facility:\n"
+    "    - lat1:\n"
+    "        kind: Lattice\n"
+    "        branches:\n"
+    "          - main:\n"
+    "              kind: BeamLine\n"
+    "              line:\n"
+    "                - begin:\n"
+    "                    kind: BeginningEle\n"
+    "                    ReferenceP:\n"
+    "                      species_ref: \"electron\"\n"
+    "                      pc_ref: 1.0e9\n"
+    "                - q1:\n"
+    "                    kind: Quadrupole\n"
+    "                    length: 0.5\n"
+    "                    MagneticMultipoleP:\n"
+    "                      Kn1: 0.3\n"
+    "                - rf1:\n"
+    "                    kind: RFCavity\n"
+    "                    length: 1.0\n"
+    "                    RFP:\n"
+    "                      gradient: 1.0e6\n"
+    "                - mark:\n"
+    "                    kind: Marker\n"
+    "    - use: lat1\n";
+
+// The same lattice with an `expand_lattice` statement and a `set` after it, so
+// the set lands on the expanded copy — after the first bookkeeper pass has
+// already run. `Kn2L` is written; `Kn2` is what the second pass derives from it.
+const char* POST_SET_YAML =
+    "PALS:\n"
+    "  facility:\n"
+    "    - lat1:\n"
+    "        kind: Lattice\n"
+    "        branches:\n"
+    "          - main:\n"
+    "              kind: BeamLine\n"
+    "              line:\n"
+    "                - begin:\n"
+    "                    kind: BeginningEle\n"
+    "                    ReferenceP:\n"
+    "                      species_ref: \"electron\"\n"
+    "                      pc_ref: 1.0e9\n"
+    "                - q1:\n"
+    "                    kind: Quadrupole\n"
+    "                    length: 0.5\n"
+    "                    MagneticMultipoleP:\n"
+    "                      Kn1: 0.3\n"
+    "    - expand_lattice\n"
+    "    - set:\n"
+    "        parameter: \"q1>MagneticMultipoleP.Kn2L\"\n"
+    "        value: 0.75\n"
+    "    - use: lat1\n";
+
+// A fork whose destination resolves, so link_fork_connections has somewhere to
+// write: it names the destination on the Fork (`forked_to`) and hangs a
+// `ForkFromP` back-reference on the destination element. Both run after the
+// bookkeeper. `propagate_reference` is deliberately left unwritten here so it
+// arrives as a materialized default.
+const char* FORK_YAML =
+    "PALS:\n"
+    "  facility:\n"
+    "    - dump_begin:\n"
+    "        kind: BeginningEle\n"
+    "    - amarker:\n"
+    "        kind: Marker\n"
+    "    - generic_dump:\n"
+    "        kind: BeamLine\n"
+    "        line:\n"
+    "          - dump_begin\n"
+    "          - amarker\n"
+    "    - lat1:\n"
+    "        kind: Lattice\n"
+    "        branches:\n"
+    "          - main:\n"
+    "              kind: BeamLine\n"
+    "              line:\n"
+    "                - begin:\n"
+    "                    kind: BeginningEle\n"
+    "                    ReferenceP:\n"
+    "                      species_ref: \"electron\"\n"
+    "                      pc_ref: 1.0e9\n"
+    "                - to_dump:\n"
+    "                    kind: Fork\n"
+    "                    ForkP:\n"
+    "                      to_line: generic_dump\n"
+    "                      destination_element: dump_begin\n"
+    "                      new_branch: this_dump\n"
+    "    - use: lat1\n";
+
+// A controller driving a parameter the author already wrote, plus an
+// `expand_lattice` and a `set` after it. Between them these are every way a
+// value can be rewritten after it was first written: `Kn1L` is authored as 0.33,
+// driven to 0.8 by the ABSOLUTE controller, and `length` is then overwritten by
+// the post-expansion set.
+const char* REWRITTEN_YAML =
+    "PALS:\n"
+    "  facility:\n"
+    "    - ps27:\n"
+    "        kind: Controller\n"
+    "        controls:\n"
+    "          - parameter: Qa.*>MagneticMultipoleP.Kn1L\n"
+    "            expression: 0.8\n"
+    "    - lat1:\n"
+    "        kind: Lattice\n"
+    "        branches:\n"
+    "          - main:\n"
+    "              kind: BeamLine\n"
+    "              line:\n"
+    "                - begin:\n"
+    "                    kind: BeginningEle\n"
+    "                    ReferenceP:\n"
+    "                      species_ref: \"electron\"\n"
+    "                      E_tot_ref: 1.0e9\n"
+    "                - Qa1:\n"
+    "                    kind: Quadrupole\n"
+    "                    length: 0.5\n"
+    "                    MagneticMultipoleP:\n"
+    "                      Kn1L: 0.33\n"
+    "    - expand_lattice\n"
+    "    - set:\n"
+    "        parameter: \"Qa1>length\"\n"
+    "        value: 0.75\n"
+    "    - use: lat1\n";
+
+// Expand a YAML string from a temp file (the only expansion entry point takes a
+// filename). The caller frees the returned trees and problem list.
+struct lattices expand_string(const char* yaml, const char* path) {
+    write_tmp(path, yaml);
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    rm_tmp(path);
+    return lat;
+}
+
+void free_all(struct lattices& lat) {
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
+    delete_tree(lat.leftover);
+}
+
+// True when `ele` in `t` carries `group`, and `group` carries `param`. A null
+// `group` looks the parameter up directly on the element.
+bool has_param(YAMLTreeHandle t, const char* ele, const char* group,
+               const char* param) {
+    YAMLNodeId e = find_by_key(t, ele);
+    if (e == YAML_NULL_ID) return false;
+    YAMLNodeId g = group ? get_child_by_key(t, e, group) : e;
+    if (g == YAML_NULL_ID) return false;
+    return get_child_by_key(t, g, param) != YAML_NULL_ID;
+}
+
+// Walk `expanded` and `full_expanded` in step and check that every scalar the
+// two share holds the same text. Maps are matched by key and sequences by
+// index: pruning only ever drops a keyed entry or trims the tail of a line, so
+// a node that survives is still where it was. `compared` counts the scalars
+// actually checked, which is what keeps the walk from passing vacuously.
+void require_same_values(YAMLTreeHandle a, YAMLNodeId na, YAMLTreeHandle b,
+                         YAMLNodeId nb, const std::string& path,
+                         size_t& compared) {
+    if (na == YAML_NULL_ID || nb == YAML_NULL_ID) return;
+
+    // `is_scalar` is ryml's is_val(), which holds only for a sequence entry --
+    // every element parameter is a keyval and reports false. A node that is
+    // neither a map nor a sequence carries a value, whether or not it has a key.
+    if (!is_map(a, na) && !is_sequence(a, na)) {
+        // A pruned tree must never hold a *different* value from the bookkept
+        // one -- sets and controllers are applied to both, because both are cut
+        // from the same finished tree.
+        if (is_map(b, nb) || is_sequence(b, nb)) return;
+        char* va = as_string(a, na);
+        char* vb = as_string(b, nb);
+        std::string sa(va ? va : ""), sb(vb ? vb : "");
+        yaml_free_string(va);
+        yaml_free_string(vb);
+        INFO("at " << path);
+        REQUIRE(sa == sb);
+        ++compared;
+        return;
+    }
+
+    if (is_map(a, na)) {
+        for (size_t i = 0; i < get_size(a, na); ++i) {
+            YAMLNodeId ca = get_child_by_index(a, na, i);
+            char* k = get_node_key(a, ca);
+            if (!k) continue;
+            std::string key(k);
+            yaml_free_string(k);
+            require_same_values(a, ca, b, get_child_by_key(b, nb, key.c_str()),
+                                path + "/" + key, compared);
+        }
+        return;
+    }
+
+    if (is_sequence(a, na)) {
+        for (size_t i = 0; i < get_size(a, na) && i < get_size(b, nb); ++i)
+            require_same_values(a, get_child_by_index(a, na, i), b,
+                                get_child_by_index(b, nb, i),
+                                path + "/" + std::to_string(i), compared);
+    }
+}
+
+// The `line` sequence of the first branch of the lattice held by `t`.
+YAMLNodeId first_line(YAMLTreeHandle t) {
+    YAMLNodeId lat1 = get_child_by_index(t, get_root(t), 0);
+    YAMLNodeId branches = get_child_by_key(t, lat1, "branches");
+    YAMLNodeId branch = get_child_by_index(t, get_child_by_index(t, branches, 0), 0);
+    return get_child_by_key(t, branch, "line");
+}
+
+}  // namespace
+
+TEST_CASE("expanded drops the parameters the bookkeeper computed",
+          "[expanded]") {
+    struct lattices lat = expand_string(SPLIT_YAML, "tmp_split.pals.yaml");
+
+    // Reference, floor and s-position are computed for every element; none of
+    // them survives, and on an element that authored nothing they leave no
+    // trace at all.
+    for (const char* ele : {"q1", "rf1", "mark"}) {
+        REQUIRE(find_by_key(lat.expanded, ele) != YAML_NULL_ID);
+        REQUIRE(has_param(lat.full_expanded, ele, "ReferenceP", "pc_ref"));
+        REQUIRE_FALSE(has_param(lat.expanded, ele, nullptr, "ReferenceP"));
+        REQUIRE_FALSE(has_param(lat.expanded, ele, nullptr, "FloorP"));
+        REQUIRE_FALSE(has_param(lat.expanded, ele, nullptr, "s_position"));
+    }
+
+    // The authored member of a multipole family stays; the three derived from
+    // it go. The group itself stays, because the author wrote it.
+    REQUIRE(has_param(lat.expanded, "q1", "MagneticMultipoleP", "Kn1"));
+    for (const char* p : {"Kn1L", "Bn1", "Bn1L"}) {
+        REQUIRE(has_param(lat.full_expanded, "q1", "MagneticMultipoleP", p));
+        REQUIRE_FALSE(has_param(lat.expanded, "q1", "MagneticMultipoleP", p));
+    }
+
+    // Ungrouped parameters the author wrote are untouched.
+    REQUIRE(has_param(lat.expanded, "q1", nullptr, "length"));
+    REQUIRE(has_param(lat.expanded, "q1", nullptr, "kind"));
+
+    free_all(lat);
+}
+
+TEST_CASE("expanded keeps an authored group but not what completes it",
+          "[expanded]") {
+    struct lattices lat = expand_string(SPLIT_YAML, "tmp_split.pals.yaml");
+
+    // The author wrote ReferenceP on the BeginningEle, so it survives -- with
+    // only the two members that were written. `E_tot_ref` and `time_ref` are
+    // the bookkeeper completing it, and go. This is the case a "what did the
+    // bookkeeper write" list gets wrong: set_num_child overwrites `pc_ref` in
+    // place rather than creating it.
+    REQUIRE(has_param(lat.expanded, "begin", nullptr, "ReferenceP"));
+    REQUIRE(has_param(lat.expanded, "begin", "ReferenceP", "species_ref"));
+    REQUIRE(has_param(lat.expanded, "begin", "ReferenceP", "pc_ref"));
+    REQUIRE(has_param(lat.full_expanded, "begin", "ReferenceP", "E_tot_ref"));
+    REQUIRE_FALSE(has_param(lat.expanded, "begin", "ReferenceP", "E_tot_ref"));
+    REQUIRE_FALSE(has_param(lat.expanded, "begin", "ReferenceP", "time_ref"));
+
+    // Which parameters are held is decided by what the author wrote; the value
+    // held is the finished one. Here they coincide -- the bookkeeper rewrote
+    // `pc_ref` in place with a value equal to the input.
+    YAMLNodeId begin = find_by_key(lat.expanded, "begin");
+    YAMLNodeId rp = get_child_by_key(lat.expanded, begin, "ReferenceP");
+    REQUIRE(close_rel(num_val(lat.expanded, get_child_by_key(lat.expanded, rp,
+                                                             "pc_ref")),
+                      1.0e9));
+
+    free_all(lat);
+}
+
+TEST_CASE("expanded drops materialized group defaults", "[expanded]") {
+    struct lattices lat = expand_string(SPLIT_YAML, "tmp_split.pals.yaml");
+
+    // RFP is authored, so it stays -- holding the gradient and nothing else.
+    // `cavity_type` and `zero_phase` are non-zero defaults the bookkeeper fills
+    // in, `L_active` defaults to the element length, and `voltage` is derived
+    // from the gradient.
+    REQUIRE(has_param(lat.expanded, "rf1", "RFP", "gradient"));
+    for (const char* p : {"cavity_type", "zero_phase", "L_active", "voltage"}) {
+        REQUIRE(has_param(lat.full_expanded, "rf1", "RFP", p));
+        REQUIRE_FALSE(has_param(lat.expanded, "rf1", "RFP", p));
+    }
+
+    free_all(lat);
+}
+
+TEST_CASE("expanded drops the branch_end the bookkeeper appends", "[expanded]") {
+    struct lattices lat = expand_string(SPLIT_YAML, "tmp_split.pals.yaml");
+
+    // The Placeholder capping the branch exists only to carry the branch's
+    // final reference and floor, so it has no reason to appear at all -- the
+    // line is left one element shorter than the bookkept one.
+    REQUIRE(find_by_key(lat.full_expanded, "branch_end") != YAML_NULL_ID);
+    REQUIRE(find_by_key(lat.expanded, "branch_end") == YAML_NULL_ID);
+
+    REQUIRE(get_size(lat.expanded, first_line(lat.expanded)) == 4);
+    REQUIRE(get_size(lat.full_expanded, first_line(lat.full_expanded)) == 5);
+
+    free_all(lat);
+}
+
+TEST_CASE("expanded keeps what a post-expand_lattice set wrote", "[expanded]") {
+    struct lattices lat = expand_string(POST_SET_YAML, "tmp_post_set.pals.yaml");
+
+    // The set runs after the first bookkeeper pass, so it lands after the point
+    // the authored parameters were recorded. Its write is an input all the same
+    // and is held; `Kn2`, which the second pass derives from it, is not.
+    REQUIRE(has_param(lat.expanded, "q1", "MagneticMultipoleP", "Kn2L"));
+    REQUIRE(has_param(lat.full_expanded, "q1", "MagneticMultipoleP", "Kn2"));
+    REQUIRE_FALSE(has_param(lat.expanded, "q1", "MagneticMultipoleP", "Kn2"));
+
+    YAMLNodeId q1 = find_by_key(lat.expanded, "q1");
+    YAMLNodeId mp = get_child_by_key(lat.expanded, q1, "MagneticMultipoleP");
+    REQUIRE(close(
+        num_val(lat.expanded, get_child_by_key(lat.expanded, mp, "Kn2L")), 0.75));
+
+    // The set invalidates the rest of the family, which the second bookkeeper
+    // pass then rebuilds -- rebuilt values are computed, so none of them stays.
+    // `Kn1`, written by the author and untouched by the set, does.
+    REQUIRE(has_param(lat.expanded, "q1", "MagneticMultipoleP", "Kn1"));
+    REQUIRE_FALSE(has_param(lat.expanded, "q1", "MagneticMultipoleP", "Kn1L"));
+
+    free_all(lat);
+}
+
+TEST_CASE("expanded drops the fork wiring but keeps the fork's own inputs",
+          "[expanded]") {
+    struct lattices lat = expand_string(FORK_YAML, "tmp_fork.pals.yaml");
+
+    // What the author wrote on the Fork stays.
+    for (const char* p : {"to_line", "destination_element", "new_branch"}) {
+        REQUIRE(has_param(lat.expanded, "to_dump", "ForkP", p));
+    }
+
+    // `destination_pointer` is synthesised while the lattice is expanded, before
+    // the bookkeeper, so it survives -- and it is still the id of the
+    // destination element in this tree, which pruning must not have disturbed
+    // (ryml keeps the ids of the nodes it does not remove).
+    YAMLNodeId fork = find_by_key(lat.expanded, "to_dump");
+    YAMLNodeId fp = get_child_by_key(lat.expanded, fork, "ForkP");
+    YAMLNodeId ptr = get_child_by_key(lat.expanded, fp, "destination_pointer");
+    REQUIRE(ptr != YAML_NULL_ID);
+    char* s = as_string(lat.expanded, ptr);
+    REQUIRE(s != nullptr);
+    YAMLNodeId dest = (YAMLNodeId)std::strtoull(s, nullptr, 10);
+    yaml_free_string(s);
+    REQUIRE(key_eq(lat.expanded, dest, "dump_begin"));
+
+    // `propagate_reference` is not written here, so it arrives as a materialized
+    // default and goes -- unlike a lattice that writes it, where it stays.
+    REQUIRE(has_param(lat.full_expanded, "to_dump", "ForkP",
+                      "propagate_reference"));
+    REQUIRE_FALSE(has_param(lat.expanded, "to_dump", "ForkP",
+                            "propagate_reference"));
+
+    // link_fork_connections runs after the bookkeeper, so what it records is
+    // computed too: the name it puts on the Fork and the back-reference it
+    // hangs on the destination.
+    REQUIRE(has_param(lat.full_expanded, "to_dump", "ForkP", "forked_to"));
+    REQUIRE_FALSE(has_param(lat.expanded, "to_dump", "ForkP", "forked_to"));
+    REQUIRE(has_param(lat.full_expanded, "dump_begin", nullptr, "ForkFromP"));
+    REQUIRE_FALSE(has_param(lat.expanded, "dump_begin", nullptr, "ForkFromP"));
+
+    // The forked branch itself is a structural result of expansion and stays,
+    // with its elements.
+    REQUIRE(find_by_key(lat.expanded, "this_dump") != YAML_NULL_ID);
+    REQUIRE(find_by_key(lat.expanded, "amarker") != YAML_NULL_ID);
+
+    free_all(lat);
+}
+
+TEST_CASE("a parameter in both trees holds the same value in both",
+          "[expanded]") {
+    // The whole invariant, checked wholesale: `expanded` is a pruned copy of the
+    // finished lattice, not a snapshot of an earlier one, so a parameter that
+    // survives pruning carries the value the lattice ended up with.
+    struct {
+        const char* yaml;
+        const char* path;
+    } cases[] = {
+        {SPLIT_YAML, "tmp_same_split.pals.yaml"},
+        {POST_SET_YAML, "tmp_same_post.pals.yaml"},
+        {FORK_YAML, "tmp_same_fork.pals.yaml"},
+        {REWRITTEN_YAML, "tmp_same_rewritten.pals.yaml"},
+    };
+
+    for (const auto& c : cases) {
+        struct lattices lat = expand_string(c.yaml, c.path);
+        size_t compared = 0;
+        require_same_values(lat.expanded, get_root(lat.expanded),
+                            lat.full_expanded, get_root(lat.full_expanded), "",
+                            compared);
+        REQUIRE(compared > 5);  // not vacuous
+        free_all(lat);
+    }
+}
+
+TEST_CASE("expanded carries the value a controller drove, not the authored one",
+          "[expanded]") {
+    struct lattices lat =
+        expand_string(REWRITTEN_YAML, "tmp_rewritten.pals.yaml");
+
+    // The ABSOLUTE controller overwrites the authored Kn1L (0.33) with 0.8. The
+    // parameter is the author's -- it is held -- but the value is the driven
+    // one, matching full_expanded.
+    REQUIRE(has_param(lat.expanded, "Qa1", "MagneticMultipoleP", "Kn1L"));
+    YAMLNodeId q = find_by_key(lat.expanded, "Qa1");
+    YAMLNodeId mp = get_child_by_key(lat.expanded, q, "MagneticMultipoleP");
+    REQUIRE(close(
+        num_val(lat.expanded, get_child_by_key(lat.expanded, mp, "Kn1L")), 0.8));
+
+    // Likewise the post-expand_lattice set overwrites the authored length.
+    REQUIRE(close(
+        num_val(lat.expanded,
+                get_child_by_key(lat.expanded, q, "length")),
+        0.75));
+
+    free_all(lat);
+}
+
+TEST_CASE("expanded and full_expanded are independent trees", "[expanded]") {
+    struct lattices lat = expand_string(SPLIT_YAML, "tmp_split.pals.yaml");
+
+    // Both are cut from the same work tree rather than one from the other, so
+    // releasing one must leave the other intact.
+    delete_tree(lat.expanded);
+    lat.expanded = nullptr;
+
+    REQUIRE(has_param(lat.full_expanded, "q1", "MagneticMultipoleP", "Kn1L"));
+    REQUIRE(find_by_key(lat.full_expanded, "branch_end") != YAML_NULL_ID);
+
+    free_all(lat);
+}

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -8,11 +8,12 @@ TEST_CASE("parse_and_expand_PALS returns four non-null handles", "[lattices]") {
     struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", nullptr);
     REQUIRE(lat.original != nullptr);
     REQUIRE(lat.combined != nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
     REQUIRE(lat.leftover != nullptr);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -20,22 +21,23 @@ TEST_CASE("parse_and_expand_PALS returns four non-null handles", "[lattices]") {
 // wrapper, and only the one entry.
 TEST_CASE("expanded holds only the root lattice", "[lattices]") {
     struct lattices lat = parse_and_expand_PALS("../lattice_files/ex.pals.yaml", "lat1");
-    YAMLNodeId root = get_root(lat.expanded);
+    YAMLNodeId root = get_root(lat.full_expanded);
 
-    REQUIRE(is_map(lat.expanded, root));
-    REQUIRE(get_size(lat.expanded, root) == 1);
-    REQUIRE(get_child_by_key(lat.expanded, root, "PALS") == YAML_NULL_ID);
+    REQUIRE(is_map(lat.full_expanded, root));
+    REQUIRE(get_size(lat.full_expanded, root) == 1);
+    REQUIRE(get_child_by_key(lat.full_expanded, root, "PALS") == YAML_NULL_ID);
 
-    YAMLNodeId entry = get_child_by_index(lat.expanded, root, 0);
-    char* key = get_node_key(lat.expanded, entry);
+    YAMLNodeId entry = get_child_by_index(lat.full_expanded, root, 0);
+    char* key = get_node_key(lat.full_expanded, entry);
     REQUIRE(std::string(key) == "lat1");
     yaml_free_string(key);
-    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, entry, "kind"),
+    REQUIRE(val_eq(lat.full_expanded, get_child_by_key(lat.full_expanded, entry, "kind"),
                    "Lattice"));
 
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     free_lattice_problems(lat.problems);
 }
@@ -67,6 +69,7 @@ TEST_CASE("leftover keeps the rest of the document", "[lattices]") {
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     free_lattice_problems(lat.problems);
 }
@@ -79,30 +82,31 @@ TEST_CASE("destination_pointer resolves inside the expanded tree", "[lattices]")
 
     // Find the destination_pointer scalar anywhere in the expanded tree.
     YAMLNodeId fp = YAML_NULL_ID;
-    std::vector<YAMLNodeId> stack{get_root(lat.expanded)};
+    std::vector<YAMLNodeId> stack{get_root(lat.full_expanded)};
     while (!stack.empty()) {
         YAMLNodeId n = stack.back();
         stack.pop_back();
-        char* key = get_node_key(lat.expanded, n);
+        char* key = get_node_key(lat.full_expanded, n);
         if (key && std::string(key) == "destination_pointer") fp = n;
         yaml_free_string(key);
-        for (size_t i = 0; i < get_size(lat.expanded, n); i++)
-            stack.push_back(get_child_by_index(lat.expanded, n, i));
+        for (size_t i = 0; i < get_size(lat.full_expanded, n); i++)
+            stack.push_back(get_child_by_index(lat.full_expanded, n, i));
     }
     REQUIRE(fp != YAML_NULL_ID);
 
-    char* val = as_string(lat.expanded, fp);
+    char* val = as_string(lat.full_expanded, fp);
     YAMLNodeId target = (YAMLNodeId)std::stoull(val);
     yaml_free_string(val);
 
     // It names the fork's destination_element in the branch expansion created.
-    char* dest = as_string(lat.expanded, target);
+    char* dest = as_string(lat.full_expanded, target);
     REQUIRE(std::string(dest) == "dump_begin");
     yaml_free_string(dest);
 
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     free_lattice_problems(lat.problems);
 }
@@ -154,33 +158,33 @@ TEST_CASE("Expansion drops `kind: BeamLine` from every branch", "[lattices]") {
               "    - use: lat1\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
-    YAMLNodeId lat1 = get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
-    YAMLNodeId branches = get_child_by_key(lat.expanded, lat1, "branches");
-    REQUIRE(get_size(lat.expanded, branches) == 3);
+    YAMLNodeId lat1 = get_child_by_index(lat.full_expanded, get_root(lat.full_expanded), 0);
+    YAMLNodeId branches = get_child_by_key(lat.full_expanded, lat1, "branches");
+    REQUIRE(get_size(lat.full_expanded, branches) == 3);
 
     // The lattice itself is not a branch and keeps its kind.
-    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, lat1, "kind"),
+    REQUIRE(val_eq(lat.full_expanded, get_child_by_key(lat.full_expanded, lat1, "kind"),
                    "Lattice"));
 
     const char* names[] = {"main", "alt", "to_dump"};
     for (size_t i = 0; i < 3; i++) {
         YAMLNodeId branch = get_child_by_index(
-            lat.expanded, get_child_by_index(lat.expanded, branches, i), 0);
-        REQUIRE(key_eq(lat.expanded, branch, names[i]));
-        REQUIRE(get_child_by_key(lat.expanded, branch, "kind") == YAML_NULL_ID);
-        REQUIRE(get_child_by_key(lat.expanded, branch, "line") != YAML_NULL_ID);
+            lat.full_expanded, get_child_by_index(lat.full_expanded, branches, i), 0);
+        REQUIRE(key_eq(lat.full_expanded, branch, names[i]));
+        REQUIRE(get_child_by_key(lat.full_expanded, branch, "kind") == YAML_NULL_ID);
+        REQUIRE(get_child_by_key(lat.full_expanded, branch, "line") != YAML_NULL_ID);
     }
 
     // A branch keeps the components that are its own. `periodic: true` also
     // survives the merge of `ring`'s `periodic: false`, as the branch setting
     // overrides the root BeamLine's.
     YAMLNodeId alt = get_child_by_index(
-        lat.expanded, get_child_by_index(lat.expanded, branches, 1), 0);
-    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, alt, "inherit"),
+        lat.full_expanded, get_child_by_index(lat.full_expanded, branches, 1), 0);
+    REQUIRE(val_eq(lat.full_expanded, get_child_by_key(lat.full_expanded, alt, "inherit"),
                    "ring"));
-    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, alt, "periodic"),
+    REQUIRE(val_eq(lat.full_expanded, get_child_by_key(lat.full_expanded, alt, "periodic"),
                    "true"));
 
     // `sub` sits inside a `line:`, so it is a sub-line: expansion splices its
@@ -188,12 +192,12 @@ TEST_CASE("Expansion drops `kind: BeamLine` from every branch", "[lattices]") {
     // `alt` inherits `ring`, whose line is `[sub, f1]`; after flattening,
     // `sub`'s only element `q1` takes its place, so line[0] is `q1` itself.
     YAMLNodeId first = get_child_by_index(
-        lat.expanded,
-        get_child_by_index(lat.expanded,
-                           get_child_by_key(lat.expanded, alt, "line"), 0),
+        lat.full_expanded,
+        get_child_by_index(lat.full_expanded,
+                           get_child_by_key(lat.full_expanded, alt, "line"), 0),
         0);
-    REQUIRE(key_eq(lat.expanded, first, "q1"));
-    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, first, "kind"),
+    REQUIRE(key_eq(lat.full_expanded, first, "q1"));
+    REQUIRE(val_eq(lat.full_expanded, get_child_by_key(lat.full_expanded, first, "kind"),
                    "Quadrupole"));
 
     // Expansion copies a definition rather than moving it, and the definition
@@ -207,6 +211,7 @@ TEST_CASE("Expansion drops `kind: BeamLine` from every branch", "[lattices]") {
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -242,31 +247,31 @@ TEST_CASE("A branch with no inherit takes its root BeamLine from its name",
               "    - use: \"machine\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     YAMLNodeId machine =
-        get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
+        get_child_by_index(lat.full_expanded, get_root(lat.full_expanded), 0);
     YAMLNodeId branch = get_child_by_index(
-        lat.expanded,
-        get_child_by_index(lat.expanded,
-                           get_child_by_key(lat.expanded, machine, "branches"),
+        lat.full_expanded,
+        get_child_by_index(lat.full_expanded,
+                           get_child_by_key(lat.full_expanded, machine, "branches"),
                            0),
         0);
-    REQUIRE(key_eq(lat.expanded, branch, "ln"));
+    REQUIRE(key_eq(lat.full_expanded, branch, "ln"));
 
     // The root line's contents are here, not just the two keys the file wrote.
-    YAMLNodeId line = get_child_by_key(lat.expanded, branch, "line");
+    YAMLNodeId line = get_child_by_key(lat.full_expanded, branch, "line");
     REQUIRE(line != YAML_NULL_ID);
-    REQUIRE(get_size(lat.expanded, line) >= 2);
-    REQUIRE(key_eq(lat.expanded,
+    REQUIRE(get_size(lat.full_expanded, line) >= 2);
+    REQUIRE(key_eq(lat.full_expanded,
                    get_child_by_index(
-                       lat.expanded, get_child_by_index(lat.expanded, line, 1), 0),
+                       lat.full_expanded, get_child_by_index(lat.full_expanded, line, 1), 0),
                    "q"));
 
     // The branch's own `periodic` still overrides the root BeamLine's, so the
     // defaulted inherit is merged on the same terms as a written one.
-    REQUIRE(val_eq(lat.expanded,
-                   get_child_by_key(lat.expanded, branch, "periodic"), "false"));
+    REQUIRE(val_eq(lat.full_expanded,
+                   get_child_by_key(lat.full_expanded, branch, "periodic"), "false"));
 
     // Nothing about the branch is a problem.
     for (size_t i = 0; i < lat.problems.count; ++i)
@@ -277,6 +282,7 @@ TEST_CASE("A branch with no inherit takes its root BeamLine from its name",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -317,30 +323,31 @@ TEST_CASE("An explicit branch inherit wins over the branch name", "[lattices]") 
               "    - use: \"machine\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     YAMLNodeId machine =
-        get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
+        get_child_by_index(lat.full_expanded, get_root(lat.full_expanded), 0);
     YAMLNodeId branch = get_child_by_index(
-        lat.expanded,
-        get_child_by_index(lat.expanded,
-                           get_child_by_key(lat.expanded, machine, "branches"),
+        lat.full_expanded,
+        get_child_by_index(lat.full_expanded,
+                           get_child_by_key(lat.full_expanded, machine, "branches"),
                            0),
         0);
-    YAMLNodeId line = get_child_by_key(lat.expanded, branch, "line");
+    YAMLNodeId line = get_child_by_key(lat.full_expanded, branch, "line");
     REQUIRE(line != YAML_NULL_ID);
     // `ring`'s element, not `alt`'s.
-    REQUIRE(key_eq(lat.expanded,
+    REQUIRE(key_eq(lat.full_expanded,
                    get_child_by_index(
-                       lat.expanded, get_child_by_index(lat.expanded, line, 1), 0),
+                       lat.full_expanded, get_child_by_index(lat.full_expanded, line, 1), 0),
                    "s_wanted"));
-    REQUIRE(val_eq(lat.expanded,
-                   get_child_by_key(lat.expanded, branch, "inherit"), "ring"));
+    REQUIRE(val_eq(lat.full_expanded,
+                   get_child_by_key(lat.full_expanded, branch, "inherit"), "ring"));
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -358,6 +365,7 @@ TEST_CASE("An empty branch is reported", "[lattices][problems]") {
         delete_tree(lat.original);
         delete_tree(lat.combined);
         delete_tree(lat.expanded);
+        delete_tree(lat.full_expanded);
         delete_tree(lat.leftover);
         rm_tmp(path);
         return msgs;
@@ -438,7 +446,7 @@ TEST_CASE("parse_and_expand_PALS reports expansion problems",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     // Collect the messages so the assertions do not depend on their order.
     std::vector<std::string> msgs;
@@ -471,6 +479,7 @@ TEST_CASE("parse_and_expand_PALS reports expansion problems",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -505,7 +514,7 @@ TEST_CASE("repeat with an unusable count keeps the entry",
         write_tmp(path, doc.c_str());
 
         struct lattices lat = parse_and_expand_PALS(path, nullptr);
-        REQUIRE(lat.expanded != nullptr);
+        REQUIRE(lat.full_expanded != nullptr);
 
         bool reported = false;
         for (size_t i = 0; i < lat.problems.count; ++i)
@@ -515,13 +524,14 @@ TEST_CASE("repeat with an unusable count keeps the entry",
 
         // The `line` under main_line must still hold the cell entry rather than
         // having been emptied.
-        YAMLNodeId line = find_by_key(lat.expanded, "line");
-        bool kept = line != YAML_NULL_ID && get_size(lat.expanded, line) > 0;
+        YAMLNodeId line = find_by_key(lat.full_expanded, "line");
+        bool kept = line != YAML_NULL_ID && get_size(lat.full_expanded, line) > 0;
 
         free_lattice_problems(lat.problems);
         delete_tree(lat.original);
         delete_tree(lat.combined);
         delete_tree(lat.expanded);
+        delete_tree(lat.full_expanded);
         delete_tree(lat.leftover);
         rm_tmp(path);
         return reported && kept;
@@ -548,15 +558,16 @@ TEST_CASE("parse_and_expand_PALS reports a missing lattice",
 
     // With no lattice to expand, expanded is an empty map and the whole document
     // is leftover — both handles are still valid.
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
     REQUIRE(lat.leftover != nullptr);
-    REQUIRE(get_size(lat.expanded, get_root(lat.expanded)) == 0);
+    REQUIRE(get_size(lat.full_expanded, get_root(lat.full_expanded)) == 0);
     REQUIRE(facility_of(lat.leftover) != YAML_NULL_ID);
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -590,7 +601,7 @@ TEST_CASE("a Fork with a ForkP sequence is reported as wrong-shape, not missing"
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     bool wrong_shape = false;
     bool missing = false;
@@ -608,6 +619,7 @@ TEST_CASE("a Fork with a ForkP sequence is reported as wrong-shape, not missing"
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -648,7 +660,7 @@ TEST_CASE("a Fork needs only to_line; destination_element and new_branch default
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     for (size_t i = 0; i < lat.problems.count; ++i)
         REQUIRE(std::string(lat.problems.items[i]).find("f1") ==
@@ -658,20 +670,21 @@ TEST_CASE("a Fork needs only to_line; destination_element and new_branch default
     // destination_pointer and the defaulted branch (named after to_line)
     // exists. The pointer is a parameter of the group, not a key loose on the
     // element.
-    YAMLNodeId forkp = find_by_key(lat.expanded, "ForkP");
-    REQUIRE(get_child_by_key(lat.expanded, forkp, "destination_pointer") !=
+    YAMLNodeId forkp = find_by_key(lat.full_expanded, "ForkP");
+    REQUIRE(get_child_by_key(lat.full_expanded, forkp, "destination_pointer") !=
             YAML_NULL_ID);
 
     // Expansion resolves ForkP.new_branch to the name of the branch it made,
     // which for the default is the to_line name.
-    REQUIRE(val_eq(lat.expanded,
-                   get_child_by_key(lat.expanded, forkp, "new_branch"),
+    REQUIRE(val_eq(lat.full_expanded,
+                   get_child_by_key(lat.full_expanded, forkp, "new_branch"),
                    "dump_line"));
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -733,33 +746,34 @@ TEST_CASE("a Fork propagates reference and floor into its new branch",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     // Branch 1 is `extraction`; its first (destination) element is `m1`.
-    YAMLNodeId dest = first_element_of_branch(lat.expanded, 1);
-    REQUIRE(key_eq(lat.expanded, dest, "m1"));
+    YAMLNodeId dest = first_element_of_branch(lat.full_expanded, 1);
+    REQUIRE(key_eq(lat.full_expanded, dest, "m1"));
 
-    YAMLNodeId refp = get_child_by_key(lat.expanded, dest, "ReferenceP");
+    YAMLNodeId refp = get_child_by_key(lat.full_expanded, dest, "ReferenceP");
     REQUIRE(refp != YAML_NULL_ID);
-    REQUIRE(val_eq(lat.expanded,
-                   get_child_by_key(lat.expanded, refp, "species_ref"),
+    REQUIRE(val_eq(lat.full_expanded,
+                   get_child_by_key(lat.full_expanded, refp, "species_ref"),
                    "proton"));
     // Energy carried through the zero-length Fork unchanged, and completion
     // filled in the momentum from it.
-    REQUIRE(val_eq(lat.expanded,
-                   get_child_by_key(lat.expanded, refp, "E_tot_ref"), "1e+09"));
-    REQUIRE(get_child_by_key(lat.expanded, refp, "pc_ref") != YAML_NULL_ID);
+    REQUIRE(val_eq(lat.full_expanded,
+                   get_child_by_key(lat.full_expanded, refp, "E_tot_ref"), "1e+09"));
+    REQUIRE(get_child_by_key(lat.full_expanded, refp, "pc_ref") != YAML_NULL_ID);
 
     // Floor placement of the source (x = 1.5) reaches the destination too.
-    YAMLNodeId floorp = get_child_by_key(lat.expanded, dest, "FloorP");
+    YAMLNodeId floorp = get_child_by_key(lat.full_expanded, dest, "FloorP");
     REQUIRE(floorp != YAML_NULL_ID);
-    REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, floorp, "x"),
+    REQUIRE(val_eq(lat.full_expanded, get_child_by_key(lat.full_expanded, floorp, "x"),
                    "1.5"));
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -803,15 +817,15 @@ TEST_CASE("propagate_reference: false leaves the new branch's reference unset",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
-    YAMLNodeId dest = first_element_of_branch(lat.expanded, 1);
-    REQUIRE(key_eq(lat.expanded, dest, "m1"));
+    YAMLNodeId dest = first_element_of_branch(lat.full_expanded, 1);
+    REQUIRE(key_eq(lat.full_expanded, dest, "m1"));
 
-    YAMLNodeId refp = get_child_by_key(lat.expanded, dest, "ReferenceP");
+    YAMLNodeId refp = get_child_by_key(lat.full_expanded, dest, "ReferenceP");
     // A ReferenceP is still written (time_ref), but no species/energy propagated.
-    REQUIRE(get_child_by_key(lat.expanded, refp, "species_ref") == YAML_NULL_ID);
-    REQUIRE(get_child_by_key(lat.expanded, refp, "E_tot_ref") == YAML_NULL_ID);
+    REQUIRE(get_child_by_key(lat.full_expanded, refp, "species_ref") == YAML_NULL_ID);
+    REQUIRE(get_child_by_key(lat.full_expanded, refp, "E_tot_ref") == YAML_NULL_ID);
 
     // `ring` has its reference from `begin`; only `extraction` is reported.
     REQUIRE(lat.problems.count == 1);
@@ -824,6 +838,7 @@ TEST_CASE("propagate_reference: false leaves the new branch's reference unset",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -873,7 +888,7 @@ TEST_CASE("a half-declared branch reference is reported for what it lacks",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     std::vector<std::string> msgs;
     for (size_t i = 0; i < lat.problems.count; ++i)
@@ -889,6 +904,7 @@ TEST_CASE("a half-declared branch reference is reported for what it lacks",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -935,39 +951,40 @@ TEST_CASE("new_branch: null forks into an existing branch, creating none",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     for (size_t i = 0; i < lat.problems.count; ++i)
         REQUIRE(std::string(lat.problems.items[i]).find("f1") ==
                 std::string::npos);
 
     // Exactly the two declared branches: the Fork added none.
-    YAMLNodeId lat1 = get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
-    YAMLNodeId branches = get_child_by_key(lat.expanded, lat1, "branches");
-    REQUIRE(get_size(lat.expanded, branches) == 2);
+    YAMLNodeId lat1 = get_child_by_index(lat.full_expanded, get_root(lat.full_expanded), 0);
+    YAMLNodeId branches = get_child_by_key(lat.full_expanded, lat1, "branches");
+    REQUIRE(get_size(lat.full_expanded, branches) == 2);
 
     // The Fork still connects: it carries a destination_pointer.
-    REQUIRE(find_by_key(lat.expanded, "destination_pointer") != YAML_NULL_ID);
+    REQUIRE(find_by_key(lat.full_expanded, "destination_pointer") != YAML_NULL_ID);
 
     // ForkP.new_branch stays `null` — no branch was made.
-    YAMLNodeId forkp = find_by_key(lat.expanded, "ForkP");
-    REQUIRE(val_eq(lat.expanded,
-                   get_child_by_key(lat.expanded, forkp, "new_branch"),
+    YAMLNodeId forkp = find_by_key(lat.full_expanded, "ForkP");
+    REQUIRE(val_eq(lat.full_expanded,
+                   get_child_by_key(lat.full_expanded, forkp, "new_branch"),
                    "null"));
 
     // `other` (branch 0) keeps its own reference — the Fork's proton/1e9 was not
     // propagated into an existing branch.
-    YAMLNodeId dest = first_element_of_branch(lat.expanded, 0);
-    REQUIRE(key_eq(lat.expanded, dest, "eb"));
-    YAMLNodeId refp = get_child_by_key(lat.expanded, dest, "ReferenceP");
-    REQUIRE(val_eq(lat.expanded,
-                   get_child_by_key(lat.expanded, refp, "species_ref"),
+    YAMLNodeId dest = first_element_of_branch(lat.full_expanded, 0);
+    REQUIRE(key_eq(lat.full_expanded, dest, "eb"));
+    YAMLNodeId refp = get_child_by_key(lat.full_expanded, dest, "ReferenceP");
+    REQUIRE(val_eq(lat.full_expanded,
+                   get_child_by_key(lat.full_expanded, refp, "species_ref"),
                    "electron"));
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -1011,7 +1028,7 @@ TEST_CASE("a destination of a kind that cannot be forked to is reported",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     int reported = 0;
     for (size_t i = 0; i < lat.problems.count; ++i) {
@@ -1025,14 +1042,15 @@ TEST_CASE("a destination of a kind that cannot be forked to is reported",
     REQUIRE(reported == 2);
 
     // Neither Fork resolved, so nothing was linked in either direction.
-    REQUIRE(find_by_key(lat.expanded, "destination_pointer") == YAML_NULL_ID);
-    REQUIRE(find_by_key(lat.expanded, "ForkFromP") == YAML_NULL_ID);
-    REQUIRE(find_by_key(lat.expanded, "forked_to") == YAML_NULL_ID);
+    REQUIRE(find_by_key(lat.full_expanded, "destination_pointer") == YAML_NULL_ID);
+    REQUIRE(find_by_key(lat.full_expanded, "ForkFromP") == YAML_NULL_ID);
+    REQUIRE(find_by_key(lat.full_expanded, "forked_to") == YAML_NULL_ID);
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -1077,35 +1095,36 @@ TEST_CASE("a fork destination lists its incoming Forks in ForkFromP",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     // f1 built the `dump_line` branch; f2 (new_branch: null) pointed into it.
-    YAMLNodeId dest = first_element_of_branch(lat.expanded, 1);
-    REQUIRE(key_eq(lat.expanded, dest, "dump_begin"));
+    YAMLNodeId dest = first_element_of_branch(lat.full_expanded, 1);
+    REQUIRE(key_eq(lat.full_expanded, dest, "dump_begin"));
 
-    YAMLNodeId group = get_child_by_key(lat.expanded, dest, "ForkFromP");
+    YAMLNodeId group = get_child_by_key(lat.full_expanded, dest, "ForkFromP");
     REQUIRE(group != YAML_NULL_ID);
-    REQUIRE(get_size(lat.expanded, group) == 2);
+    REQUIRE(get_size(lat.full_expanded, group) == 2);
 
     // f1 is the 2nd element of ring, f2 the 4th.
     YAMLNodeId e0 = get_child_by_index(
-        lat.expanded, get_child_by_index(lat.expanded, group, 0), 0);
-    REQUIRE(key_eq(lat.expanded, e0, "ring>>f1"));
-    REQUIRE(val_eq(lat.expanded, e0, "2"));
+        lat.full_expanded, get_child_by_index(lat.full_expanded, group, 0), 0);
+    REQUIRE(key_eq(lat.full_expanded, e0, "ring>>f1"));
+    REQUIRE(val_eq(lat.full_expanded, e0, "2"));
 
     YAMLNodeId e1 = get_child_by_index(
-        lat.expanded, get_child_by_index(lat.expanded, group, 1), 0);
-    REQUIRE(key_eq(lat.expanded, e1, "ring>>f2"));
-    REQUIRE(val_eq(lat.expanded, e1, "4"));
+        lat.full_expanded, get_child_by_index(lat.full_expanded, group, 1), 0);
+    REQUIRE(key_eq(lat.full_expanded, e1, "ring>>f2"));
+    REQUIRE(val_eq(lat.full_expanded, e1, "4"));
 
     // The group is built only for elements a Fork actually points at.
-    REQUIRE(get_child_by_key(lat.expanded, first_element_of_branch(lat.expanded, 0),
+    REQUIRE(get_child_by_key(lat.full_expanded, first_element_of_branch(lat.full_expanded, 0),
                              "ForkFromP") == YAML_NULL_ID);
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -1175,25 +1194,26 @@ TEST_CASE("a Fork names its destination in ForkP.forked_to", "[lattices]") {
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
     REQUIRE(lat.problems.count == 0);
 
     // f1 renamed the branch it built, so `forked_to` names `proton_dump` where
     // `to_line` said `dump_line`.
-    REQUIRE(forked_to_of(lat.expanded, 0, 1) == "proton_dump>>dump_begin");
+    REQUIRE(forked_to_of(lat.full_expanded, 0, 1) == "proton_dump>>dump_begin");
 
     // f2 took the default (SELF): the branch is named after the beam line, and
     // the destination defaults to that line's first element.
-    REQUIRE(forked_to_of(lat.expanded, 0, 2) == "alt_line>>alt_begin");
+    REQUIRE(forked_to_of(lat.full_expanded, 0, 2) == "alt_line>>alt_begin");
 
     // f3 pointed into the branch f1 had already built, and names the same
     // destination as f1 does.
-    REQUIRE(forked_to_of(lat.expanded, 0, 3) == "proton_dump>>dump_begin");
+    REQUIRE(forked_to_of(lat.full_expanded, 0, 3) == "proton_dump>>dump_begin");
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -1249,23 +1269,23 @@ TEST_CASE("a Fork inside a forked-to branch resolves exactly once",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     // Exactly four branches: the two listed, and one each from the two Forks.
-    YAMLNodeId lat1 = get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
-    YAMLNodeId branches = get_child_by_key(lat.expanded, lat1, "branches");
-    REQUIRE(get_size(lat.expanded, branches) == 4);
+    YAMLNodeId lat1 = get_child_by_index(lat.full_expanded, get_root(lat.full_expanded), 0);
+    YAMLNodeId branches = get_child_by_key(lat.full_expanded, lat1, "branches");
+    REQUIRE(get_size(lat.full_expanded, branches) == 4);
 
     // f2, the Fork in the branch that f1 built, ran once: its ForkP holds one
     // destination_pointer. A second run would append a second one to the same
     // group, since handle_fork reuses the ForkP it finds.
-    YAMLNodeId f2 = first_element_of_branch(lat.expanded, 2);
-    REQUIRE(key_eq(lat.expanded, f2, "f2"));
-    YAMLNodeId forkp = get_child_by_key(lat.expanded, f2, "ForkP");
+    YAMLNodeId f2 = first_element_of_branch(lat.full_expanded, 2);
+    REQUIRE(key_eq(lat.full_expanded, f2, "f2"));
+    YAMLNodeId forkp = get_child_by_key(lat.full_expanded, f2, "ForkP");
     int pointers = 0;
-    for (size_t i = 0; i < get_size(lat.expanded, forkp); ++i) {
-        char* k = get_node_key(lat.expanded,
-                               get_child_by_index(lat.expanded, forkp, i));
+    for (size_t i = 0; i < get_size(lat.full_expanded, forkp); ++i) {
+        char* k = get_node_key(lat.full_expanded,
+                               get_child_by_index(lat.full_expanded, forkp, i));
         if (k && std::string(k) == "destination_pointer") pointers++;
         yaml_free_string(k);
     }
@@ -1275,6 +1295,7 @@ TEST_CASE("a Fork inside a forked-to branch resolves exactly once",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -1380,12 +1401,12 @@ TEST_CASE("a destination_pointer survives expression substitution intact",
               "    - use: \"root_lat\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
     REQUIRE(lat.problems.count == 0);
 
     // Five Forks resolve: two chains of three (zero_line -> a_line -> b_line,
     // one_line -> c_line -> a_line -> b_line), sharing no branch instances.
-    std::vector<std::string> ptrs = all_values_for(lat.expanded, "destination_pointer");
+    std::vector<std::string> ptrs = all_values_for(lat.full_expanded, "destination_pointer");
     REQUIRE(ptrs.size() == 5);
     for (const std::string& p : ptrs) {
         INFO("destination_pointer: " << p);
@@ -1395,12 +1416,13 @@ TEST_CASE("a destination_pointer survives expression substitution intact",
 
     // Each of those Forks reaches its destination, so each destination carries
     // the reverse link. A misparsed pointer drops the entry without a word.
-    REQUIRE(all_values_for(lat.expanded, "ForkFromP").size() == 5);
+    REQUIRE(all_values_for(lat.full_expanded, "ForkFromP").size() == 5);
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -1435,7 +1457,7 @@ TEST_CASE("new_branch: null with a to_line that is not a branch is reported",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     bool reported = false;
     for (size_t i = 0; i < lat.problems.count; ++i)
@@ -1448,6 +1470,7 @@ TEST_CASE("new_branch: null with a to_line that is not a branch is reported",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -1470,7 +1493,7 @@ TEST_CASE("a malformed top-level file is a fatal parse problem, not a crash",
     // No usable tree: every handle is NULL.
     REQUIRE(lat.original == nullptr);
     REQUIRE(lat.combined == nullptr);
-    REQUIRE(lat.expanded == nullptr);
+    REQUIRE(lat.full_expanded == nullptr);
     REQUIRE(lat.leftover == nullptr);
 
     // A single problem, naming the file and the offending line.
@@ -1483,6 +1506,7 @@ TEST_CASE("a malformed top-level file is a fatal parse problem, not a crash",
     delete_tree(lat.original);  // all NULL — delete_tree(NULL) is a safe no-op
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }

--- a/tests/test_expressions.cpp
+++ b/tests/test_expressions.cpp
@@ -142,27 +142,27 @@ TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     const double a_var = 3.75e7 / (2.99792458e8 * 2.99792458e8);
 
     // `cleo` is referenced by main_line, so expansion inlines its definition
     // into the lattice; this is the copy inside the expanded tree.
-    YAMLNodeId cleo = find_by_key(lat.expanded, "cleo");
+    YAMLNodeId cleo = find_by_key(lat.full_expanded, "cleo");
     REQUIRE(cleo != YAML_NULL_ID);
 
     // Immediate expression using a user variable.
-    YAMLNodeId len = get_child_by_key(lat.expanded, cleo, "length");
-    REQUIRE(close(num_val(lat.expanded, len), 0.1 * std::log(0.34)));
+    YAMLNodeId len = get_child_by_key(lat.full_expanded, cleo, "length");
+    REQUIRE(close(num_val(lat.full_expanded, len), 0.1 * std::log(0.34)));
 
-    YAMLNodeId mmp = get_child_by_key(lat.expanded, cleo, "MagneticMultipoleP");
+    YAMLNodeId mmp = get_child_by_key(lat.full_expanded, cleo, "MagneticMultipoleP");
     // expr()-delayed expression is evaluated to a number in the expanded tree.
-    YAMLNodeId kn1 = get_child_by_key(lat.expanded, mmp, "Kn1");
-    REQUIRE(close(num_val(lat.expanded, kn1), 3.74 * a_var));
+    YAMLNodeId kn1 = get_child_by_key(lat.full_expanded, mmp, "Kn1");
+    REQUIRE(close(num_val(lat.full_expanded, kn1), 3.74 * a_var));
 
     // random_gauss() is deferred: the text is left untouched.
-    YAMLNodeId kn2 = get_child_by_key(lat.expanded, mmp, "Kn2");
-    REQUIRE(val_eq(lat.expanded, kn2, "0.01 + 0.003*random_gauss()"));
+    YAMLNodeId kn2 = get_child_by_key(lat.full_expanded, mmp, "Kn2");
+    REQUIRE(val_eq(lat.full_expanded, kn2, "0.01 + 0.003*random_gauss()"));
 
     // Expressions are evaluated before the document is split, so a definition
     // that stayed behind is evaluated in leftover just the same. `m_e` is not
@@ -171,7 +171,7 @@ TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
     REQUIRE(m_e != YAML_NULL_ID);
     YAMLNodeId m_e_val = get_child_by_key(lat.leftover, m_e, "value");
     REQUIRE(close(num_val(lat.leftover, m_e_val), 510998.95069000003));
-    REQUIRE(find_by_key(lat.expanded, "m_e") == YAML_NULL_ID);
+    REQUIRE(find_by_key(lat.full_expanded, "m_e") == YAML_NULL_ID);
 
     // The combined tree keeps the original expression text (evaluation happens
     // downstream of it).
@@ -182,6 +182,7 @@ TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -215,7 +216,7 @@ TEST_CASE("parse_and_expand_PALS resolves map-form constants/variables",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     const double a_const = 0.3 * evaluate_pals_expression("r_electron", nullptr);
 
@@ -234,15 +235,16 @@ TEST_CASE("parse_and_expand_PALS resolves map-form constants/variables",
 
     // An element parameter may reference the map-form definitions too; this is
     // d1 as inlined into the expanded lattice.
-    YAMLNodeId d1 = find_by_key(lat.expanded, "d1");
+    YAMLNodeId d1 = find_by_key(lat.full_expanded, "d1");
     REQUIRE(d1 != YAML_NULL_ID);
-    REQUIRE(close(num_val(lat.expanded, get_child_by_key(lat.expanded, d1,
+    REQUIRE(close(num_val(lat.full_expanded, get_child_by_key(lat.full_expanded, d1,
                                                          "length")),
                   a_const + 0.45));
 
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -280,13 +282,13 @@ TEST_CASE("parse_and_expand_PALS resolves element-parameter references",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
-    YAMLNodeId dh1a = find_by_key(lat.expanded, "DH1A");
+    YAMLNodeId dh1a = find_by_key(lat.full_expanded, "DH1A");
     REQUIRE(dh1a != YAML_NULL_ID);
-    YAMLNodeId bendp = get_child_by_key(lat.expanded, dh1a, "BendP");
+    YAMLNodeId bendp = get_child_by_key(lat.full_expanded, dh1a, "BendP");
     REQUIRE(close(
-        num_val(lat.expanded, get_child_by_key(lat.expanded, bendp, "edge2_int")),
+        num_val(lat.full_expanded, get_child_by_key(lat.full_expanded, bendp, "edge2_int")),
         0.02 * 0.1));
 
     // A clean lattice reports no problems.
@@ -296,6 +298,7 @@ TEST_CASE("parse_and_expand_PALS resolves element-parameter references",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -329,7 +332,7 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     const double m_3he = 2809413528.3197904;  // mass_of("#3He"), CODATA 2022
 
@@ -338,18 +341,18 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
                           get_child_by_key(lat.leftover, consts, "b_const")),
                   0.45 * m_3he));
 
-    YAMLNodeId dh1a = find_by_key(lat.expanded, "DH1A");
+    YAMLNodeId dh1a = find_by_key(lat.full_expanded, "DH1A");
     REQUIRE(dh1a != YAML_NULL_ID);
-    YAMLNodeId bendp = get_child_by_key(lat.expanded, dh1a, "BendP");
-    REQUIRE(close(num_val(lat.expanded,
-                          get_child_by_key(lat.expanded, bendp, "h1")),
+    YAMLNodeId bendp = get_child_by_key(lat.full_expanded, dh1a, "BendP");
+    REQUIRE(close(num_val(lat.full_expanded,
+                          get_child_by_key(lat.full_expanded, bendp, "h1")),
                   1.1 * m_3he));
 
     // A bare identifier naming the species constant (`species_ref: species`) is
     // replaced by its species-name string in the expanded tree.
-    YAMLNodeId refp = get_child_by_key(lat.expanded, dh1a, "ReferenceP");
-    REQUIRE(val_eq(lat.expanded,
-                   get_child_by_key(lat.expanded, refp, "species_ref"),
+    YAMLNodeId refp = get_child_by_key(lat.full_expanded, dh1a, "ReferenceP");
+    REQUIRE(val_eq(lat.full_expanded,
+                   get_child_by_key(lat.full_expanded, refp, "species_ref"),
                    "#3He"));
 
     // The species constant itself stays as its (string) species name.
@@ -363,6 +366,7 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -399,7 +403,7 @@ TEST_CASE("parse_and_expand_PALS leaves root prose alone", "[expr][lattices]") {
               "    - use: \"lat1\"\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     REQUIRE(lat.problems.count == 0);
     free_lattice_problems(lat.problems);
@@ -407,6 +411,7 @@ TEST_CASE("parse_and_expand_PALS leaves root prose alone", "[expr][lattices]") {
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -444,6 +449,7 @@ std::vector<std::string> problems_for_value(const char* path,
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
     return out;
@@ -536,6 +542,7 @@ TEST_CASE("a controller says why an expression failed", "[expr][controllers]") {
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }

--- a/tests/test_key_order.cpp
+++ b/tests/test_key_order.cpp
@@ -100,13 +100,13 @@ TEST_CASE("Expansion preserves the key order of the source file", "[key_order]")
     // order they were written in.
     const std::vector<std::string> expected_branch = {"multipass", "length",
                                                       "zero_point", "line"};
-    YAMLNodeId lat1 = get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
-    REQUIRE(key_eq(lat.expanded, lat1, "lat1"));
-    YAMLNodeId branches = get_child_by_key(lat.expanded, lat1, "branches");
+    YAMLNodeId lat1 = get_child_by_index(lat.full_expanded, get_root(lat.full_expanded), 0);
+    REQUIRE(key_eq(lat.full_expanded, lat1, "lat1"));
+    YAMLNodeId branches = get_child_by_key(lat.full_expanded, lat1, "branches");
     YAMLNodeId e_line = get_child_by_index(
-        lat.expanded, get_child_by_index(lat.expanded, branches, 0), 0);
-    REQUIRE(key_eq(lat.expanded, e_line, "main_line"));
-    REQUIRE(keys_of(lat.expanded, e_line) == expected_branch);
+        lat.full_expanded, get_child_by_index(lat.full_expanded, branches, 0), 0);
+    REQUIRE(key_eq(lat.full_expanded, e_line, "main_line"));
+    REQUIRE(keys_of(lat.full_expanded, e_line) == expected_branch);
 
     // Merging `inherit: thingB` brings the parent's keys in ahead of the
     // child's own, rather than sorting the merged result. `main_line` is a
@@ -114,22 +114,23 @@ TEST_CASE("Expansion preserves the key order of the source file", "[key_order]")
     // `multipass_index`, appended after the inherited keys. Finally, the element
     // bookkeeper appends its computed output groups (`ReferenceP`, `FloorP`) and
     // `s_position`, in that order, after everything the file supplied.
-    YAMLNodeId line_seq = get_child_by_key(lat.expanded, e_line, "line");
+    YAMLNodeId line_seq = get_child_by_key(lat.full_expanded, e_line, "line");
     YAMLNodeId thingZ = get_child_by_index(
-        lat.expanded, get_child_by_index(lat.expanded, line_seq, 0), 0);
-    REQUIRE(key_eq(lat.expanded, thingZ, "thingZ"));
+        lat.full_expanded, get_child_by_index(lat.full_expanded, line_seq, 0), 0);
+    REQUIRE(key_eq(lat.full_expanded, thingZ, "thingZ"));
     const std::vector<std::string> inherited = {
         "kind",           "length",     "inherit", "multipass_index",
         "ReferenceP",     "FloorP",     "s_position"};
-    REQUIRE(keys_of(lat.expanded, thingZ) == inherited);
-    REQUIRE(val_eq(lat.expanded,
-                   get_child_by_key(lat.expanded, thingZ, "multipass_index"),
+    REQUIRE(keys_of(lat.full_expanded, thingZ) == inherited);
+    REQUIRE(val_eq(lat.full_expanded,
+                   get_child_by_key(lat.full_expanded, thingZ, "multipass_index"),
                    "1"));
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }

--- a/tests/test_load.cpp
+++ b/tests/test_load.cpp
@@ -26,6 +26,7 @@ struct LoadCase {
         delete_tree(lat.original);
         delete_tree(lat.combined);
         delete_tree(lat.expanded);
+        delete_tree(lat.full_expanded);
         delete_tree(lat.leftover);
         std::filesystem::remove_all(dir);
     }
@@ -198,11 +199,11 @@ TEST_CASE("a loaded settings file drives the lattice the layout file defines",
     c.parse("joiner.pals.yaml");
     REQUIRE(c.joined_problems() == "");
 
-    YAMLNodeId q1a = find_by_key(c.lat.expanded, "Q1a");
+    YAMLNodeId q1a = find_by_key(c.lat.full_expanded, "Q1a");
     REQUIRE(q1a != YAML_NULL_ID);
-    YAMLNodeId mult = get_child_by_key(c.lat.expanded, q1a, "MagneticMultipoleP");
+    YAMLNodeId mult = get_child_by_key(c.lat.full_expanded, q1a, "MagneticMultipoleP");
     REQUIRE(mult != YAML_NULL_ID);
-    REQUIRE(close(num_val(c.lat.expanded, get_child_by_key(c.lat.expanded, mult,
+    REQUIRE(close(num_val(c.lat.full_expanded, get_child_by_key(c.lat.full_expanded, mult,
                                                            "Kn1")),
                   0.34));
 }

--- a/tests/test_multipass.cpp
+++ b/tests/test_multipass.cpp
@@ -50,29 +50,30 @@ TEST_CASE("Multipass sub-lines are numbered with a multipass_index",
               "    - use: lat1\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     // Flat line: mark, cavA, cavA, cavA, cavA (5 elements), plus the appended
     // `branch_end` Placeholder the bookkeeper caps every branch with (6 total).
-    YAMLNodeId lat1 = get_child_by_index(lat.expanded, get_root(lat.expanded), 0);
+    YAMLNodeId lat1 = get_child_by_index(lat.full_expanded, get_root(lat.full_expanded), 0);
     YAMLNodeId branch = get_child_by_index(
-        lat.expanded,
-        get_child_by_index(lat.expanded,
-                           get_child_by_key(lat.expanded, lat1, "branches"), 0),
+        lat.full_expanded,
+        get_child_by_index(lat.full_expanded,
+                           get_child_by_key(lat.full_expanded, lat1, "branches"), 0),
         0);
-    REQUIRE(get_size(lat.expanded, get_child_by_key(lat.expanded, branch, "line")) == 6);
+    REQUIRE(get_size(lat.full_expanded, get_child_by_key(lat.full_expanded, branch, "line")) == 6);
 
     // mark, from the non-multipass inj, carries no index.
-    REQUIRE(mp_index_at(lat.expanded, 0) == YAML_NULL_ID);
-    REQUIRE(val_eq(lat.expanded, mp_index_at(lat.expanded, 1), "1"));  // linac pass 1
-    REQUIRE(val_eq(lat.expanded, mp_index_at(lat.expanded, 2), "1"));
-    REQUIRE(val_eq(lat.expanded, mp_index_at(lat.expanded, 3), "2"));  // linac pass 2
-    REQUIRE(val_eq(lat.expanded, mp_index_at(lat.expanded, 4), "2"));
+    REQUIRE(mp_index_at(lat.full_expanded, 0) == YAML_NULL_ID);
+    REQUIRE(val_eq(lat.full_expanded, mp_index_at(lat.full_expanded, 1), "1"));  // linac pass 1
+    REQUIRE(val_eq(lat.full_expanded, mp_index_at(lat.full_expanded, 2), "1"));
+    REQUIRE(val_eq(lat.full_expanded, mp_index_at(lat.full_expanded, 3), "2"));  // linac pass 2
+    REQUIRE(val_eq(lat.full_expanded, mp_index_at(lat.full_expanded, 4), "2"));
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }
@@ -114,20 +115,21 @@ TEST_CASE("Nested multipass lines: the nearest multipass line wins",
               "    - use: lat1\n");
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
-    REQUIRE(lat.expanded != nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
 
     // Flat line: x, y, y, y, y, x.
-    REQUIRE(val_eq(lat.expanded, mp_index_at(lat.expanded, 0), "1"));  // outer, pass 1
-    REQUIRE(val_eq(lat.expanded, mp_index_at(lat.expanded, 1), "1"));  // inner instance 1
-    REQUIRE(val_eq(lat.expanded, mp_index_at(lat.expanded, 2), "1"));  // inner instance 1
-    REQUIRE(val_eq(lat.expanded, mp_index_at(lat.expanded, 3), "2"));  // inner instance 2
-    REQUIRE(val_eq(lat.expanded, mp_index_at(lat.expanded, 4), "2"));  // inner instance 2
-    REQUIRE(val_eq(lat.expanded, mp_index_at(lat.expanded, 5), "1"));  // outer, pass 1
+    REQUIRE(val_eq(lat.full_expanded, mp_index_at(lat.full_expanded, 0), "1"));  // outer, pass 1
+    REQUIRE(val_eq(lat.full_expanded, mp_index_at(lat.full_expanded, 1), "1"));  // inner instance 1
+    REQUIRE(val_eq(lat.full_expanded, mp_index_at(lat.full_expanded, 2), "1"));  // inner instance 1
+    REQUIRE(val_eq(lat.full_expanded, mp_index_at(lat.full_expanded, 3), "2"));  // inner instance 2
+    REQUIRE(val_eq(lat.full_expanded, mp_index_at(lat.full_expanded, 4), "2"));  // inner instance 2
+    REQUIRE(val_eq(lat.full_expanded, mp_index_at(lat.full_expanded, 5), "1"));  // outer, pass 1
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
     rm_tmp(path);
 }

--- a/tests/test_sets.cpp
+++ b/tests/test_sets.cpp
@@ -30,6 +30,7 @@ void free_all(struct lattices& lat) {
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
     delete_tree(lat.leftover);
 }
 
@@ -119,9 +120,9 @@ TEST_CASE("a set writes every element its pattern matches",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
 
-    REQUIRE(close(one_param(lat.expanded, "B1a", "BendP", "e1"),
+    REQUIRE(close(one_param(lat.full_expanded, "B1a", "BendP", "e1"),
                   2 * 0.1 + std::atan(0.02)));
-    REQUIRE(close(one_param(lat.expanded, "B1b", "BendP", "e1"),
+    REQUIRE(close(one_param(lat.full_expanded, "B1b", "BendP", "e1"),
                   2 * 0.3 + std::atan(0.02)));
 
     free_all(lat);
@@ -158,9 +159,9 @@ TEST_CASE("a set only reaches elements defined before it",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
 
-    REQUIRE(close(one_param(lat.expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
+    REQUIRE(close(one_param(lat.full_expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
                   0.12));
-    REQUIRE(close(one_param(lat.expanded, "Q2", "MagneticMultipoleP", "Kn1L"),
+    REQUIRE(close(one_param(lat.full_expanded, "Q2", "MagneticMultipoleP", "Kn1L"),
                   0.1));
 
     free_all(lat);
@@ -187,7 +188,7 @@ TEST_CASE("a set creates a parameter that defaults to zero",
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
-    REQUIRE(close(one_param(lat.expanded, "Q1", "MagneticMultipoleP", "Kn0"),
+    REQUIRE(close(one_param(lat.full_expanded, "Q1", "MagneticMultipoleP", "Kn0"),
                   0.02));
 
     free_all(lat);
@@ -253,7 +254,7 @@ TEST_CASE("an unwritten parameter with no written family member reads as zero",
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
-    REQUIRE(close(one_param(lat.expanded, "Q2", "MagneticMultipoleP", "Kn1L"),
+    REQUIRE(close(one_param(lat.full_expanded, "Q2", "MagneticMultipoleP", "Kn1L"),
                   0.5));
 
     free_all(lat);
@@ -282,9 +283,9 @@ TEST_CASE("the compact sets form writes each pair", "[expr][lattices][set]") {
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
-    REQUIRE(close(one_param(lat.expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
+    REQUIRE(close(one_param(lat.full_expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
                   0.25));
-    REQUIRE(close(one_param(lat.expanded, "D1", nullptr, "length"), 3.0));
+    REQUIRE(close(one_param(lat.full_expanded, "D1", nullptr, "length"), 3.0));
 
     free_all(lat);
     rm_tmp(path);
@@ -315,7 +316,7 @@ TEST_CASE("without expand_lattice a set writes the single definition",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
     for (size_t i = 0; i < 3; ++i)
-        REQUIRE(close(nth_param(lat.expanded, "q1", i, "MagneticMultipoleP",
+        REQUIRE(close(nth_param(lat.full_expanded, "q1", i, "MagneticMultipoleP",
                                 "Kn1L"),
                       0.75));
 
@@ -353,7 +354,7 @@ TEST_CASE("after expand_lattice a set reaches each expanded copy",
 
     // The copies sit at s = 0, 0.5 and 1.0.
     for (size_t i = 0; i < 3; ++i)
-        REQUIRE(close(nth_param(lat.expanded, "q1", i, "MagneticMultipoleP",
+        REQUIRE(close(nth_param(lat.full_expanded, "q1", i, "MagneticMultipoleP",
                                 "Kn1L"),
                       0.375 + 0.5 * static_cast<double>(i)));
 
@@ -393,10 +394,10 @@ TEST_CASE("a post-expansion set makes the bookkeeper redo the family",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
 
-    REQUIRE(close(one_param(lat.expanded, "q1", "MagneticMultipoleP", "Kn1L"),
+    REQUIRE(close(one_param(lat.full_expanded, "q1", "MagneticMultipoleP", "Kn1L"),
                   0.75));
-    double b1 = one_param(lat.expanded, "q1", "MagneticMultipoleP", "Bn1L");
-    double b2 = one_param(lat.expanded, "q2", "MagneticMultipoleP", "Bn1L");
+    double b1 = one_param(lat.full_expanded, "q1", "MagneticMultipoleP", "Bn1L");
+    double b2 = one_param(lat.full_expanded, "q2", "MagneticMultipoleP", "Bn1L");
     REQUIRE(b1 != 0.0);
     REQUIRE(close_rel(b1, b2));
 
@@ -427,8 +428,8 @@ TEST_CASE("a post-expansion set that changes a length moves the lattice",
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
-    REQUIRE(close(one_param(lat.expanded, "m1", nullptr, "s_position"), 3.5));
-    REQUIRE(close(one_param(lat.expanded, "m1", "FloorP", "z"), 3.5));
+    REQUIRE(close(one_param(lat.full_expanded, "m1", nullptr, "s_position"), 3.5));
+    REQUIRE(close(one_param(lat.full_expanded, "m1", "FloorP", "z"), 3.5));
 
     free_all(lat);
     rm_tmp(path);
@@ -463,7 +464,7 @@ TEST_CASE("controllers stay authoritative over a post-expansion set",
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
-    REQUIRE(close(one_param(lat.expanded, "q1", "MagneticMultipoleP", "Kn1L"),
+    REQUIRE(close(one_param(lat.full_expanded, "q1", "MagneticMultipoleP", "Kn1L"),
                   0.9));
 
     free_all(lat);
@@ -495,7 +496,7 @@ TEST_CASE("a set with an error term reports that it is not applied",
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(any_contains(problem_list(lat),
                          "absolute_error/relative_error are not applied"));
-    REQUIRE(close(one_param(lat.expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
+    REQUIRE(close(one_param(lat.full_expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
                   0.4));
 
     free_all(lat);
@@ -545,7 +546,7 @@ TEST_CASE("a set with a random value is deferred", "[expr][lattices][set]") {
 
     struct lattices lat = parse_and_expand_PALS(path, nullptr);
     REQUIRE(joined(lat) == "");
-    REQUIRE(close(one_param(lat.expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
+    REQUIRE(close(one_param(lat.full_expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
                   0.375));
 
     free_all(lat);


### PR DESCRIPTION
`parse_and_expand_PALS` now returns five trees rather than four.

- **`full_expanded`** — the lattice the bookkeeper finishes: every dependent parameter computed and present. Each element carries its `ReferenceP`, `FloorP` and `s_position`, the derived members of every parameter family it uses (`Kn1L` alongside `Kn1`, `voltage` alongside `gradient`, …) and the non-zero defaults of the groups it carries; each branch is capped with a `branch_end` Placeholder holding its final reference and floor.
- **`expanded`** — that same tree pruned back to the author's inputs. A parameter is kept when it was present before `run_element_bookkeeper` first ran, or when a post-`expand_lattice` `set` wrote it. Everything else the bookkeeper produced is dropped, along with any group left empty and the `branch_end` elements.

`expanded` is `full_expanded` with nodes removed rather than an earlier snapshot, so a parameter present in both holds the **same value** in both, with every `set` and ABSOLUTE controller applied. Use it to see the inputs rather than their consequences, or to write a lattice back out without the derived values.

## API

The tree that took the old `expanded` name now takes `full_expanded`: `node_link.full_expanded`, `build_correspondence_map(original, combined, full_expanded, leftover)` and `get_lattice_parameter_value(full_expanded, leftover, …)`. `expanded` takes no part in the correspondence — it is a pruned copy, not a step in the derivation chain, so its nodes are located by path.

`struct lattices` gained `full_expanded` between `expanded` and `leftover`, so callers binding it by layout need updating. PALSJulia follows in a companion PR.

## Tests

New `tests/test_expanded_minus_dependent.cpp` (9 cases) pins the boundary between the two trees: an authored `ReferenceP` the bookkeeper completes, one authored member of a multipole family with the rest derived, an authored RFP gradient plus materialized defaults, and an element holding nothing but its `kind`. The existing suites follow the rename.

Full suite: 1291 assertions in 236 test cases, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
