### PR TITLE
Fix sign of the bend rotation axis for tilted bends

### DIFF
--- a/src/pals_floor.cpp
+++ b/src/pals_floor.cpp
@@ -121,9 +121,11 @@ void bend_LS(double length, double angle, double tilt_ref, Vec3& L, Quat& S) {
     // tilt_ref about z.
     Vec3 L_tilde{rho * (std::cos(angle) - 1.0), 0.0, rho * std::sin(angle)};
     L = quat_rotate(quat_rot_z(tilt_ref), L_tilde);
-    // Rotation axis u = (-sin(tilt_ref), -cos(tilt_ref), 0), angle = angle_ref
-    // (Eq. ustt). u is a unit vector.
-    S = quat_from_axis_angle(Vec3{-std::sin(tilt_ref), -std::cos(tilt_ref), 0.0},
+    // Rotation axis u = (sin(tilt_ref), -cos(tilt_ref), 0), angle = angle_ref
+    // (Eq. ustt). u is a unit vector: the untilted axis (0, -1, 0) carried around
+    // by R_z(tilt_ref), the same tilt applied to L_tilde above, which is what
+    // keeps the frame tangent to the arc it is travelling along.
+    S = quat_from_axis_angle(Vec3{std::sin(tilt_ref), -std::cos(tilt_ref), 0.0},
                              angle);
 }
 

--- a/tests/test_floor.cpp
+++ b/tests/test_floor.cpp
@@ -139,7 +139,9 @@ TEST_CASE("bend_LS in the horizontal plane matches the arc geometry", "[floor]")
 
 TEST_CASE("bend_LS with tilt pi/2 bends vertically", "[floor]") {
     // tilt_ref = pi/2 rotates the bend plane into y-z: the displacement moves
-    // into +y and the downstream z-axis tips upward to (0, sin angle, cos angle).
+    // into -y and the downstream z-axis tips downward to (0, -sin angle,
+    // cos angle). tilt_ref = +pi/2 is a downward bend, and the heading has to
+    // follow the displacement rather than tip against it.
     const double len = 1.5, ang = 0.15;
     const double rho = len / ang;
     Vec3 L;
@@ -147,7 +149,32 @@ TEST_CASE("bend_LS with tilt pi/2 bends vertically", "[floor]") {
     bend_LS(len, ang, kPi / 2, L, S);
 
     chk_vec(L, 0.0, rho * (std::cos(ang) - 1.0), rho * std::sin(ang));
-    chk_vec(quat_rotate(S, Vec3{0, 0, 1}), 0.0, std::sin(ang), std::cos(ang));
+    chk_vec(quat_rotate(S, Vec3{0, 0, 1}), 0.0, -std::sin(ang), std::cos(ang));
+}
+
+TEST_CASE("bend_LS keeps the frame tangent to the arc at any tilt", "[floor]") {
+    // The general statement behind the two cases above: whatever tilt_ref does to
+    // the bend plane, the downstream z-axis must be the tangent to the arc that
+    // L traces. Eqs. ustt and srrr are two spellings of that one rotation, so
+    // they must agree; they do only for u's first component = +sin(tilt_ref).
+    const double len = 1.5, ang = 0.15;
+    for (double tilt : {0.0, 0.3, kPi / 2, 2.0, kPi, -0.7}) {
+        Vec3 L;
+        Quat S;
+        bend_LS(len, ang, tilt, L, S);
+
+        // Eq. srrr: S = R_z(tilt) R_y(-ang) R_z(-tilt).
+        Quat srrr = quat_mul(quat_rot_z(tilt),
+                             quat_mul(quat_rot_y(-ang), quat_rot_z(-tilt)));
+        chk_same_rotation(S, srrr);
+
+        // And the heading is the arc's tangent: R_z(tilt) applied to the untilted
+        // tangent (-sin ang, 0, cos ang).
+        Vec3 tangent = quat_rotate(quat_rot_z(tilt),
+                                   Vec3{-std::sin(ang), 0.0, std::cos(ang)});
+        Vec3 zaxis = quat_rotate(S, Vec3{0, 0, 1});
+        chk_vec(zaxis, tangent.x, tangent.y, tangent.z);
+    }
 }
 
 TEST_CASE("bend_LS with a ~zero angle degenerates to a straight segment",


### PR DESCRIPTION
## Summary

`bend_LS` built the reference-coordinate rotation from the standard's Eq. `ustt` as `u = (-sin(tilt_ref), -cos(tilt_ref), 0)`. That first component has the wrong sign, which makes Eq. `ustt` a **different rotation** from Eq. `srrr` (`S = R_z(t) R_y(-a) R_z(-t)`) for any bend rolled out of its branch's x-z plane.

Only the `srrr` form is consistent with the displacement `L`, which Eq. `lrztt` builds as `R_z(tilt_ref) * L_tilde` — the untilted bend turned bodily about z — so the coordinate rotation has to be the untilted one conjugated the same way. The axis is just the untilted axis `(0, -1, 0)` carried around by that same `R_z(tilt_ref)`.

With the old sign the frame's z axis came off the tangent to the arc it was travelling along by about `2 sin(angle) sin(tilt)`.

The corresponding fix to Eq. `ustt` has been made in the pals standard.

## Tests

The `tilt = pi/2` test encoded the bug rather than catching it: it asserted the displacement moves toward `-y` while the heading tips toward `+y`. Per the standard, `tilt_ref = +pi/2` is a downward bend, so both go down. Corrected, and added a test that `bend_LS` agrees with Eq. `srrr` and stays tangent to its own arc across a range of tilts.

All 240 test cases (1403 assertions) pass.

## Compatibility

This changes floor coordinates downstream of any tilted bend. Lattices with `tilt_ref = 0` throughout are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
