### PR TITLE
Expand the copies a `repeat` splices

### DIFF
--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -473,7 +473,8 @@ static void stamp_multipass_pass(ryml::Tree& t, size_t first, size_t stop,
 /**
  * Perform lattice expansion on the element `node`.
  * 1. Substitute scalar elements with their full definition taken from emap.
- * 2. Beamlines that contain "repeat: n" have their contents repeated n times.
+ * 2. Beamlines that contain "repeat: n" have their contents repeated n times,
+ *    each copy expanded in turn like any other entry of the enclosing line.
  * 3. Elements that contain "inherit: ancestor" have the contents of ancestor
  * copied into element.
  * 4. A beamline referenced by bare name inside a `line:` is a sub-line: its
@@ -541,7 +542,12 @@ static void expand(ryml::Tree& t, size_t node,
                             size_t def = emap[target];
                             size_t line_id =
                                 t.find_child(def, ryml::to_csubstr("line"));
-                            size_t after = t.prev_sibling(child);
+                            // `before`/`next` bracket the run about to be
+                            // spliced in: both are outside it and stay put
+                            // while it is built, so they still bracket it once
+                            // `child` itself is gone.
+                            size_t before = t.prev_sibling(child);
+                            size_t after = before;
                             // if beamline to be repeated has a line, duplicate
                             // it `count` times, else just duplicate the name of
                             // the beamline `count` times
@@ -567,6 +573,25 @@ static void expand(ryml::Tree& t, size_t node,
                             }
                             erase_prov_subtree(t, child, prov);
                             t.remove(child);
+
+                            // Expand the copies just spliced in. They are
+                            // duplicates of the repeated definition's own
+                            // entries -- element references and nested
+                            // sub-lines -- so they need exactly the expansion
+                            // the enclosing loop would have given them had they
+                            // been written out by hand. Skipping them left a
+                            // branch of bare names that extracted as an empty
+                            // lattice, and reported nothing.
+                            for (size_t cur = (before == ryml::NONE)
+                                                  ? t.first_child(node)
+                                                  : t.next_sibling(before);
+                                 cur != ryml::NONE && cur != next;) {
+                                size_t nx = t.next_sibling(cur);
+                                expand(t, cur, emap, prov, problems, branches,
+                                       mp_pass, done);
+                                cur = nx;
+                            }
+
                             child = next;
                             continue;
                         }

--- a/tests/test_correspondence.cpp
+++ b/tests/test_correspondence.cpp
@@ -185,16 +185,17 @@ TEST_CASE("build_correspondence_map maps one source to many expanded copies",
         build_correspondence_map(lat.original, lat.combined, lat.full_expanded,
                                  lat.leftover);
 
-    // Unrolling `repeat: 3` over a one-element cell produces three keyless `d1`
-    // scalars in the expanded line, all copied from the same combined source.
-    // Build a histogram of the combined ids that the expanded scalar `d1`
-    // nodes point to; a single source must account for at least three copies.
+    // Unrolling `repeat: 3` over a one-element cell produces three `d1` entries
+    // in the expanded line, all copied from the same combined source. They are
+    // maps keyed `d1` carrying the substituted definition: a copy is expanded
+    // like any other line entry. (This test used to look for keyless `d1`
+    // scalars, which is what the copies were left as while `repeat` spliced
+    // them without expanding them.)
     std::map<YAMLNodeId, int> combined_hits;
     for (size_t i = 0; i < m.count; i++) {
         // Skip the leftover half of the map: those ids index a different tree.
         if (m.links[i].full_expanded == YAML_NULL_ID) continue;
-        if (!is_scalar(lat.full_expanded, m.links[i].full_expanded)) continue;
-        if (!val_eq(lat.full_expanded, m.links[i].full_expanded, "d1")) continue;
+        if (!key_eq(lat.full_expanded, m.links[i].full_expanded, "d1")) continue;
         REQUIRE(m.links[i].combined != YAML_NULL_ID);  // has a source
         combined_hits[m.links[i].combined]++;
     }

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -542,6 +542,78 @@ TEST_CASE("repeat with an unusable count keeps the entry",
     REQUIRE(counts_rejected("-1"));     // parses, but meaningless
 }
 
+TEST_CASE("repeat expands the copies it splices", "[lattices]") {
+    // `repeat: n` used to splice the definition's entries and then step past
+    // them, so the copies were never expanded: the branch came out a list of
+    // bare element names rather than elements, and the lattice read as empty
+    // with nothing reported. Writing the sub-line out by hand always worked, so
+    // the two spellings of the same line disagreed.
+    //
+    // `inner` is nested inside the repeated `cell` to pin the recursive case:
+    // the copies are expanded, so a sub-line among them flattens in its turn.
+    const char* path = "tmp_repeat_expands.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - d1:\n"
+              "        kind: Drift\n"
+              "        length: 2.0\n"
+              "    - q1:\n"
+              "        kind: Quadrupole\n"
+              "        length: 0.4\n"
+              "    - inner:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - q1\n"
+              "    - cell:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - d1\n"
+              "          - inner\n"
+              "    - main_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - cell:\n"
+              "              repeat: 3\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - main_line\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
+
+    for (size_t i = 0; i < lat.problems.count; ++i)
+        REQUIRE(std::string(lat.problems.items[i]).find("repeat") ==
+                std::string::npos);
+
+    // Three copies of a two-element cell, flattened: d1 q1 d1 q1 d1 q1.
+    YAMLNodeId line = find_by_key(lat.expanded, "line");
+    REQUIRE(line != YAML_NULL_ID);
+    REQUIRE(get_size(lat.expanded, line) == 6);
+
+    // Each entry is the element itself rather than a reference to it: a
+    // single-key map naming the element, carrying the definition it was
+    // substituted with. A bare name would have no children to ask for a `kind`.
+    for (size_t i = 0; i < 6; i++) {
+        YAMLNodeId entry = get_child_by_index(lat.expanded, line, i);
+        YAMLNodeId def = get_child_by_index(lat.expanded, entry, 0);
+        bool even = (i % 2 == 0);
+        REQUIRE(key_eq(lat.expanded, def, even ? "d1" : "q1"));
+        REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, def, "kind"),
+                       even ? "Drift" : "Quadrupole"));
+    }
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}
+
 TEST_CASE("parse_and_expand_PALS reports a missing lattice",
           "[lattices][problems]") {
     const char* path = "tmp_nolattice.pals.yaml";


### PR DESCRIPTION
## The bug

A beamline repeated with `repeat: n` expanded to a list of bare element names instead of elements, so the lattice extracted as empty — with nothing added to `problems`.

```yaml
    - cell:
        kind: BeamLine
        line:
          - d
          - q
    - ramp:
        kind: BeamLine
        line:
          - beg
          - cell:
              repeat: 3
```

Before: 2 elements (`beg`, `branch_end`). Writing `- cell` out three times instead: 8. The two spellings of the same line disagreed, and the shorter one was silently empty.

## The cause

In the seq branch of `expand`, the repeat path ends:

```cpp
t.remove(child);
child = next;      // captured before the splice
continue;
```

The copies are inserted *ahead* of `child`, so resuming at `next` steps over every node just inserted and none of them reaches the scalar-substitution branch below.

## The fix

The bare sub-line path a few lines down already handles this: it brackets the spliced run with the siblings either side (both outside the run, both stay put) and expands what lies between them. The repeat path now does the same, which also covers the recursive case — a sub-line among the copies flattens in its turn, which the new test pins.

## Test change

`build_correspondence_map maps one source to many expanded copies` asserted the old output, looking for the three keyless `d1` scalars that were the symptom. Its subject — one combined source, three expanded copies — is unchanged; it now finds the copies by key, as the substituted definitions they should have been.

Full suite: 237 cases, 1307 assertions, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
