### PR TITLE
Number each expanded element with its position in its branch

### DIFF
--- a/docs/src/guide/expressions.md
+++ b/docs/src/guide/expressions.md
@@ -1,197 +1,94 @@
 # Evaluating expressions
 
 A PALS lattice may write numeric values as mathematical *expressions* —
-`0.3 * r_electron`, `a_const^2`, `mass_of("proton")`. As the final step of
-expansion, `parse_and_expand_PALS` evaluates every such expression in the
-**`expanded`** tree to a plain number, so the expanded lattice is fully numeric.
-The `original` and `combined` views always keep the expression text exactly as
-written.
+`0.3 * r_electron`, `a_const^2`, `mass_of("proton")`. As part of expansion,
+`parse_and_expand_PALS` evaluates every such expression to a plain number, so
+both expanded trees are fully numeric. The `original` and `combined` views
+always keep the expression text exactly as written.
 
-Only scalars that are genuine expressions are touched. Names that happen to sit
-where a value could go — element and line references in a `line:`, `kind:`
-names, booleans — are not expressions and are left untouched.
+The expression language itself — the grammar and its precedence, the built-in
+constants, the functions, the syntax for defining constants and variables, for
+`Controller` elements and for `set` commands — belongs to the PALS standard and
+is documented with it at
+[pals-project.readthedocs.io](https://pals-project.readthedocs.io). This page
+covers what *this library* does with it: when evaluation happens, what it
+declines to evaluate, and what it reports rather than guesses.
 
-## What gets evaluated, and when
-
-Two kinds of expression are evaluated to a number in the expanded tree:
-
-- **Immediate** expressions — a bare value such as `length: 0.3 * r_electron`.
-- **Delayed** expressions wrapped in `expr(...)`, such as
-  `Kn1: expr(3.74 * a_var)`. In the fully expanded tree the distinction no
-  longer matters: both become numbers.
-
-One case is deliberately **not** evaluated. An expression that calls `random()`
-or `random_gauss()` is left as text, so that expanding the same lattice twice
-gives byte-identical output:
-
-```yaml
-Kn2: 0.01 + 0.003*random_gauss()   # kept verbatim in `expanded`
-```
-
-## Grammar
-
-The expression grammar is the arithmetic you would expect:
-
-- operators `+` `-` `*` `/` `^`, with the usual precedence;
-- `^` (power) is **right-associative**, so `2^3^2` is `2^(3^2) = 512`;
-- a unary sign binds *looser* than `^`, so `-2^2` is `-(2^2) = -4`, while a
-  signed exponent still works (`2^-2` is `2^(-2) = 0.25`) — the Fortran/Bmad
-  convention used across the ecosystem;
-- parentheses group sub-expressions.
-
-## Built-in constants
-
-The named physical constants below are available in every expression. Their
-values come from
+Constant values come from
 [AtomicAndPhysicalConstantsCLib](https://github.com/pals-project/AtomicAndPhysicalConstantsCLib)
 (APC — a C++ mirror of
 [AtomicAndPhysicalConstants.jl](https://github.com/bmad-sim/AtomicAndPhysicalConstants.jl),
-CODATA 2022), fetched automatically by CMake, so PALS shares one set of numbers
-with the rest of the toolchain.
+CODATA 2022), fetched automatically by CMake, so pals-cpp shares one set of
+numbers with the rest of the toolchain.
 
-| Constant | Meaning |
-| --- | --- |
-| `pi` | π |
-| `c_light` | speed of light |
-| `h_planck` | Planck constant |
-| `hbar` | reduced Planck constant |
-| `k_boltzmann` | Boltzmann constant |
-| `r_electron`, `r_proton` | classical electron / proton radius |
-| `e_charge` | elementary charge |
-| `mu_0`, `epsilon_0` | vacuum permeability / permittivity |
-| `classical_radius_factor` | 1 / (4π ε₀ c²) |
-| `fine_structure` | fine-structure constant |
-| `n_avogadro` | Avogadro constant |
+## Where the standard leaves a choice
 
-## Functions
+Two points the standard's function and constant lists do not settle, which this
+library therefore has to fix:
 
-Standard math functions are available: `sqrt`, `exp`, `log`, `abs`, `sign`,
-`factorial`; the trigonometric and hyperbolic families and their inverses
-(`sin`, `cos`, `tan`, `cot`, `sinc`, `asin`, `acos`, `atan`, `atan2`, `sinh`,
-`cosh`, `tanh`, `coth`, `asinh`, `acosh`, `atanh`, `acoth`); and the rounding
-helpers `int` (toward zero), `nint` (nearest), `floor`, `ceiling`, and
-`modulo(x, p)`.
+- **Associativity and the unary sign.** `^` is right-associative, so `2^3^2` is
+  `2^(3^2) = 512`. A unary sign binds *looser* than `^`, so `-2^2` is
+  `-(2^2) = -4`, while a signed exponent still works (`2^-2` is `0.25`). This is
+  the Fortran/Bmad convention used across the ecosystem.
+- **Species names must be quoted.** `mass_of("proton")` is read; an unquoted
+  name is an error. A mass number carries a leading `#` — `"#3He"`, not `"3He"`
+  — matching
+  [AtomicAndPhysicalConstants.jl](https://github.com/bmad-sim/AtomicAndPhysicalConstants.jl),
+  and quoting is also what lets that `#` be written without tripping YAML's
+  comment rule. The argument may instead be a constant or variable whose value
+  is a species name, passed unquoted; such a definition may also be used
+  directly wherever a species name is expected, and a bare identifier used as a
+  parameter value is replaced by the species string it stands for.
 
-### Particle-data functions
+## What gets evaluated
 
-`mass_of`, `charge_of`, and `anomalous_moment_of` look a particle up by name and
-return its mass (eV), charge (units of `e`), or anomalous magnetic moment, drawn
-from APC. **The species name must be quoted** (single or double quotes); an
-unquoted name is an error. A mass number must carry a leading `#` — write
-`"#3He"`, not `"3He"` (matching
-[AtomicAndPhysicalConstants.jl](https://github.com/bmad-sim/AtomicAndPhysicalConstants.jl)).
-Quoting also lets that `#` be written without tripping YAML's comment rule:
+Only scalars that are genuine expressions are touched. Names that happen to sit
+where a value could go — element and line references in a `line:`, `kind:`
+names, booleans, a `MetaP` description — are not expressions and are left
+alone. Immediate expressions (`length: 0.3 * r_electron`) and delayed ones
+(`Kn1: expr(3.74 * a_var)`) both become numbers; in the expanded tree the
+distinction no longer matters.
 
-```yaml
-m_e:     mass_of("electron")
-q_he:    charge_of("helion")
-b_const: 0.45 * mass_of("#3He")
-```
+A value that fails to evaluate is left as text rather than aborting the
+expansion, and it is reported as a problem *only if it looks like one* — an
+operator, a parenthesis, a `>` reference, or an explicit `expr(...)`. That is
+what keeps a plain name or a label from being mistaken for broken arithmetic.
 
-The argument may also be a **user constant or variable whose value is a species
-name**, passed by name (without quotes). This lets one definition fix the species
-and every expression refer to it:
+Some keys are excluded from evaluation outright, because their values are names
+or free-form prose that could otherwise collide with a constant or parse as
+arithmetic — `kind`, `use` and `inherit`, the fork targets, and the `authors`,
+`notes` and `reminders` prose among them.
 
-```yaml
-- constants:
-    species: "#3He"                 # a species-valued constant
-    b_const: 0.45 * mass_of(species) # resolves species -> "#3He"
-```
+Definitions are resolved in dependency order, so a value may reference one
+written later in the file as readily as one written earlier. A reference that
+cannot be resolved, or a genuine cycle, leaves the value as text and is
+reported.
 
-Such a species-valued constant may also be referenced **directly** wherever a
-species name is expected: a bare identifier used as a parameter value is
-replaced by the constant's species string in the expanded tree.
+### Randomness is deferred, never invented
+
+An expression that calls `random()` or `random_gauss()` is left as text, so that
+expanding the same lattice twice gives byte-identical output:
 
 ```yaml
-- begin:
-    kind: BeginningEle
-    ReferenceP:
-      species_ref: species          # -> "#3He" in `expanded`
+Kn2: 0.01 + 0.003*random_gauss()   # kept verbatim
 ```
 
-## User constants and variables
+The same rule reaches everywhere such an expression can appear: a control
+expression containing one is deferred and so drives nothing, and a `set` whose
+`value` calls one leaves its parameter untouched.
 
-A lattice can define its own constants and variables and refer to them by name
-from later expressions. Both the full form and the compact form are recognised:
+`absolute_error` and `relative_error` follow from the same principle. The
+standard gives the error *magnitude* — `absolute_error + relative_error *
+|value|` — but not its distribution, so this library reads them, writes the
+deterministic value, and reports a problem rather than picking a distribution
+on the author's behalf.
 
-```yaml
-facility:
-  # Full form.
-  - r_scaled:
-      kind: constant
-      value: 0.3 * r_electron
-  # Compact form (a seq of single-key maps, or a plain map — both accepted).
-  - constants:
-      a_const: 0.3 * r_electron
-      b_const: 0.45
-  - variables:
-      a_var: a_const^2          # may reference an earlier definition
-```
+## How controllers are applied
 
-Definitions are resolved in dependency order, so a later value may reference an
-earlier one (`a_var` uses `a_const` above). A reference that cannot be resolved,
-or a genuine cycle, leaves the value as text rather than aborting the expansion.
-
-## Element-parameter references
-
-An expression may also reference another element's parameter by name, using the
-`element>group.sub. ... .param` syntax (the same parameter path used elsewhere in
-the standard). It resolves to that parameter's value, itself evaluated as an
-expression:
-
-```yaml
-- thingB:
-    kind: Sextupole
-    MagneticMultipoleP:
-      Kn2L: 0.1
-- DH1A:
-    kind: Bend
-    BendP:
-      edge_int2: 0.02 * thingB>MagneticMultipoleP.Kn2L   # → 0.002
-```
-
-The reference names one specific element (an exact name — pattern matching is
-not used in a value expression) and its full parameter path. As with any other
-reference, one that cannot be resolved leaves the value as text.
-
-## Controllers
-
-A `Controller` element bundles expressions that drive lattice parameters. Its
-`variables:` form a symbol table *scoped to that controller*, and each
-`controls:` entry pairs a `parameter` target with an `expression`. During
-expansion the controller variables are evaluated against that scoped table, and
-each control `expression` is computed and written back into its control entry:
-
-```yaml
-- ps27:
-    kind: Controller
-    control_type: ABSOLUTE
-    variables:
-      cur1: 0.023
-      cur2: 1e8 / c_light       # a constant expression, as initial values are
-    controls:
-      - parameter: Qa.*>MagneticMultipoleP.Ks2L
-        expression: 0.075*sin(cur1) + 0.3*cur2   # → a number in `expanded`
-```
-
-A variable's **initial value is a constant expression**: it may use the built-in
-and user-defined constants and the functions, but no variable at all — not even
-another variable of the same controller. That is what makes the initial values
-independent of the order they are written in. A variable written with no value
-is zero.
-
-A control **`expression` uses its own controller's variables**, and nothing from
-outside the controller: neither an initial value nor a control expression may
-reference a lattice parameter or another controller's variable. Both of those
-are spelled with `>`, and keeping them out is what makes the evaluation order
-well defined. The `parameter` target specification and `control_type` are names,
-not expressions, and are left untouched.
-
-### How controllers are applied
-
-The `parameter` target is a [name-matching string](../api.md#name-matching), so one entry
-drives every element it matches. What happens to those parameters depends on
-`control_type`:
+A `Controller`'s `variables` are evaluated as constant expressions, each
+`controls` entry's `expression` is evaluated against that controller's own
+variable table, and the result is written back into the control entry. What then
+happens to the driven parameters depends on `control_type`:
 
 - **`ABSOLUTE`** (the default, materialized into the tree when the key is
   omitted) means the controllers determine the parameter outright. Each matched
@@ -203,64 +100,31 @@ drives every element it matches. What happens to those parameters depends on
   changes nothing during expansion: the parameter keeps the value its element
   gives, and only the control expression is evaluated, for the program's use.
 
+A `parameter` target is a [name-matching string](../api.md#name-matching), so
+one entry drives every element it matches. Controllers may drive other
+controllers' variables, forming a hierarchy that is evaluated from the top down;
+a driven variable takes its driving value instead of its own initial value. The
+order controllers are written in the file does not matter.
+
 The controllers are applied after the branches are expanded and before the
 element bookkeeper runs, so the reference, floor and dependent parameters are
 computed from the driven values — a driven `Kn1L` yields the matching `Bn1L`.
 
-A controller may also drive another controller's variable, which is named
-`controller>variable`:
+These are reported as problems: a circular control hierarchy, a parameter driven
+by both an ABSOLUTE and a RELATIVE controller, a parameter that is both
+controlled and assigned a delayed (`expr(...)`) expression, a target that
+matches nothing in the expanded lattice, and a `control_type` that is neither
+`ABSOLUTE` nor `RELATIVE`.
 
-```yaml
-- high:
-    kind: Controller
-    variables:
-      knob: 3
-    controls:
-      - parameter: low>cur       # a variable of the `low` controller
-        expression: knob / 4
-```
-
-Controllers therefore form a hierarchy, which is evaluated from the top
-downwards; a driven variable takes its driving value instead of its own initial
-value. The order controllers are written in the file does not matter. These are
-reported as problems: a circular control hierarchy, a parameter driven by both
-an ABSOLUTE and a RELATIVE controller, a parameter that is both controlled and
-assigned a delayed (`expr(...)`) expression, a target that matches nothing in
-the expanded lattice, and a `control_type` that is neither `ABSOLUTE` nor
-`RELATIVE`.
-
-A control expression containing `random()`/`random_gauss()` is deferred like any
-other, keeping its text — and so drives nothing, leaving the expanded tree
-reproducible.
-
-## Set commands
-
-A `set` writes a value into every parameter its `parameter` name-matching string
-selects. In the `value` expression, `PARAMETER` stands for the current value of
-the parameter being written and `SELF` for the element that owns it:
-
-```yaml
-- set:
-    parameter: B1.*>BendP.e1
-    value: 2*PARAMETER + atan(SELF.BendP.g_ref)
-```
-
-Pattern matching applies to the `parameter` target only, never inside `value`.
-The compact form is a list of `target: value` pairs with no error terms:
-
-```yaml
-- sets:
-    - Q1>MagneticMultipoleP.Kn1L: 0.25
-    - D1>length: 2 * 1.5
-```
+## How sets are applied
 
 A parameter of a known element that has not been written reads as **zero**, so
 `PARAMETER + 0.02` works on an element that carries no such group yet — the
-group is created. The exception is a parameter that is *still to be derived*:
-if any member of its linked family is written (the four interchangeable forms
+group is created. The exception is a parameter that is *still to be derived*: if
+any member of its linked family has been written (the four interchangeable forms
 `BnN`/`BnNL`/`KnN`/`KnNL` of a magnetic multipole component, the two forms of an
-electric one, or the tied BendP geometry), then its value comes from the
-bookkeeper and reading it before that is an error:
+electric one, or the tied `BendP` geometry), its value is the bookkeeper's to
+compute and reading it beforehand is an error:
 
 ```yaml
 - Q1:
@@ -272,53 +136,42 @@ bookkeeper and reading it before that is an error:
     value: Q1>MagneticMultipoleP.Bs1   # error: Bs1 needs the reference momentum
 ```
 
-`absolute_error` and `relative_error` are read but **not applied**: the standard
-gives the error magnitude (`absolute_error + relative_error * |value|`) but not
-its distribution, and this library never invents randomness. The deterministic
-`value` is written and a problem is reported. A `value` that itself calls
-`random()`/`random_gauss()` is deferred like any other, leaving its parameter
-untouched.
-
 ### `expand_lattice` and where a set acts
 
 An `expand_lattice` node divides the `facility` list in two, and which side a
 set sits on decides what it writes:
 
-```yaml
-facility:
-  - q1:
-      kind: Quadrupole
-      MagneticMultipoleP:
-        Kn1L: 0.375
-  - bline:
-      kind: BeamLine
-      line:
-        - q1:
-            repeat: 3
-  - lat: {kind: Lattice, branches: bline}
-
-  - expand_lattice
-
-  - set:
-      parameter: lat>>>q1>MagneticMultipoleP.Kn1L
-      value: PARAMETER * (1 + 1e-4*random_gauss())
-```
-
 - **Before** `expand_lattice` a set acts on the element *definitions*, and only
   on those defined earlier in the list — an element defined after it is
-  untouched. One definition is written once, so all three copies of `q1` would
-  inherit the same value.
+  untouched. One definition is written once, so every copy of a repeated element
+  inherits the same value.
 - **After** `expand_lattice` a set acts on the already-expanded lattice, so each
-  of the three copies is a separate element and is written separately. The
-  bookkeeper has already run at this point, so a value may use computed
-  parameters such as `SELF.s_position`.
+  copy is a separate element and is written separately. The bookkeeper has
+  already run at this point, so a value may use computed parameters such as
+  `SELF.s_position`.
 
-The full expansion order is: pre-expansion sets → branch and fork expansion →
-ABSOLUTE controllers → bookkeeper → post-expansion sets → ABSOLUTE controllers
-again → bookkeeper again. Applying the controllers last is what keeps a
-controller authoritative over a parameter a later set also writes; the second
-bookkeeper pass recomputes the reference, floor and s-position values, and the
-family members a post-expansion set invalidated.
+## The order of the passes
+
+```text
+pre-expansion sets
+  → branch and fork expansion
+  → expression evaluation
+  → ABSOLUTE controllers
+  → element bookkeeper
+  → post-expansion sets
+  → expression evaluation
+  → ABSOLUTE controllers again
+  → element bookkeeper again
+```
+
+Applying the controllers last is what keeps a controller authoritative over a
+parameter a later set also writes. The second bookkeeper pass recomputes what
+those writes invalidated: the reference, floor and position values, and the
+family members a post-expansion set dropped.
+
+The snapshot that separates `expanded` from `full_expanded` is taken between the
+first expression evaluation and the first bookkeeper pass — see
+[The five trees](trees.md).
 
 ## Evaluating a single expression
 
@@ -333,7 +186,7 @@ double v = evaluate_pals_expression("3.75e7 / c_light^2", &ok);
 
 This evaluates a *standalone* string, so user-defined constants and variables
 are **not** in scope — use `parse_and_expand_PALS` for whole-lattice evaluation,
-whose `expanded` tree already has every expression resolved. `ok` is set to
+whose expanded trees already have every expression resolved. `ok` is set to
 `false` on a parse error, an unknown identifier or species, an unquoted species
 name, a `random()`/`random_gauss()` expression (intentionally deferred), or a
 non-finite result.

--- a/docs/src/guide/trees.md
+++ b/docs/src/guide/trees.md
@@ -1,0 +1,272 @@
+# The five trees
+
+`parse_and_expand_PALS` does not return *the* lattice. It returns five YAML
+trees, each a complete, independently owned view of the same document at a
+different stage of its derivation. Which one to read depends on the question
+being asked: what the file says, what the author wrote, or what the lattice
+actually is.
+
+The PALS standard deliberately leaves this open — it says what lattice expansion
+must produce, not how a parser must hold the result. The five trees are this
+library's answer, and everything on this page is pals-cpp's own arrangement
+rather than part of the standard.
+
+| Tree | Holds |
+| --- | --- |
+| `original` | every file, verbatim, keyed by path |
+| `combined` | those files spliced into one document |
+| `full_expanded` | one lattice, expanded, with every computed value |
+| `expanded` | the same lattice, back to the author's inputs |
+| `leftover` | everything the expanded trees do not carry |
+
+All five are `YAMLTreeHandle`s, and each must be freed with `delete_tree`.
+Freeing one leaves the other four intact.
+
+## A worked example
+
+```yaml
+PALS:
+  facility:
+    - constants:
+        k_q: 0.32
+    - begin:
+        kind: BeginningEle
+        ReferenceP:
+          species_ref: "electron"
+          E_tot_ref: 1.0e9
+    - d1: {kind: Drift, length: 2.0}
+    - q1:
+        kind: Quadrupole
+        length: 0.5
+        MagneticMultipoleP:
+          Kn1: k_q
+    - cell:
+        kind: BeamLine
+        line: [d1, q1]
+    - main:
+        kind: BeamLine
+        line:
+          - begin
+          - cell: {repeat: 2}
+    - lat1: {kind: Lattice, branches: [main]}
+    - use: "lat1"
+```
+
+### `original` and `combined`
+
+`original` maps each file the document is built from — the top-level file and
+every file it reaches by `include` or `load`, at any depth — to its unparsed
+contents, keyed by path. Nothing is resolved and nothing is evaluated: an
+expression is still its text, and `Kn1` is still `k_q`. For a single-file
+document it is that one file under its own name.
+
+`combined` is the same content as one document: every `include` spliced inline
+where the directive stood, and every `load`ed file merged in subnode by subnode
+under the `PALS` root. It is still unevaluated — this is the document as though
+it had been written as one file.
+
+### `full_expanded`
+
+The selected lattice, expanded, and nothing else:
+
+```yaml
+lat1:
+  kind: Lattice
+  branches:
+    - main:
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: electron
+                E_tot_ref: 1e+09
+                pc_ref: 999999869.4400277
+                time_ref: 0
+              FloorP: {x: 0, y: 0, z: 0, theta: 0, phi: -0, psi: 0}
+              s_position: 0
+              element_index: 1
+          - d1:
+              kind: Drift
+              length: 2
+              # ... ReferenceP, FloorP ...
+              s_position: 0
+              element_index: 2
+          - q1:
+              kind: Quadrupole
+              length: 0.5
+              MagneticMultipoleP:
+                Kn1: 0.32
+                Kn1L: 0.16
+                Bn1: -1.0674049652737057
+                Bn1L: -0.5337024826368528
+              # ... ReferenceP, FloorP ...
+              s_position: 2
+              element_index: 3
+          # ... the second copy of the cell: d1, q1 ...
+          - branch_end:
+              kind: Placeholder
+              # ... ReferenceP, FloorP ...
+              s_position: 5
+              element_index: 6
+```
+
+Note what the shape is, before the values. The tree is rooted at the lattice
+entry itself, stripped of the `PALS`/`facility` scaffolding it was defined
+under, so its root map holds the single `lat1:` entry. The `branches:` entries
+are **branches, not the BeamLines they were built from**, and so carry no
+`kind:` — `main` was a `kind: BeamLine` definition in the file and is a branch
+here. A BeamLine referenced inside a `line:` is a sub-line whose contents are
+spliced straight into the enclosing line, so no nested BeamLine survives either:
+`cell` is gone and its two elements appear twice, flat, where the `repeat: 2`
+put them.
+
+### What the expansion adds
+
+Everything below is written by pals-cpp into `full_expanded` and appears in no
+other tree.
+
+**Per element, from the element bookkeeper:**
+
+- `element_index` — the element's position in the branch line that holds it,
+  counting from one. Every entry of the line is counted, so this is the array
+  index the element sits at. It restarts at one in each branch, and it is a
+  position rather than an identity: the two `d1` copies above are indices 2 and
+  4.
+- `s_position` — the longitudinal position of the element's upstream end.
+- `ReferenceP` — the reference species, energy, momentum and time, threaded
+  along the branch from the beginning element (or from the `Fork` that created
+  the branch) and propagated through each element in turn.
+- `FloorP` — the element's floor placement, likewise accumulated along the
+  branch.
+- The **derived members of every parameter family** the element uses: an
+  authored `Kn1` brings `Kn1L`, `Bn1` and `Bn1L` with it, a `gradient` brings a
+  `voltage`, an authored pair of bend geometry parameters brings the rest.
+- The **non-zero defaults** of every parameter group the element carries.
+  Presence of the group is what triggers this: a group the element does not
+  carry is not materialized.
+
+**Per branch:**
+
+- A `branch_end` element, a zero-length `Placeholder` appended after the last
+  real element of every non-empty branch. It exists to hold the branch's final
+  state — the reference and floor at the downstream end of the last element —
+  which nothing else in the tree records. It is an element of the line like any
+  other, so it is numbered with the rest (index 6 above).
+
+**Where the lattice's own structure needs recording:**
+
+- `multipass_index` on the elements of a `multipass` line, giving the pass
+  number: how many times a particle will have travelled through that physical
+  element by that point.
+- `ForkP.forked_to` on each resolved `Fork`, naming the destination it actually
+  reached as `{branch}>>{element}`, and a matching `ForkFromP` back-reference on
+  that destination, one entry per incoming Fork.
+
+Every expression in the tree has been evaluated to a number, every `set`
+executed, and every ABSOLUTE controller applied to the parameters it drives.
+See [Evaluating expressions](expressions.md) for when each of those happens.
+
+### `expanded`
+
+The same lattice with all of that removed:
+
+```yaml
+lat1:
+  kind: Lattice
+  branches:
+    - main:
+        line:
+          - begin:
+              kind: BeginningEle
+              ReferenceP:
+                species_ref: electron
+                E_tot_ref: 1e+09
+          - d1: {kind: Drift, length: 2}
+          - q1:
+              kind: Quadrupole
+              length: 0.5
+              MagneticMultipoleP: {Kn1: 0.32}
+          - d1: {kind: Drift, length: 2}
+          - q1:
+              kind: Quadrupole
+              length: 0.5
+              MagneticMultipoleP: {Kn1: 0.32}
+```
+
+What stays is decided by **what the author wrote**, recorded as a snapshot of
+the lattice's shape taken at the last moment it held the inputs and nothing
+else: after expansion and expression evaluation, before the bookkeeper. A
+parameter is kept when it was present in that snapshot or was written by a
+post-`expand_lattice` `set`; everything else the bookkeeper computed is cut,
+along with any group left empty by the cutting and the `branch_end` elements.
+`kind` is always kept — it says what an element is, not how it was set up.
+
+Two consequences worth being clear about:
+
+- The **values are the finished ones**. This is `full_expanded` with nodes
+  removed, not a snapshot taken earlier, so a parameter present in both trees
+  carries the same value in both — expressions evaluated, sets applied,
+  ABSOLUTE controllers applied. `Kn1` reads `0.32` here, not `k_q`.
+- The distinction is *authored versus computed*, not *input versus output*. A
+  `multipass_index` survives into `expanded` because it is stamped during
+  expansion, before the snapshot; an `element_index` does not, because the
+  bookkeeper writes it after.
+
+Use `expanded` to see what was asked for rather than what it implies, or to
+write a lattice back out without the derived values.
+
+### `leftover`
+
+Everything the expanded trees do not carry, keeping the `PALS`/`facility`
+scaffolding it was written under: element and beamline definitions, `use`
+statements, constants and variables, controllers, `set` commands, and any
+`Lattice` that was not the one expanded.
+
+A definition substituted into the lattice is *copied* rather than moved, so it
+appears in both places: `d1` above is in the expanded lattice twice and still
+standing in `leftover` once, as the definition those two copies were made from.
+
+## Choosing a tree
+
+- **What does this lattice actually do?** `full_expanded`. It is the only tree
+  that carries a dependent parameter, and the only one where each copy of a
+  repeated element is a separate element with its own position and reference.
+- **What did the author write?** `expanded` for the lattice, `leftover` for
+  everything around it — the constants, the definitions, the controllers.
+- **Where in the file did this come from?** `original` and `combined`, which
+  alone keep the expression text and the file structure.
+- **Writing a lattice back out?** `expanded` plus `leftover`.
+
+`get_lattice_parameter_value` takes the pair that between them hold every value
+a lattice has: `full_expanded` for element parameters and `leftover` for
+constants, variables and unused definitions.
+
+## Tracking a node across the trees
+
+`build_correspondence_map` links a node to its counterparts in the other trees.
+The link is recorded as each tree is derived from the one before it, not
+reconstructed afterwards by matching paths or names, so it survives the
+rearrangement that expansion does: one definition in `combined` maps to every
+copy expansion made of it.
+
+`original`, `combined`, `full_expanded` and `leftover` take part. `expanded`
+does not: it is a pruned copy of `full_expanded` rather than a derivation of its
+own, so its nodes are found by path.
+
+A node the expansion *created* — a `ReferenceP`, an `element_index`, a
+`branch_end` — has no counterpart anywhere upstream and so appears in no link.
+That is the correspondence map's answer to "where did this come from": nowhere,
+it was computed.
+
+## Problems
+
+Expansion does not abort on a recoverable problem. Instead it leaves the
+offending value as it found it and appends a message to the `problems` list the
+`lattices` struct also carries: an undefined lattice, a `line` reference to an
+undefined element, a missing `inherit`/`repeat`/`Fork` target, a branch whose
+reference parameters cannot be computed, an expression that could not be
+evaluated. The list is empty when expansion was clean, and the caller owns it —
+release it with `free_lattice_problems`.
+
+The library never prints. Whether to report, save, or ignore the messages is the
+caller's decision.

--- a/docs/src/guide/usage.md
+++ b/docs/src/guide/usage.md
@@ -23,7 +23,7 @@ tests. Put lattice files under `lattice_files/`.
 expands the selected lattice, and returns a `lattices` struct with five
 independent views —
 `original`, `combined`, `expanded`, `full_expanded`, and `leftover` (see
-[What it does](../index.md)). Each is a `YAMLTreeHandle` and must be freed with
+[The five trees](trees.md)). Each is a `YAMLTreeHandle` and must be freed with
 `delete_tree`.
 
 ```cpp
@@ -63,6 +63,13 @@ whether to report, save, or ignore the messages — and must release the list wi
 `free_lattice_problems`. Only values that look like expressions (an operator, a
 parenthesis, a `>` reference, or an explicit `expr(...)`) are flagged when they
 fail to evaluate, so plain names and labels are not mistaken for broken math.
+
+### Reading the expanded lattice
+
+Which of the five trees answers a given question, and what the expansion adds to
+`full_expanded` that appears nowhere else — `element_index`, `s_position`,
+`ReferenceP`, `FloorP`, the derived parameter families, the `branch_end` cap —
+is covered in [The five trees](trees.md).
 
 ## Navigating and editing trees
 
@@ -119,12 +126,17 @@ The `examples/` directory contains runnable programs:
   ./example_rw
   ```
 
-- **`examples/print_lattices`** — expand a lattice and print all four views. It
-  takes a file name and an optional `-lat <name>` flag:
+- **`examples/print_lattices`** — expand a lattice and print all five views. It
+  takes a file name and an optional `-lat <name>` flag naming the lattice to
+  expand:
 
   ```console
   ./print_lattices ex.pals.yaml -lat lat2
   ```
+
+  The file name is resolved under `../lattice_files/`, so run it from a
+  directory that sits beside `lattice_files/` — `build/`, say — and put the
+  lattice in `lattice_files/`.
 
 ## Extensions
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,6 +13,7 @@ a C API (`yaml_c_wrapper.h`) that other languages — such as
 :caption: User Guide
 
 guide/usage
+guide/trees
 guide/expressions
 ```
 
@@ -25,41 +26,30 @@ api
 
 ## What it does
 
-Lattice expansion follows the PALS specification and produces five views of a
-document:
+Lattice expansion follows the PALS specification: elements are substituted with
+their definitions, `repeat`ed beamlines unrolled, `inherit`ed ancestors merged,
+forks resolved, expressions evaluated, `set` commands executed, controllers
+applied, and the reference, floor and dependent parameters computed.
 
-1. **`original`** — the raw tree mapping each file the document is built from —
-   the top-level file and every file it reaches by `include` or `load`, at any
-   depth — to its unparsed contents, keyed by path.
-2. **`combined`** — the tree with every `include` directive resolved and spliced
-   inline, and every `load`ed file merged in subnode by subnode under the `PALS`
-   root.
-3. **`full_expanded`** — the selected lattice fully expanded, and nothing else:
-   elements substituted with their definitions, `repeat`ed beamlines unrolled,
-   `inherit`ed ancestors merged, forks resolved, every mathematical expression
-   evaluated to a number, `set` commands executed, and the ABSOLUTE controllers
-   applied to the parameters they drive. It is rooted at the lattice entry
-   itself, without the `PALS`/`facility` scaffolding it was defined under. Every
-   dependent parameter has been computed: each element carries its `ReferenceP`,
-   `FloorP` and `s_position`, the derived members of every parameter family it
-   uses, and the non-zero defaults of the groups it carries; each branch is
-   capped with a `branch_end` Placeholder holding its final reference and floor.
-4. **`expanded`** — the same lattice with all of that removed. What the author
-   wrote decides which parameters stay; the values are the finished ones. It is
-   `full_expanded` with nodes removed rather than an earlier snapshot, so a
-   parameter present in both trees holds the same value in both, with every
-   `set` and ABSOLUTE controller applied. Use it to see the inputs rather than
-   their consequences, or to write a lattice back out without the computed
-   values.
-5. **`leftover`** — everything the expanded trees do not carry, keeping that
-   scaffolding: element and beamline definitions, `use` statements, constants,
-   controllers, `set` commands, and any lattice that was not the one expanded.
-   A definition substituted into the lattice is copied, so it appears in both
-   views.
+The result is returned as five independent views of the document:
 
-See [Building and using the library](guide/usage.md) to get started,
-[Evaluating expressions](guide/expressions.md) for the expression grammar and
-evaluation model, and the [API Reference](api.md) for the full C interface.
+| Tree | Holds |
+| --- | --- |
+| `original` | every file the document is built from, verbatim, keyed by path |
+| `combined` | those files spliced into one document, still unevaluated |
+| `full_expanded` | one lattice, expanded, with every computed value |
+| `expanded` | the same lattice, back to the author's inputs |
+| `leftover` | everything the expanded trees do not carry — definitions, constants, controllers, unexpanded lattices |
+
+See [The five trees](guide/trees.md) for what each one holds and which to reach
+for, [Building and using the library](guide/usage.md) to get started,
+[Evaluating expressions](guide/expressions.md) for this library's evaluation
+model, and the [API Reference](api.md) for the full C interface.
+
+The PALS standard itself — the schema, the element kinds and parameter groups,
+the expression grammar, the built-in constants and functions — is documented at
+[pals-project.readthedocs.io](https://pals-project.readthedocs.io) and is not
+restated here.
 
 ## Quick start
 

--- a/src/pals_check.cpp
+++ b/src/pals_check.cpp
@@ -255,7 +255,7 @@ const std::set<std::string>& element_params(const std::string& kind) {
     static const std::set<std::string> base = {
         "field_master", "is_on",  "kind",      "length",
         "name",         "s_position", "inherit", "direction",
-        "multipass_index"};
+        "multipass_index", "element_index"};
     static const std::set<std::string> beamline = [] {
         std::set<std::string> s = base;
         s.insert({"line", "multipass", "zero_point", "repeat"});

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -1452,7 +1452,7 @@ static const std::set<std::string>& non_expr_keys() {
         "inherit",    "zero_point",  "to_line",
         "destination_element", "new_branch", "multipass",
         "propagate_reference", "name", "multipass_index",
-        "destination_pointer", "forked_to",
+        "element_index", "destination_pointer", "forked_to",
         "authors",    "notes",       "reminders"};
     return keys;
 }
@@ -3591,6 +3591,17 @@ static void _element_bookkeeper(ryml::Tree& t, size_t prev, size_t ele,
     compute_rf_dependent(t, ele, length, problems);
 }
 
+// Stamp `element_index: n` on an element definition: the element's position in
+// the branch line that holds it, counting from one.
+//
+// Every entry of the line is counted, so the index is the array index the
+// element sits at even when an entry before it is a bare name the expansion
+// could not resolve and so has no definition to fill in. The `branch_end` cap
+// is an element of the line like any other and is numbered with the rest.
+static void set_element_index(ryml::Tree& t, size_t ele, size_t index) {
+    set_plain_child(t, ele, "element_index", std::to_string(index).c_str());
+}
+
 // Append a zero-length `Placeholder` element named `branch_end` to a branch's
 // `line` and return its definition node. This is the marker that holds the
 // branch's final floor placement and reference parameters; the bookkeeper fills
@@ -3675,8 +3686,10 @@ static void run_element_bookkeeper(ryml::Tree& t, size_t lat_node,
         if (line == ryml::NONE || !t.is_seq(line)) continue;
 
         size_t prev = ryml::NONE;
+        size_t index = 0;  // position in `line` of the entry being visited
         for (size_t le = t.first_child(line); le != ryml::NONE;
              le = t.next_sibling(le)) {
+            ++index;
             // A line entry is a wrapper map whose first child is the keyed
             // element definition; bare unresolved references have no parameters.
             if (!t.is_map(le)) continue;
@@ -3690,6 +3703,7 @@ static void run_element_bookkeeper(ryml::Tree& t, size_t lat_node,
                 if (it != fork_seed.end()) seed = it->second;
             }
             _element_bookkeeper(t, prev, def, problems, seed);
+            set_element_index(t, def, index);
             if (first) check_branch_reference(t, branch, def, problems);
 
             // Record where a Fork propagates its reference/floor to. Propagation
@@ -3730,8 +3744,13 @@ static void run_element_bookkeeper(ryml::Tree& t, size_t lat_node,
         // just bookkept it like any other element, so there is nothing to add.
         bool capped = prev != ryml::NONE &&
                       t.key(prev) == ryml::to_csubstr("branch_end");
-        if (prev != ryml::NONE && !capped)
-            _element_bookkeeper(t, prev, append_branch_end(t, line), problems);
+        if (prev != ryml::NONE && !capped) {
+            size_t cap = append_branch_end(t, line);
+            _element_bookkeeper(t, prev, cap, problems);
+            // Appended past the last entry the loop counted, so it takes the
+            // next index.
+            set_element_index(t, cap, index + 1);
+        }
     }
 }
 

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -204,7 +204,9 @@ extern "C" {
  * survives. Elements of a `multipass` line carry a `multipass_index` giving
  * their pass number — how many times a particle will have travelled through
  * that physical element by that point. Every dependent parameter has been
- * computed: each element carries its `ReferenceP`, `FloorP` and `s_position`,
+ * computed: each element carries its `element_index` — its position, counting
+ * from one, in the branch line that holds it — its `ReferenceP`, `FloorP` and
+ * `s_position`,
  * the derived members of every parameter family it uses (`Kn1L` alongside
  * `Kn1`, `voltage` alongside `gradient`, ...), the non-zero defaults of the
  * groups it carries, and each branch is capped with a `branch_end` Placeholder

--- a/tests/test_bookkeeper.cpp
+++ b/tests/test_bookkeeper.cpp
@@ -183,6 +183,100 @@ TEST_CASE("Bookkeeper caps each branch with a branch_end Placeholder",
     delete_tree(lat.leftover);
 }
 
+TEST_CASE("Bookkeeper numbers each element with its position in the branch",
+          "[bookkeeper]") {
+    struct lattices lat = expand_bookkeeper();
+    YAMLTreeHandle t = lat.full_expanded;
+
+    // element_index counts from one along the branch line, so it is the array
+    // index of the element rather than an offset. The `branch_end` cap is an
+    // element of the line like any other and takes the next number after the
+    // last real one.
+    const char* order[] = {"begin", "d1", "q1", "b1", "d2", "end", "branch_end"};
+    for (size_t i = 0; i < 7; ++i)
+        REQUIRE(param_num(t, order[i], nullptr, "element_index") ==
+                static_cast<double>(i + 1));
+
+    // It is written as a plain integer, not through the double formatter that
+    // gives the physical parameters their shortest round-tripping decimal.
+    REQUIRE(val_eq(t, get_child_by_key(t, find_by_key(t, "q1"), "element_index"),
+                   "3"));
+
+    // Being computed, it belongs to `full_expanded` alone; `expanded` carries
+    // what the author wrote.
+    REQUIRE(get_child_by_key(lat.expanded, find_by_key(lat.expanded, "q1"),
+                             "element_index") == YAML_NULL_ID);
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
+    delete_tree(lat.leftover);
+}
+
+TEST_CASE("element_index restarts at one in each branch", "[bookkeeper]") {
+    // A Fork gives the lattice a second branch. The index is a position within
+    // the branch that holds the element, not a running count over the lattice,
+    // so the forked branch starts again at one.
+    const char* path = "tmp_element_index_fork.pals.yaml";
+    write_tmp(path,
+              "PALS:\n"
+              "  facility:\n"
+              "    - dump_begin:\n"
+              "        kind: BeginningEle\n"
+              "        ReferenceP:\n"
+              "          species_ref: \"electron\"\n"
+              "          E_tot_ref: 1.0e9\n"
+              "    - dump_end:\n"
+              "        kind: Marker\n"
+              "    - dump_line:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - dump_begin\n"
+              "          - dump_end\n"
+              "    - ring:\n"
+              "        kind: BeamLine\n"
+              "        line:\n"
+              "          - begin:\n"
+              "              kind: BeginningEle\n"
+              "              ReferenceP:\n"
+              "                species_ref: \"electron\"\n"
+              "                E_tot_ref: 1.0e9\n"
+              "          - drift1:\n"
+              "              kind: Drift\n"
+              "              length: 1.0\n"
+              "          - f1:\n"
+              "              kind: Fork\n"
+              "              ForkP:\n"
+              "                to_line: dump_line\n"
+              "    - lat1:\n"
+              "        kind: Lattice\n"
+              "        branches:\n"
+              "          - ring\n"
+              "    - use: \"lat1\"\n");
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    YAMLTreeHandle t = lat.full_expanded;
+
+    // ring: begin, drift1, f1, branch_end.
+    REQUIRE(param_num(t, "begin", nullptr, "element_index") == 1.0);
+    REQUIRE(param_num(t, "drift1", nullptr, "element_index") == 2.0);
+    REQUIRE(param_num(t, "f1", nullptr, "element_index") == 3.0);
+
+    // dump_line: numbered from one again, and capped by its own branch_end.
+    REQUIRE(param_num(t, "dump_begin", nullptr, "element_index") == 1.0);
+    REQUIRE(param_num(t, "dump_end", nullptr, "element_index") == 2.0);
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
+    delete_tree(lat.leftover);
+    rm_tmp(path);
+}
+
 // A branch with a single RFCavity, whose RFP body is spliced in from `rfp_body`
 // (raw YAML at 16-space indentation). Lets each RF test set voltage/gradient/
 // L_active as it likes.

--- a/tests/test_expanded_minus_dependent.cpp
+++ b/tests/test_expanded_minus_dependent.cpp
@@ -238,15 +238,17 @@ TEST_CASE("expanded drops the parameters the bookkeeper computed",
           "[expanded]") {
     struct lattices lat = expand_string(SPLIT_YAML, "tmp_split.pals.yaml");
 
-    // Reference, floor and s-position are computed for every element; none of
-    // them survives, and on an element that authored nothing they leave no
-    // trace at all.
+    // Reference, floor, s-position and element index are computed for every
+    // element; none of them survives, and on an element that authored nothing
+    // they leave no trace at all.
     for (const char* ele : {"q1", "rf1", "mark"}) {
         REQUIRE(find_by_key(lat.expanded, ele) != YAML_NULL_ID);
         REQUIRE(has_param(lat.full_expanded, ele, "ReferenceP", "pc_ref"));
+        REQUIRE(has_param(lat.full_expanded, ele, nullptr, "element_index"));
         REQUIRE_FALSE(has_param(lat.expanded, ele, nullptr, "ReferenceP"));
         REQUIRE_FALSE(has_param(lat.expanded, ele, nullptr, "FloorP"));
         REQUIRE_FALSE(has_param(lat.expanded, ele, nullptr, "s_position"));
+        REQUIRE_FALSE(has_param(lat.expanded, ele, nullptr, "element_index"));
     }
 
     // The authored member of a multipole family stays; the three derived from

--- a/tests/test_key_order.cpp
+++ b/tests/test_key_order.cpp
@@ -112,15 +112,16 @@ TEST_CASE("Expansion preserves the key order of the source file", "[key_order]")
     // child's own, rather than sorting the merged result. `main_line` is a
     // `multipass` root line, so its one element also picks up a trailing
     // `multipass_index`, appended after the inherited keys. Finally, the element
-    // bookkeeper appends its computed output groups (`ReferenceP`, `FloorP`) and
-    // `s_position`, in that order, after everything the file supplied.
+    // bookkeeper appends its computed output groups (`ReferenceP`, `FloorP`),
+    // `s_position` and `element_index`, in that order, after everything the file
+    // supplied.
     YAMLNodeId line_seq = get_child_by_key(lat.full_expanded, e_line, "line");
     YAMLNodeId thingZ = get_child_by_index(
         lat.full_expanded, get_child_by_index(lat.full_expanded, line_seq, 0), 0);
     REQUIRE(key_eq(lat.full_expanded, thingZ, "thingZ"));
     const std::vector<std::string> inherited = {
-        "kind",           "length",     "inherit", "multipass_index",
-        "ReferenceP",     "FloorP",     "s_position"};
+        "kind",           "length",     "inherit",    "multipass_index",
+        "ReferenceP",     "FloorP",     "s_position", "element_index"};
     REQUIRE(keys_of(lat.full_expanded, thingZ) == inherited);
     REQUIRE(val_eq(lat.full_expanded,
                    get_child_by_key(lat.full_expanded, thingZ, "multipass_index"),


### PR DESCRIPTION
Adds `element_index` to every element of the full expanded lattice, and documents the five trees.

## `element_index`

The element's position in the branch line that holds it, counting from one, stamped by the element bookkeeper alongside `s_position`:

```yaml
- q1:
    kind: Quadrupole
    length: 0.5
    MagneticMultipoleP: {Kn1: 0.32, Kn1L: 0.16, Bn1: -1.067…, Bn1L: -0.533…}
    ReferenceP: {…}
    FloorP: {…}
    s_position: 2
    element_index: 3
```

Three decisions worth stating:

- **Every entry of the line is counted**, including one the expansion could not resolve to a definition. That keeps the value the array index the element sits at rather than a count of the entries that worked out.
- **`branch_end` is numbered with the rest.** It is an element of the line like any other, so it takes the next index after the last real one.
- **The numbering restarts in each branch.** It is a position, not an identity — the two copies of a repeated element carry different indices, and a forked branch starts again at one.

Being computed, it belongs to `full_expanded` alone. Nothing was needed to keep it out of `expanded`: pruning works off the authored-shape snapshot taken before the bookkeeper runs. That gives the two index parameters a contrast now pinned by tests — a `multipass_index` survives into `expanded` because expansion stamps it *before* the snapshot, an `element_index` does not.

Also added to `pals_check.cpp`'s allowed ungrouped element parameters and to `non_expr_keys()`, matching what `multipass_index` already does.

## Documentation

`docs/src/guide/trees.md` is new — what each of the five trees holds, a worked example of one lattice through `expanded`, `full_expanded` and `leftover` (output taken from `print_lattices`, not hand-written), and an explicit inventory of what expansion adds to `full_expanded` and to nothing else: `element_index`, `s_position`, `ReferenceP`, `FloorP`, the derived parameter families, the materialized group defaults, the `branch_end` cap, `multipass_index`, and the `forked_to`/`ForkFromP` link pair. Then what decides the `expanded`/`full_expanded` boundary, how correspondence works across the trees, and which tree answers which question.

Material belonging to the PALS standard rather than to this library comes out of `expressions.md` — the built-in constants table, the function lists, and the syntax for constants, variables, controllers and sets, all of which are documented at pals-project.readthedocs.io. It is 339 lines down to 192, and what remains says what pals-cpp *does* with the expression language: when evaluation runs, the "looks like an expression" rule that decides what gets reported, deferred randomness, how ABSOLUTE and RELATIVE are applied, where a `set` acts relative to `expand_lattice`, the pass order, and `evaluate_pals_expression`. Two things stay because the standard does not fix them and this library therefore has to: `^` right-associativity with the looser unary sign, and the species-name quoting convention.

`index.md`'s five-paragraph tree description collapses to a table plus a link.

## Testing

All 239 test cases / 1331 assertions pass. New coverage for the numbering, the plain-integer formatting, the per-branch restart across a `Fork`, and the absence from `expanded`; `test_key_order.cpp` picks up the new trailing key. Sphinx builds with no warnings. PALSJulia's suite passes unchanged against the rebuilt library — its translators ignore unrecognized ungrouped keys.

## Noted, not changed here

`examples/print_lattices.cpp` segfaults on any file it cannot find: it hardcodes a `../lattice_files/` prefix and then streams `tree_to_string`'s null return into `std::cout`. Pre-existing on `main`. `usage.md` now documents the actual path behaviour (and says five views rather than four) instead of the program being changed under this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
