### PR TITLE
Move the developer notes into the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,68 +49,13 @@ The [PALSJulia.jl](https://github.com/pals-project/PALSJulia.jl) package is an e
 - Provide a translator from `PALS` files to [`Bmad`](https://github.com/bmad-sim/bmad-ecosystem) lattice files.
 - Provide a translator from `PALS` files to [`SciBmad`](https://github.com/bmad-sim/SciBmad.jl) lattice files.
 
-## Developer Notes
+## Documentation
 
-### Source layout
-The library sources live in `src/`, split by concern:
+The full documentation — the user guide, the five-tree model, the expression
+evaluation rules, and the generated C API reference — is at
+<https://pals-project.github.io/pals-cpp/>.
 
-- `yaml_c_wrapper.h` — the public C API: the opaque handle types and every
-  exported function. This is the only header consumers include.
-- `yaml_c_wrapper.cpp` — the generic YAML tree wrapper over rapidyaml (parse,
-  traverse, query, modify, emit). Knows nothing about PALS.
-- `yaml_tree.h` — internal declarations shared between the wrapper and the PALS
-  code: the tree representation behind `YAMLTreeHandle` (`ParsedData`) plus the
-  low-level tree helpers (`ensure_capacity`, `deep_copy_recursive`).
-- `pals_expand.cpp` — the lattice expansion pipeline that builds the five-tree
-  representation (`original` / `combined` / `expanded` / `full_expanded` /
-  `leftover`): include
-  splicing, `load` merging, structural expansion (repeats, inherits, forks), expression,
-  controller and `set` evaluation, and the element bookkeeper that walks each
-  branch
-  filling in reference parameters, floor placement, s-positions and dependent
-  parameters.
-- `pals_check.{h,cpp}` — spelling checks against the fixed PALS vocabulary
-  (element kinds and parameter group names). A `FlorP` group parses as valid
-  YAML and would otherwise go unrecognised in silence, so it is reported here,
-  with a "did you mean" suggestion where a near match exists.
-- `pals_floor.{h,cpp}` — floor (global) coordinate geometry. A placement is a
-  position plus an orientation, carried as a unit quaternion rather than the
-  standard's W matrix; `floor_propagate` advances one along the reference
-  curve, and straight_LS / bend_LS / patch_LS build the (L, S) pair for the
-  three geometries PALS defines.
-- `pals_match.cpp` — PALS name matching and parameter lookup (the PCRE2-based
-  `match_names` / `get_parameter_value` family).
-- `pals_util.{h,cpp}` — small helpers shared across the PALS split
-  (`child_val_str`, `split_dots`, `resolve_param_path`, `strip_expr_wrapper`).
-- `pals_expression.{h,cpp}` — the standalone PALS expression grammar and
-  evaluator (arithmetic, functions, built-in constants, particle-data lookups).
-
-Everything builds into `libyaml_c_wrapper.dylib`; see `CMakeLists.txt`.
-
-### Memory model
-`YAMLTreeHandle` wraps `ryml::Tree` into C objects so they can be part of a shared object library to interface with other languages. `ryml::Tree`s are stored in memory simply as arrays. `ryml::NodeRef` acts as a simple wrapper around nodes, which are just indices in the tree array. Trees are obtained by parsing C++ std::string, and values are simply pointers to locations in the string. Therefore, the string must be kept in memory as long as the tree is in use. 
-
-Most of the relevant ryml code for reference is contained in `/build/_deps/rapidyaml-src/src/c4/yml/tree.hpp`.
-
-The documentation site is built with Sphinx (MyST Markdown + the Furo theme),
-with the C/C++ API pulled in from Doxygen via [Breathe](https://breathe.readthedocs.io).
-The published site is at <https://pals-project.github.io/pals-cpp/>. To build and
-preview it locally (requires `doxygen` and `python3`):
-
-```console
-docs/build_local.sh
-```
-
-This runs `docs/build.py` — Doxygen (API → XML) then Sphinx → `docs/build/html` —
-and serves it at <http://localhost:8000/>. Narrative pages live in `docs/src/`.
-
-To build the test, in the root directory run
-
-```console
-ctest --test-dir build --output-on-failure
-```
-
-To run a specific test, run
-```console
-ctest --test-dir build -R "Test Name"
-```
+Notes for working on the library itself (source layout, memory model, running
+the tests, building the docs) are on the
+[Working on pals-cpp](https://pals-project.github.io/pals-cpp/develop.html)
+page.

--- a/README.md
+++ b/README.md
@@ -1,69 +1,10 @@
 ## Introduction
-Pals-cpp is the parser library for PALS accelerator lattice files. It uses rapidyaml https://github.com/biojppm/rapidyaml to read lattices into memory and provides additional capabilities like printing to console, writing to files, and searching for elements. One major component is performing lattice expansion following the PALS specifications:
-1. The lattice to be expanded can be specified by the user. If none is specified, the one in the last `use: root_lattice` statement will be expanded. If none exists, the last lattice in the file is expanded. 
-2. Content from other files can be brought into scope in two ways. An `include: filename` splices that file's contents in verbatim at the point the `include` is written. A `load` list under the `PALS` node instead merges whole files subnode by subnode — list subnodes concatenate in load order, dictionary subnodes take the union, and `SELF` marks where the joining file's own contents belong — which is how a layout file and a settings file are composed into one lattice. Paths are relative to the file naming them, and both can nest to any depth.
-3. Elements that inherit parameters from other elements will have those properties brought into scope.
-4. Beamlines in a lattice with a `repeat: count` will have their contents repeated `count` times in the lattice.
-5. Elements in a lattice defined outside of it will have their definitions brought it.
-6. Fork elements will create new branches in the lattice to their destination branch. 
-7. Mathematical expressions are evaluated to numbers (see below).
-8. `set` commands are executed and controllers are applied to the parameters they drive, on either side of an `expand_lattice` node (see below).
-
-## Expression Evaluation
-As a final step of expansion, every scalar value in the `expanded` tree that is a
-PALS mathematical expression is replaced with its numeric value. This covers the
-full PALS expression grammar — arithmetic (`+ - * / ^`), parentheses, the
-[built-in constants](https://github.com/pals-project/pals) (`pi`, `c_light`,
-`r_electron`, …), the math functions (`sqrt`, `log`, `sin`, `floor`, `modulo`, …),
-and user-defined constants and variables (both the `kind: constant`/`value:` and
-the compact `constants:`/`variables:` forms — the compact form may be written as
-a sequence of single-key maps or as a plain map — resolved in dependency order).
-Both immediate expressions and `expr(...)`-delayed expressions are evaluated to a
-number in the expanded tree. Values that are not expressions — element/line name
-references, `kind:` names, booleans — are left untouched, and expressions
-containing `random()`/`random_gauss()` are left as text so the expanded tree stays
-reproducible. The `combined` and `original` trees always retain the original
-expression text.
-
-Operator precedence is standard, with two conventions worth noting: `^` (power)
-is right-associative, so `2^3^2` is `2^(3^2) = 512`; and a unary sign binds
-*looser* than `^`, so `-2^2` is `-(2^2) = -4` while a signed exponent still works
-(`2^-2` is `2^(-2) = 0.25`) — the Fortran/Bmad convention used across the
-ecosystem.
-
-**Controllers.** A `kind: Controller` element bundles expressions that drive
-lattice parameters. Its `variables:` form a controller-scoped symbol table —
-each initial value is a constant expression (constants and functions only, no
-variables), and each entry in `controls:` pairs a `parameter` target — a
-name-matching string — with an `expression` over that controller's own
-variables, reaching nothing outside the controller. `control_type:
-ABSOLUTE` (the default) means the controllers determine the parameter outright,
-so during expansion each matched parameter is set to the sum of the values of
-every ABSOLUTE controller driving it; `control_type: RELATIVE` describes a knob
-the simulation program varies afterwards and so changes nothing at expansion.
-A controller may also drive another controller's variable, named
-`controller>variable`, which makes controllers a hierarchy evaluated from the
-top down. See [Evaluating expressions](docs/src/guide/expressions.md).
-
-The particle-data functions `mass_of`, `charge_of`, and `anomalous_moment_of` take
-a quoted species name (e.g. `mass_of("#3He")`); an unquoted name is an error. A
-mass number must carry a leading `#` (`"#3He"`, not `"3He"`). These
-functions and the physical values behind the named constants are provided by
-[AtomicAndPhysicalConstantsCLib](https://github.com/pals-project/AtomicAndPhysicalConstantsCLib)
-(a C++ mirror of [AtomicAndPhysicalConstants.jl](https://github.com/bmad-sim/AtomicAndPhysicalConstants.jl)),
-fetched automatically by CMake. A single expression can also be evaluated on its
-own via `evaluate_pals_expression()`.
-
-**Set commands.** A `set` writes a value into every parameter its `parameter`
-name-matching string selects; in the `value` expression `PARAMETER` is the
-current value and `SELF` the element that owns it
-(`value: 2*PARAMETER + atan(SELF.BendP.g_ref)`). The compact `sets:` form is a
-list of `target: value` pairs. An `expand_lattice` node in the `facility` list
-decides what a set acts on: before it, the element *definitions* (and only those
-defined earlier in the list); after it, the already-expanded lattice, so each
-copy of a repeated element is written separately. `absolute_error` and
-`relative_error` are reported rather than applied — the standard does not
-specify the error distribution.
+Pals-cpp is a parser library for [PALS](https://github.com/pals-project/pals) accelerator lattice files. 
+It uses rapidyaml https://github.com/biojppm/rapidyaml to read lattices into memory and provides 
+additional capabilities like printing to console, writing to files, and searching for elements. 
+One major component is performing lattice expansion following the PALS specifications.
+The lattice to be expanded can be specified by the user as an argument to the `parse_and_expand_PALS`
+function. If none is specified, the lattice is chosen using the prescription given by PALS.
 
 ## Usage
 First, to build, run the following in the root directory:  

--- a/docs/src/develop.md
+++ b/docs/src/develop.md
@@ -1,0 +1,93 @@
+# Working on pals-cpp
+
+Notes for working on the library itself: where the code lives, how trees are
+held in memory, how to run the tests, and how to build this documentation.
+
+## Source layout
+
+The library sources live in `src/`, split by concern:
+
+- **`yaml_c_wrapper.h`** — the public C API: the opaque handle types and every
+  exported function. This is the only header consumers include.
+- **`yaml_c_wrapper.cpp`** — the generic YAML tree wrapper over rapidyaml
+  (parse, traverse, query, modify, emit). Knows nothing about PALS.
+- **`yaml_tree.h`** — internal declarations shared between the wrapper and the
+  PALS code: the tree representation behind `YAMLTreeHandle` (`ParsedData`)
+  plus the low-level tree helpers (`ensure_capacity`,
+  `deep_copy_recursive`).
+- **`pals_expand.cpp`** — the lattice expansion pipeline that builds the
+  five-tree representation (`original` / `combined` / `expanded` /
+  `full_expanded` / `leftover`): include splicing, `load` merging, structural
+  expansion (repeats, inherits, forks), expression, controller and `set`
+  evaluation, and the element bookkeeper that walks each branch filling in
+  reference parameters, floor placement, s-positions and dependent parameters.
+- **`pals_check.{h,cpp}`** — spelling checks against the fixed PALS vocabulary
+  (element kinds and parameter group names). A `FlorP` group parses as valid
+  YAML and would otherwise go unrecognised in silence, so it is reported here,
+  with a "did you mean" suggestion where a near match exists.
+- **`pals_floor.{h,cpp}`** — floor (global) coordinate geometry. A placement is
+  a position plus an orientation, carried as a unit quaternion rather than the
+  standard's W matrix; `floor_propagate` advances one along the reference
+  curve, and `straight_LS` / `bend_LS` / `patch_LS` build the (L, S) pair for
+  the three geometries PALS defines.
+- **`pals_match.cpp`** — PALS name matching and parameter lookup (the
+  PCRE2-based `match_names` / `get_parameter_value` family).
+- **`pals_util.{h,cpp}`** — small helpers shared across the PALS split
+  (`child_val_str`, `split_dots`, `resolve_param_path`, `strip_expr_wrapper`).
+- **`pals_expression.{h,cpp}`** — the standalone PALS expression grammar and
+  evaluator (arithmetic, functions, built-in constants, particle-data lookups).
+
+Everything builds into `libyaml_c_wrapper`; see `CMakeLists.txt`.
+
+## Memory model
+
+`YAMLTreeHandle` wraps a `ryml::Tree` into a C object so that trees can be
+handed across the shared library boundary to other languages. A `ryml::Tree` is
+stored in memory as a plain array of nodes, and a `ryml::NodeRef` is a thin
+wrapper around an index into that array — which is what `YAMLNodeId` is.
+
+Trees are obtained by parsing a C++ `std::string`, and the parsed values are
+pointers into that string rather than copies. **The string must therefore stay
+alive as long as the tree is in use**, which is why `ParsedData` owns both
+together.
+
+Most of the relevant ryml code for reference is in
+`build/_deps/rapidyaml-src/src/c4/yml/tree.hpp`.
+
+## Running the tests
+
+The tests are [Catch2](https://github.com/catchorg/Catch2) cases under
+`tests/`, registered with CTest. Rebuild before running them — the tests link
+against the freshly built library:
+
+```console
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+To run a single test case, match it by name:
+
+```console
+ctest --test-dir build -R "Test Name"
+```
+
+## Building the documentation
+
+The site is built with Sphinx (MyST Markdown + the Furo theme), with the C/C++
+API pulled in from Doxygen via [Breathe](https://breathe.readthedocs.io). The
+published site is at <https://pals-project.github.io/pals-cpp/>.
+
+To build and preview it locally (requires `doxygen` and `python3`):
+
+```console
+docs/build_local.sh
+```
+
+This runs `docs/build.py` — Doxygen (API → XML), then Sphinx →
+`docs/build/html` — and serves the result at <http://localhost:8000/>. Pass
+`--no-serve` to build without starting a server, or `--port N` to serve
+elsewhere.
+
+Narrative pages live in `docs/src/`; the API reference is generated from the
+doc comments in `src/yaml_c_wrapper.h` and `src/pals_expression.h`, so API
+documentation is edited in the headers themselves.

--- a/docs/src/guide/expressions.md
+++ b/docs/src/guide/expressions.md
@@ -83,39 +83,6 @@ standard gives the error *magnitude* — `absolute_error + relative_error *
 deterministic value, and reports a problem rather than picking a distribution
 on the author's behalf.
 
-## How controllers are applied
-
-A `Controller`'s `variables` are evaluated as constant expressions, each
-`controls` entry's `expression` is evaluated against that controller's own
-variable table, and the result is written back into the control entry. What then
-happens to the driven parameters depends on `control_type`:
-
-- **`ABSOLUTE`** (the default, materialized into the tree when the key is
-  omitted) means the controllers determine the parameter outright. Each matched
-  parameter is set to the **sum** of the values of every ABSOLUTE controller
-  driving it, replacing whatever the element itself gave. A parameter the
-  element does not carry is created, group and all.
-- **`RELATIVE`** describes a knob — an orbit bump, a chromaticity family —
-  whose *changes* the simulation program applies after the file is read. It
-  changes nothing during expansion: the parameter keeps the value its element
-  gives, and only the control expression is evaluated, for the program's use.
-
-A `parameter` target is a [name-matching string](../api.md#name-matching), so
-one entry drives every element it matches. Controllers may drive other
-controllers' variables, forming a hierarchy that is evaluated from the top down;
-a driven variable takes its driving value instead of its own initial value. The
-order controllers are written in the file does not matter.
-
-The controllers are applied after the branches are expanded and before the
-element bookkeeper runs, so the reference, floor and dependent parameters are
-computed from the driven values — a driven `Kn1L` yields the matching `Bn1L`.
-
-These are reported as problems: a circular control hierarchy, a parameter driven
-by both an ABSOLUTE and a RELATIVE controller, a parameter that is both
-controlled and assigned a delayed (`expr(...)`) expression, a target that
-matches nothing in the expanded lattice, and a `control_type` that is neither
-`ABSOLUTE` nor `RELATIVE`.
-
 ## How sets are applied
 
 A parameter of a known element that has not been written reads as **zero**, so

--- a/docs/src/guide/trees.md
+++ b/docs/src/guide/trees.md
@@ -262,11 +262,10 @@ it was computed.
 
 Expansion does not abort on a recoverable problem. Instead it leaves the
 offending value as it found it and appends a message to the `problems` list the
-`lattices` struct also carries: an undefined lattice, a `line` reference to an
-undefined element, a missing `inherit`/`repeat`/`Fork` target, a branch whose
-reference parameters cannot be computed, an expression that could not be
-evaluated. The list is empty when expansion was clean, and the caller owns it —
-release it with `free_lattice_problems`.
+`lattices` struct also carries, so the five trees come back expanded as far as
+they could be. The list is empty when expansion was clean, and the caller owns
+it — release it with `free_lattice_problems`.
 
 The library never prints. Whether to report, save, or ignore the messages is the
-caller's decision.
+caller's decision. What is reported is set out in
+[Problems found during expansion](usage.md#problems-found-during-expansion).

--- a/docs/src/guide/usage.md
+++ b/docs/src/guide/usage.md
@@ -53,16 +53,66 @@ is none — the last lattice defined in the file.
 
 ### Problems found during expansion
 
-Expansion does not abort on a recoverable problem — a `line` reference to an
-undefined element, a missing `inherit`/`repeat`/`Fork` target, or an expression
-that cannot be evaluated (an unknown constant, a dangling element‑parameter
-reference, a cycle). Instead it leaves the offending value as text and appends a
+Expansion does not abort on a recoverable problem. It leaves the offending
+value as it found it, carries on with the rest of the lattice, and appends a
 human‑readable message to `lat.problems`, an owning `string_list`. The list is
 empty when expansion was clean. The library never prints — the caller decides
-whether to report, save, or ignore the messages — and must release the list with
-`free_lattice_problems`. Only values that look like expressions (an operator, a
-parenthesis, a `>` reference, or an explicit `expr(...)`) are flagged when they
-fail to evaluate, so plain names and labels are not mistaken for broken math.
+whether to report, save, or ignore the messages — and must release the list
+with `free_lattice_problems`.
+
+Expansion is therefore always worth reading: a lattice with problems still
+comes back expanded as far as it could be, with the trees around the fault
+intact. The one exception is a top‑level file that is not valid YAML, where
+there is nothing to expand: all five handles come back `NULL` and the parse
+error, with its location, is the single problem reported.
+
+What gets reported falls into a few groups.
+
+**Structure.** A lattice named in the call (or in `use`) that does not exist, a
+`line` reference to an undefined element or line, a missing
+`inherit`/`repeat`/`Fork` target, an invalid `repeat` count, a `Fork` whose
+`to_line` cannot be resolved, a branch that never got expanded, and a `load` or
+`include` that cannot be read or that conflicts with what it is merged into.
+
+**Expressions.** A value that cannot be evaluated — an unknown constant or
+species, a dangling element‑parameter reference, a reference cycle, a syntax
+error — is left as text and reported. Only values that *look* like expressions
+(an operator, a parenthesis, a `>` reference, or an explicit `expr(...)`) are
+flagged, so a plain name or a label is not mistaken for broken math. See
+[Evaluating expressions](expressions.md).
+
+**Controllers.** A `control_type` that is neither `ABSOLUTE` nor `RELATIVE`; a
+`controls` entry with no `parameter` or no `expression`; a control target that
+is malformed, names no element parameter, or matches nothing in the expanded
+lattice; a reference to a variable a named controller does not have; a
+controller variable whose initial value is not a constant expression; a
+circular control hierarchy; a parameter driven by both an ABSOLUTE and a
+RELATIVE controller; and a parameter that is both controlled and assigned a
+delayed (`expr(...)`) expression.
+
+**Sets.** A `set` with no `parameter` or no `value`; a target that is
+malformed, names no element parameter, or matches nothing (for a
+pre‑`expand_lattice` set, nothing *defined before it*); a value that cannot be
+evaluated; and a value that reads a parameter whose value is still to be
+derived during expansion.
+
+**Bookkeeping.** A branch whose first element gives neither a reference species
+nor a reference energy, so the reference parameters cannot be computed; and a
+parameter the author wrote that is inconsistent with what the rest of its
+family or the bend geometry implies — the authored value is kept and the
+disagreement reported rather than silently overwritten.
+
+**Vocabulary.** An element kind or parameter group name that is not one the
+standard defines — a `FlorP` group is valid YAML and would otherwise go
+unrecognised in silence — reported with a "did you mean" suggestion where a
+near match exists.
+
+**Deliberately not computed.** Where the standard fixes a value's magnitude but
+not how to produce it, this library reports rather than guesses: an
+`absolute_error`/`relative_error` on a `set` (the error distribution is
+unspecified, so the deterministic value is written and the error is not), and a
+`Foil` element's downstream species change (the stripping model is undefined,
+so the species is left as the upstream one).
 
 ### Reading the expanded lattice
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,6 +24,13 @@ guide/expressions
 api
 ```
 
+```{toctree}
+:hidden:
+:caption: Development
+
+develop
+```
+
 ## What it does
 
 Lattice expansion follows the PALS specification: elements are substituted with
@@ -45,6 +52,8 @@ See [The five trees](guide/trees.md) for what each one holds and which to reach
 for, [Building and using the library](guide/usage.md) to get started,
 [Evaluating expressions](guide/expressions.md) for this library's evaluation
 model, and the [API Reference](api.md) for the full C interface.
+[Working on pals-cpp](develop.md) covers the source layout, the memory model,
+the tests, and building this site.
 
 The PALS standard itself — the schema, the element kinds and parameter groups,
 the expression grammar, the built-in constants and functions — is documented at


### PR DESCRIPTION
Two documentation cleanups.

**Developer notes → the docs site.** The README carried the source layout, the memory model, how to run the tests, and how to build the docs. That is developer documentation and belongs on the site with the rest of it, so it moves to a new **Working on pals-cpp** page (`docs/src/develop.md`, under a *Development* toctree caption). The README keeps its introduction, usage and examples, and gains a short Documentation section pointing at the site. The tests got their own section in the move — they were previously buried in the doc-build paragraph.

**"How controllers are applied" removed.** What a `Controller` means — its variables, its controls entries, what ABSOLUTE and RELATIVE do to a driven parameter — is the PALS standard's to define, and the expressions page was restating it. The section is gone. What remains that touches controllers is only pals-cpp's own pipeline: where the ABSOLUTE passes sit in the order of the passes, and the deferral of a control expression that calls `random()`.

**Problems, in one place.** The controller problems the library reports *are* its own behavior, so they move to `usage.md`, whose "Problems found during expansion" grows from a paragraph into the full account: the never-abort/never-print contract, ownership via `free_lattice_problems`, the one fatal case (an unparseable top-level file — five NULL handles, one problem), then the problems themselves by group — structure, expressions, controllers, sets, bookkeeping, vocabulary, and the two things deliberately not computed (a `set`'s error distribution, a `Foil`'s species change). The list was written from the `add_problem` call sites rather than from the old prose, so it also covers things nothing documented before: load conflicts, inconsistent authored family and bend-geometry values, and a controller variable whose initial value is not a constant expression. The shorter, partial list in `trees.md` now points here instead of competing with it.

Sphinx builds clean and the cross-references resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)