### PR TITLE
Nullify the rest of the family a set or controller writes

### DIFF
--- a/docs/src/guide/expressions.md
+++ b/docs/src/guide/expressions.md
@@ -103,6 +103,35 @@ compute and reading it beforehand is an error:
     value: Q1>MagneticMultipoleP.Bs1   # error: Bs1 needs the reference momentum
 ```
 
+### Interdependent parameters
+
+The members of such a family state one physical quantity in different units, so
+only one of them can be the statement of it. Writing one **nullifies the
+previous settings of all the others**: they are removed, and the bookkeeper
+derives them again from the value just written.
+
+```yaml
+- s1:
+    kind: Sextupole
+    length: 0.27
+    MagneticMultipoleP:
+      Ks2: 0.34
+- set:
+    parameter: s1>MagneticMultipoleP.Ks2L
+    value: 0.5
+```
+
+Here `s1` states its skew sextupole component as `Ks2` and the set restates it
+as `Ks2L`; the `Ks2` goes, and `Ks2` comes back as `0.5 / 0.27`. Without this
+the two would be left contradicting each other and reported as inconsistent.
+
+The rule holds for every writer that reaches a parameter from outside the
+element definition — sets before and after `expand_lattice`, and ABSOLUTE
+controllers, which are ordered among themselves by the order they are evaluated
+in. Two members written *inside* one element definition are a different matter:
+neither is "previous", so that stays an inconsistency for the bookkeeper to
+report.
+
 ### `expand_lattice` and where a set acts
 
 An `expand_lattice` node divides the `facility` list in two, and which side a
@@ -134,7 +163,7 @@ pre-expansion sets
 Applying the controllers last is what keeps a controller authoritative over a
 parameter a later set also writes. The second bookkeeper pass recomputes what
 those writes invalidated: the reference, floor and position values, and the
-family members a post-expansion set dropped.
+family members a post-expansion set or a controller nullified.
 
 The snapshot that separates `expanded` from `full_expanded` is taken between the
 first expression evaluation and the first bookkeeper pass — see

--- a/docs/src/guide/usage.md
+++ b/docs/src/guide/usage.md
@@ -100,7 +100,10 @@ derived during expansion.
 nor a reference energy, so the reference parameters cannot be computed; and a
 parameter the author wrote that is inconsistent with what the rest of its
 family or the bend geometry implies — the authored value is kept and the
-disagreement reported rather than silently overwritten.
+disagreement reported rather than silently overwritten. (Two members of one
+family stated in the *same* element definition are what this catches: a `set`
+or a controller restating a family member nullifies the earlier statement
+instead, so there is nothing to disagree with.)
 
 **Vocabulary.** An element kind or parameter group name that is not one the
 standard defines — a `FlorP` group is valid YAML and would otherwise go

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -1554,6 +1554,87 @@ static void set_plain_child(ryml::Tree& t, size_t parent, const char* key,
     t.set_val(c, t.to_arena(ryml::to_csubstr(v)));
 }
 
+// ------------------------------------------------------------
+// Interdependent parameters
+//
+// Some parameters are computed from one another, so writing one leaves the rest
+// of its family stale. A magnetic multipole component of order N has four
+// interchangeable forms (BnN, BnNL, KnN, KnNL, tied by the element length and
+// the reference momentum); an electric one has two; a bend's geometry is tied
+// together through BendP.
+//
+// miscellaneous.md (s:set): "For any group of interdependent parameters, the set
+// of one member of the group nullifies previous settings of all other members of
+// the group." Nullifying is what keeps the family from being flagged as
+// inconsistent when the bookkeeper derives it: whoever writes last states the
+// quantity, and the earlier statements of it are gone. The rule holds for every
+// writer that acts on a parameter from outside the element definition -- `set`
+// commands, before and after expansion, and ABSOLUTE controllers alike. Two
+// members written inside one element definition are a different matter: neither
+// is "previous", so that stays an inconsistency for the bookkeeper to report.
+// ------------------------------------------------------------
+
+// The family `key` belongs to within `group`, including `key` itself; empty for
+// a parameter that stands alone.
+//
+// This is also what tells a value expression that a parameter is *not yet
+// computable* rather than zero: before the bookkeeper has run, an absent
+// parameter with a written family member is one whose value is still to be
+// derived (lattice-construction.md, s:lattice.expand).
+static std::set<std::string> linked_family(const std::string& group,
+                                           const std::string& key) {
+    // `<letter><n|s><digits>[L]`, the shape both multipole groups use.
+    auto split_component = [](const std::string& k, const char* letters,
+                              std::string& comp) {
+        if (k.size() < 3 || !std::strchr(letters, k[0])) return false;
+        if (k[1] != 'n' && k[1] != 's') return false;
+        size_t i = 2;
+        while (i < k.size() && std::isdigit(static_cast<unsigned char>(k[i])))
+            ++i;
+        if (i == 2) return false;
+        if (i != k.size() && !(i + 1 == k.size() && k[i] == 'L')) return false;
+        comp = k.substr(1, i - 1);  // e.g. "n1"
+        return true;
+    };
+
+    std::string comp;
+    if (group == "MagneticMultipoleP" && split_component(key, "BK", comp))
+        return {"B" + comp, "B" + comp + "L", "K" + comp, "K" + comp + "L"};
+    if (group == "ElectricMultipoleP" && split_component(key, "E", comp))
+        return {"E" + comp, "E" + comp + "L"};
+
+    static const std::set<std::string> bend = {
+        "g_ref",     "radius_ref", "Bn0_ref",
+        "angle_ref", "L_chord",    "L_rectangle"};
+    if (group == "BendP" && bend.count(key)) return bend;
+
+    return {};
+}
+
+// Drop the rest of the family of the parameter `path` names on `ele`, so the
+// bookkeeper derives them again from the value just written. Provenance entries
+// go with them: ryml reuses freed ids, and a stale link would then point the
+// correspondence map at the wrong node.
+static void nullify_family(ryml::Tree& t, size_t ele,
+                           const std::vector<std::string>& path,
+                           std::map<size_t, size_t>& prov) {
+    if (ele == ryml::NONE || path.empty()) return;
+    const std::string& key = path.back();
+    std::string group = path.size() >= 2 ? path[path.size() - 2] : std::string();
+    std::set<std::string> family = linked_family(group, key);
+    if (family.empty()) return;
+
+    std::vector<std::string> sib = path;
+    for (const std::string& member : family) {
+        if (member == key) continue;
+        sib.back() = member;
+        size_t node = resolve_param_path(t, ele, sib);
+        if (node == ryml::NONE) continue;
+        erase_prov_subtree(t, node, prov);
+        t.remove(node);
+    }
+}
+
 // True if `node` is a map defining a `kind: Controller` element.
 static bool is_controller(const ryml::Tree& t, size_t node) {
     if (node == ryml::NONE || !t.is_map(node)) return false;
@@ -1972,6 +2053,11 @@ struct CtrlTarget {
     bool has_absolute = false;
     bool has_relative = false;
     bool deferred = false;  // some driving expression stayed unevaluated
+    // Position of the last `controls` entry naming this parameter, in
+    // evaluation order. Two controllers driving two members of one
+    // interdependent family are ordered by it: the later write is the one that
+    // states the quantity, and it nullifies the earlier.
+    size_t seq = 0;
 };
 
 // Evaluates the controllers and applies them to the expanded lattice.
@@ -1992,6 +2078,7 @@ struct CtrlTarget {
 static void evaluate_controllers(ryml::Tree& t, size_t lat_node,
                                  const pals::SymbolLookup& global_resolve,
                                  const pals::SpeciesLookup& species,
+                                 std::map<size_t, size_t>& prov,
                                  ProblemList& problems) {
     std::vector<Ctrl> ctrls;
     std::vector<CtrlVar> vars;
@@ -2133,8 +2220,13 @@ static void evaluate_controllers(ryml::Tree& t, size_t lat_node,
     // Gather what drives each lattice parameter. Targets are keyed on the
     // element and the path rather than on a parameter node, so a parameter the
     // element does not carry yet is still recognised as the same target.
-    for (const Ctrl& c : ctrls) {
+    // Walked in evaluation order, and each `controls` entry numbered, so that
+    // "previous" has a meaning when two of them name one interdependent family.
+    size_t seq = 0;
+    for (size_t ci : order) {
+        const Ctrl& c = ctrls[ci];
         for (const CtrlControl& cc : c.controls) {
+            ++seq;
             if (cc.target_ctrl != SIZE_MAX) continue;
             ElementMatches m = match_element_parameters(t, lat_node, cc.param);
             if (!m.valid) {
@@ -2164,6 +2256,7 @@ static void evaluate_controllers(ryml::Tree& t, size_t lat_node,
                 path += (path.empty() ? "" : ".") + p;
             for (size_t def : m.elements) {
                 CtrlTarget& tg = targets[{def, path}];
+                tg.seq = seq;
                 if (c.absolute) {
                     tg.has_absolute = true;
                     if (cc.ok)
@@ -2177,7 +2270,20 @@ static void evaluate_controllers(ryml::Tree& t, size_t lat_node,
         }
     }
 
-    for (const auto& kv : targets) {
+    // Applied in the order the controls were reached, not in the map's key
+    // order: a later write nullifies the family members an earlier one stated,
+    // so which one comes last decides what the parameter ends up saying.
+    std::vector<decltype(targets)::const_iterator> in_order;
+    in_order.reserve(targets.size());
+    for (auto it = targets.begin(); it != targets.end(); ++it)
+        in_order.push_back(it);
+    std::stable_sort(in_order.begin(), in_order.end(),
+                     [](const auto& a, const auto& b) {
+                         return a->second.seq < b->second.seq;
+                     });
+
+    for (const auto& it : in_order) {
+        const auto& kv = *it;
         size_t def = kv.first.first;
         const CtrlTarget& tg = kv.second;
         std::vector<std::string> path = split_dots(kv.first.second);
@@ -2213,6 +2319,10 @@ static void evaluate_controllers(ryml::Tree& t, size_t lat_node,
         for (size_t i = 0; i + 1 < path.size(); ++i)
             parent = find_or_add_map_child(t, parent, path[i].c_str());
         set_num_child(t, parent, path.back().c_str(), tg.sum);
+        // The controller states this member of its family; what the element
+        // definition, or a control reached earlier, said through another member
+        // is nullified rather than left to be flagged as inconsistent.
+        nullify_family(t, def, path, prov);
     }
 }
 
@@ -2321,12 +2431,13 @@ static void make_expression_context(const ryml::Tree& t,
 // applies the controllers to `lat_node`. Records anything that could not be
 // evaluated in `problems`.
 static void evaluate_expressions(ryml::Tree& t, size_t lat_node,
+                                 std::map<size_t, size_t>& prov,
                                  ProblemList& problems) {
     pals::SymbolLookup resolve;
     pals::SpeciesLookup species;
     make_expression_context(t, resolve, species);
 
-    evaluate_controllers(t, lat_node, resolve, species, problems);
+    evaluate_controllers(t, lat_node, resolve, species, prov, problems);
     substitute_values(t, t.root_id(), resolve, species, problems);
 }
 
@@ -2445,47 +2556,6 @@ static bool is_expand_lattice(const ryml::Tree& t, size_t entry) {
     return c != ryml::NONE && t.key(c) == ryml::to_csubstr("expand_lattice");
 }
 
-// The parameters that are computed from one another, so that writing one leaves
-// the rest of the family stale. A magnetic multipole component has four
-// interchangeable forms (BnN, BnNL, KnN, KnNL, tied by the length and the
-// reference momentum); an electric one has two; a bend's geometry is tied
-// together through BendP. Returns the family including `key` itself, or an empty
-// set for a parameter that stands alone.
-//
-// This is also what tells a value expression that a parameter is *not yet
-// computable* rather than zero: before the bookkeeper has run, an absent
-// parameter with a written family member is one whose value is still to be
-// derived (lattice-construction.md, s:lattice.expand).
-static std::set<std::string> linked_family(const std::string& group,
-                                           const std::string& key) {
-    // `<letter><n|s><digits>[L]`, the shape both multipole groups use.
-    auto split_component = [](const std::string& k, const char* letters,
-                              std::string& comp) {
-        if (k.size() < 3 || !std::strchr(letters, k[0])) return false;
-        if (k[1] != 'n' && k[1] != 's') return false;
-        size_t i = 2;
-        while (i < k.size() && std::isdigit(static_cast<unsigned char>(k[i])))
-            ++i;
-        if (i == 2) return false;
-        if (i != k.size() && !(i + 1 == k.size() && k[i] == 'L')) return false;
-        comp = k.substr(1, i - 1);  // e.g. "n1"
-        return true;
-    };
-
-    std::string comp;
-    if (group == "MagneticMultipoleP" && split_component(key, "BK", comp))
-        return {"B" + comp, "B" + comp + "L", "K" + comp, "K" + comp + "L"};
-    if (group == "ElectricMultipoleP" && split_component(key, "E", comp))
-        return {"E" + comp, "E" + comp + "L"};
-
-    static const std::set<std::string> bend = {
-        "g_ref",     "radius_ref", "Bn0_ref",
-        "angle_ref", "L_chord",    "L_rectangle"};
-    if (group == "BendP" && bend.count(key)) return bend;
-
-    return {};
-}
-
 // Everything a `set` needs to know about where it is writing: the element, the
 // group node holding the parameter (ryml::NONE until it is created), the
 // parameter key, and the group name for the family lookup.
@@ -2551,25 +2621,6 @@ static bool read_set_operand(const ryml::Tree& t, size_t ele,
     }
     out = 0.0;
     return true;
-}
-
-// Delete the rest of a parameter's family, so the bookkeeper derives it again
-// from the value just written instead of flagging the two as inconsistent.
-// Provenance entries go with them: ryml reuses freed ids, and a stale link would
-// then point the correspondence map at the wrong node.
-static void invalidate_family(ryml::Tree& t, const SetTarget& tg,
-                              std::map<size_t, size_t>& prov) {
-    std::set<std::string> family = linked_family(tg.group, tg.key);
-    if (family.empty()) return;
-    std::vector<std::string> sib = tg.path;
-    for (const std::string& member : family) {
-        if (member == tg.key) continue;
-        sib.back() = member;
-        size_t node = resolve_param_path(t, tg.ele, sib);
-        if (node == ryml::NONE) continue;
-        erase_prov_subtree(t, node, prov);
-        t.remove(node);
-    }
 }
 
 // One `set` command, read out of the tree.
@@ -2703,9 +2754,10 @@ static void execute_set(ryml::Tree& t, const SetCommand& cmd,
             parent = find_or_add_map_child(t, parent, tg.path[i].c_str());
         set_num_child(t, parent, tg.key.c_str(), r.value);
         if (written) written->push_back(tg);
-        // After the bookkeeper has run the rest of the family holds values
-        // derived from the old one; drop them so the next pass rebuilds them.
-        if (!pre) invalidate_family(t, tg, prov);
+        // This write nullifies the previous settings of the rest of the family:
+        // whatever the definition stated before expansion, and -- after it --
+        // whatever the first bookkeeper pass derived from that.
+        nullify_family(t, ele, tg.path, prov);
     }
 }
 
@@ -3882,9 +3934,9 @@ static void link_fork_connections(ryml::Tree& t, size_t lat_node) {
 //
 // What counts as computed is recorded as the set of *authored* parameter paths,
 // taken before any bookkeeping runs, rather than as a list of what the
-// bookkeeper writes. Node ids cannot serve: a post-expansion `set` invalidates a
+// bookkeeper writes. Node ids cannot serve: a post-expansion `set` nullifies a
 // parameter family with t.remove(), ryml recycles the freed ids, and a recorded
-// id would then name a different node -- the hazard invalidate_family already
+// id would then name a different node -- the hazard nullify_family already
 // guards provenance against. And recording writes would be wrong even so:
 // set_num_child overwrites an existing key in place, so write_ref writes an
 // author's `E_tot_ref` without creating it, and it would be lost.
@@ -4220,7 +4272,7 @@ static void make_expanded_and_leftover(ParsedData* comb,
         // Node ids of existing nodes are unchanged -- only scalar text is
         // rewritten -- so provenance stays valid; a parameter a controller
         // creates is new and simply has no provenance, like ReferenceP/FloorP.
-        evaluate_expressions(t, lat_node, problems);
+        evaluate_expressions(t, lat_node, work.provenance, problems);
 
         // The last point at which the lattice holds the author's inputs and
         // nothing else. Record their paths now; everything the finished lattice
@@ -4249,7 +4301,7 @@ static void make_expanded_and_leftover(ParsedData* comb,
             // snapshot above; join them to it before the second bookkeeper pass
             // derives their families again.
             add_set_targets(t, lat_node, set_writes, authored);
-            evaluate_expressions(t, lat_node, problems);
+            evaluate_expressions(t, lat_node, work.provenance, problems);
             run_element_bookkeeper(t, lat_node, problems);
         }
 

--- a/tests/test_controllers.cpp
+++ b/tests/test_controllers.cpp
@@ -73,6 +73,16 @@ double expanded_param(YAMLTreeHandle t, const char* ele, const char* group,
     return num_val(t, get_child_by_key(t, g, param));
 }
 
+// Whether the first element named `ele` carries `group.param` at all.
+bool has_param(YAMLTreeHandle t, const char* ele, const char* group,
+               const char* param) {
+    YAMLNodeId e = find_by_key(t, ele);
+    REQUIRE(e != YAML_NULL_ID);
+    YAMLNodeId g = get_child_by_key(t, e, group);
+    if (g == YAML_NULL_ID) return false;
+    return get_child_by_key(t, g, param) != YAML_NULL_ID;
+}
+
 }  // namespace
 
 TEST_CASE("parse_and_expand_PALS evaluates controller expressions",
@@ -706,6 +716,83 @@ TEST_CASE("an unknown control_type is reported",
     REQUIRE(any_contains(problem_list(lat),
                          "control_type must be ABSOLUTE or RELATIVE, not "
                          "SOMETHING"));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a controller nullifies the rest of the family it writes",
+          "[expr][lattices][controller]") {
+    // A controller states its parameter the same way a `set` does, so the
+    // interdependent-parameter rule of miscellaneous.md applies to it: q1's
+    // definition gives the quadrupole component as Kn1, the controller gives it
+    // as Kn1L, and the definition's Kn1 is nullified rather than left to be
+    // reported as inconsistent with it.
+    const char* path = "tmp_ctrl_family.pals.yaml";
+    write_tmp(path,
+              lattice_with("    - ps1:\n"
+                           "        kind: Controller\n"
+                           "        control_type: ABSOLUTE\n"
+                           "        controls:\n"
+                           "          - parameter: q1>MagneticMultipoleP.Kn1L\n"
+                           "            expression: 0.6\n",
+                           "                - q1:\n"
+                           "                    kind: Quadrupole\n"
+                           "                    length: 0.5\n"
+                           "                    MagneticMultipoleP:\n"
+                           "                      Kn1: 3.0\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    REQUIRE(!has_param(lat.expanded, "q1", "MagneticMultipoleP", "Kn1"));
+    REQUIRE(close(expanded_param(lat.full_expanded, "q1", "MagneticMultipoleP",
+                                 "Kn1L"),
+                  0.6));
+    // Derived back over the length, from the controller's value and not the 3.0
+    // the definition gave.
+    REQUIRE(close(expanded_param(lat.full_expanded, "q1", "MagneticMultipoleP",
+                                 "Kn1"),
+                  1.2));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("of two controllers on one family the later one states it",
+          "[expr][lattices][controller]") {
+    // Neither controller drives the other, so they are evaluated in file order
+    // and ps2 comes last: its Kn1L nullifies the Kn1 ps1 wrote, exactly as a
+    // later `set` would. (Two controllers on the *same* parameter still sum --
+    // that is what the ABSOLUTE rule says, and it is a different case.)
+    const char* path = "tmp_ctrl_family_two.pals.yaml";
+    write_tmp(path,
+              lattice_with("    - ps1:\n"
+                           "        kind: Controller\n"
+                           "        control_type: ABSOLUTE\n"
+                           "        controls:\n"
+                           "          - parameter: q1>MagneticMultipoleP.Kn1\n"
+                           "            expression: 3.0\n"
+                           "    - ps2:\n"
+                           "        kind: Controller\n"
+                           "        control_type: ABSOLUTE\n"
+                           "        controls:\n"
+                           "          - parameter: q1>MagneticMultipoleP.Kn1L\n"
+                           "            expression: 0.6\n",
+                           "                - q1:\n"
+                           "                    kind: Quadrupole\n"
+                           "                    length: 0.5\n"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    REQUIRE(!has_param(lat.expanded, "q1", "MagneticMultipoleP", "Kn1"));
+    REQUIRE(close(expanded_param(lat.full_expanded, "q1", "MagneticMultipoleP",
+                                 "Kn1L"),
+                  0.6));
+    REQUIRE(close(expanded_param(lat.full_expanded, "q1", "MagneticMultipoleP",
+                                 "Kn1"),
+                  1.2));
 
     free_all(lat);
     rm_tmp(path);

--- a/tests/test_sets.cpp
+++ b/tests/test_sets.cpp
@@ -76,6 +76,16 @@ double one_param(YAMLTreeHandle t, const char* ele, const char* group,
     return nth_param(t, ele, 0, group, param);
 }
 
+// Whether the first element named `ele` carries `group.param` at all.
+bool has_param(YAMLTreeHandle t, const char* ele, const char* group,
+               const char* param) {
+    YAMLNodeId e = find_by_key(t, ele);
+    REQUIRE(e != YAML_NULL_ID);
+    YAMLNodeId g = get_child_by_key(t, e, group);
+    if (g == YAML_NULL_ID) return false;
+    return get_child_by_key(t, g, param) != YAML_NULL_ID;
+}
+
 // A beamline holding one BeginningEle plus whatever `body` adds.
 const char* BEGIN_ENTRY =
     "          - begin:\n"
@@ -400,6 +410,46 @@ TEST_CASE("a post-expansion set makes the bookkeeper redo the family",
     double b2 = one_param(lat.full_expanded, "q2", "MagneticMultipoleP", "Bn1L");
     REQUIRE(b1 != 0.0);
     REQUIRE(close_rel(b1, b2));
+
+    free_all(lat);
+    rm_tmp(path);
+}
+
+TEST_CASE("a pre-expansion set nullifies the rest of its family",
+          "[expr][lattices][set]") {
+    // miscellaneous.md, the interdependent-parameter example verbatim: s1
+    // states its sextupole skew component as Ks2, and a set then states the
+    // same component as Ks2L. The set nullifies the Ks2 the definition gave, so
+    // the two are not left inconsistent -- the component is what the set says,
+    // and the bookkeeper derives Ks2 back from it over the element length.
+    const char* path = "tmp_set_family_pre.pals.yaml";
+    write_tmp(path,
+              facility_file("    - s1:\n"
+                            "        kind: Sextupole\n"
+                            "        length: 0.27\n"
+                            "        MagneticMultipoleP:\n"
+                            "          Ks2: 0.34\n"
+                            "    - set:\n"
+                            "        parameter: s1>MagneticMultipoleP.Ks2L\n"
+                            "        value: 0.5\n"
+                            "    - main:\n"
+                            "        kind: BeamLine\n"
+                            "        line:\n" +
+                                std::string(BEGIN_ENTRY) + "          - s1\n",
+                            "main"));
+
+    struct lattices lat = parse_and_expand_PALS(path, nullptr);
+    REQUIRE(joined(lat) == "");
+
+    // Only the set's own parameter survives as an input; the nullified Ks2 is
+    // no longer something the author asked for.
+    REQUIRE(has_param(lat.expanded, "s1", "MagneticMultipoleP", "Ks2L"));
+    REQUIRE(!has_param(lat.expanded, "s1", "MagneticMultipoleP", "Ks2"));
+    REQUIRE(close(one_param(lat.full_expanded, "s1", "MagneticMultipoleP", "Ks2L"),
+                  0.5));
+    REQUIRE(close_rel(one_param(lat.full_expanded, "s1", "MagneticMultipoleP",
+                                "Ks2"),
+                      0.5 / 0.27));
 
     free_all(lat);
     rm_tmp(path);


### PR DESCRIPTION
`miscellaneous.md` (s:set): *"For any group of interdependent parameters, the set of one member of the group nullifies previous settings of all other members of the group."*

Only the post-expansion `set` case did this, and only to clear what the first bookkeeper pass had derived from the old value. This applies the rule to every writer that reaches a parameter from **outside** the element definition:

- **Pre-expansion sets.** A definition stating `Ks2` and a set restating it as `Ks2L` were left contradicting each other and reported as inconsistent. Now the definition's value goes and the bookkeeper derives it back from the set's — the interdependent-parameter example of `miscellaneous.md`, verbatim, is the new test in `test_sets.cpp`.
- **ABSOLUTE controllers.** A controller states its parameter the way a set does. Controller targets are now applied in the order their `controls` entries are reached rather than in map-key order, so that "previous" has a meaning when two of them name two members of one family; the later write states the quantity. Two controllers on the *same* parameter still sum, which is a different case and unchanged.

Two members written *inside* one element definition are also unchanged: neither is "previous", so that stays an inconsistency for the bookkeeper to report.

`invalidate_family` becomes `nullify_family`, moved up next to `linked_family` so the controller pass can reach it, and takes an element plus a path instead of a `SetTarget`. `evaluate_expressions` now threads the provenance map through, since removing nodes has to erase their provenance — ryml recycles freed ids.

Docs updated: a new "Interdependent parameters" section in the expressions guide, and the inconsistency note in the usage guide now says which case it covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)