### PR TITLE
Accept the momentum dependence of the Twiss parameters

### DIFF
--- a/src/pals_check.cpp
+++ b/src/pals_check.cpp
@@ -98,10 +98,17 @@ const std::map<std::string, std::set<std::string>>& group_params() {
         {"TaylorP",
          {"x_out", "px_out", "y_out", "py_out", "z_out", "pz_out", "S_q1_out",
           "S_qx_out", "S_qy_out", "S_qz_out", "ref_in"}},
+        // The eight `_dpz` components are the dependence of a Twiss, alpha or
+        // dispersion component on momentum (pals#284). Note that the derivative
+        // of `eta_x` with respect to momentum is `deta_x_dpz` while the one
+        // with respect to s is `deta_x_ds`, and that `detap_x_dpz` derives
+        // `etap_x`, not `deta_x_ds`.
         {"TwissP",
          {"alpha_a", "alpha_b", "beta_a", "beta_b", "cmat11", "cmat12",
           "cmat21", "cmat22", "eta_x", "eta_y", "etap_x", "etap_y",
-          "deta_x_ds", "deta_y_ds", "phi_a", "phi_b"}}};
+          "deta_x_ds", "deta_y_ds", "phi_a", "phi_b",
+          "dalpha_a_dpz", "dalpha_b_dpz", "dbeta_a_dpz", "dbeta_b_dpz",
+          "deta_x_dpz", "deta_y_dpz", "detap_x_dpz", "detap_y_dpz"}}};
     return p;
 }
 

--- a/tests/test_check.cpp
+++ b/tests/test_check.cpp
@@ -145,6 +145,37 @@ TEST_CASE("the retired actual-field bend parameters are reported",
     REQUIRE(!has(ps, "unknown parameter 'g_ref'"));
 }
 
+TEST_CASE("the momentum dependence of the Twiss parameters is accepted",
+          "[check][problems]") {
+    // twiss.md gained the dependence of the Twiss, alpha and dispersion
+    // components on momentum (pals#284). The names pair a component with the
+    // variable differentiated against, so a mode letter used where an axis
+    // belongs -- `dbeta_x_dpz` for what is `dbeta_a_dpz` or `dbeta_b_dpz` --
+    // is still caught.
+    auto ps = problems_for("tmp_check_dpz.pals.yaml",
+                           "PALS:\n"
+                           "  facility:\n"
+                           "    - beg:\n"
+                           "        kind: BeginningEle\n"
+                           "        TwissP:\n"
+                           "          beta_a: 12.5\n"
+                           "          dbeta_a_dpz: 1.5\n"
+                           "          dalpha_a_dpz: 0.1\n"
+                           "          dbeta_b_dpz: -2.0\n"
+                           "          dalpha_b_dpz: 0.2\n"
+                           "          deta_x_dpz: 0.3\n"
+                           "          detap_x_dpz: 0.4\n"
+                           "          deta_y_dpz: 0.5\n"
+                           "          detap_y_dpz: 0.6\n"
+                           "          dbeta_x_dpz: 1.0\n");
+
+    REQUIRE(has(ps, "element 'beg>TwissP': unknown parameter 'dbeta_x_dpz'"));
+    REQUIRE(count_with(ps, "unknown parameter") == 1);
+    // `deta_x_ds` is the derivative with respect to s and stays a parameter of
+    // its own alongside `deta_x_dpz`.
+    REQUIRE(!has(ps, "'deta_x_ds'"));
+}
+
 TEST_CASE("multipole component names are accepted by shape, not by list",
           "[check][problems]") {
     // A multipole component name is generated from its order, so there is no


### PR DESCRIPTION
[pals#284](https://github.com/pals-project/pals/pull/284) adds eight components to `TwissP` in `source/parameters/twiss.md` — the dependence of the Twiss, alpha and dispersion values on momentum:

`dbeta_a_dpz`, `dalpha_a_dpz`, `dbeta_b_dpz`, `dalpha_b_dpz`, `deta_x_dpz`, `detap_x_dpz`, `deta_y_dpz`, `detap_y_dpz`

`TwissP` is a closed vocabulary in `group_params()`, so without this a lattice carrying any of them is reported as having an unknown parameter. Note that `deta_x_dpz` (with respect to momentum) and the existing `deta_x_ds` (with respect to s) are different parameters, and that `detap_x_dpz` derives `etap_x`, not `deta_x_ds`.

The new test feeds a `BeginningEle` all eight names plus `dbeta_x_dpz` — a mode letter where an axis belongs — to show the check is still live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)