### PR TITLE
Rename the `leftover` tree to `adjunct`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -42,7 +42,7 @@ The opaque handles and sentinel values shared across the API.
 ## Parsing & expansion
 
 Read PALS/YAML from disk or memory and expand a lattice into its four
-representations (`original`, `combined`, `expanded`, `leftover`).
+representations (`original`, `combined`, `expanded`, `adjunct`).
 
 ```{doxygengroup} parse
 :project: pals-cpp

--- a/docs/src/develop.md
+++ b/docs/src/develop.md
@@ -17,7 +17,7 @@ The library sources live in `src/`, split by concern:
   `deep_copy_recursive`).
 - **`pals_expand.cpp`** — the lattice expansion pipeline that builds the
   five-tree representation (`original` / `combined` / `expanded` /
-  `full_expanded` / `leftover`): include splicing, `load` merging, structural
+  `full_expanded` / `adjunct`): include splicing, `load` merging, structural
   expansion (repeats, inherits, forks), expression, controller and `set`
   evaluation, and the element bookkeeper that walks each branch filling in
   reference parameters, floor placement, s-positions and dependent parameters.

--- a/docs/src/guide/trees.md
+++ b/docs/src/guide/trees.md
@@ -17,7 +17,7 @@ rather than part of the standard.
 | `combined` | those files spliced into one document |
 | `full_expanded` | one lattice, expanded, with every computed value |
 | `expanded` | the same lattice, back to the author's inputs |
-| `leftover` | everything the expanded trees do not carry |
+| `adjunct` | everything the expanded trees do not carry |
 
 All five are `YAMLTreeHandle`s, and each must be freed with `delete_tree`.
 Freeing one leaves the other four intact.
@@ -215,7 +215,7 @@ Two consequences worth being clear about:
 Use `expanded` to see what was asked for rather than what it implies, or to
 write a lattice back out without the derived values.
 
-### `leftover`
+### `adjunct`
 
 Everything the expanded trees do not carry, keeping the `PALS`/`facility`
 scaffolding it was written under: element and beamline definitions, `use`
@@ -224,21 +224,21 @@ statements, constants and variables, controllers, `set` commands, and any
 
 A definition substituted into the lattice is *copied* rather than moved, so it
 appears in both places: `d1` above is in the expanded lattice twice and still
-standing in `leftover` once, as the definition those two copies were made from.
+standing in `adjunct` once, as the definition those two copies were made from.
 
 ## Choosing a tree
 
 - **What does this lattice actually do?** `full_expanded`. It is the only tree
   that carries a dependent parameter, and the only one where each copy of a
   repeated element is a separate element with its own position and reference.
-- **What did the author write?** `expanded` for the lattice, `leftover` for
+- **What did the author write?** `expanded` for the lattice, `adjunct` for
   everything around it — the constants, the definitions, the controllers.
 - **Where in the file did this come from?** `original` and `combined`, which
   alone keep the expression text and the file structure.
-- **Writing a lattice back out?** `expanded` plus `leftover`.
+- **Writing a lattice back out?** `expanded` plus `adjunct`.
 
 `get_lattice_parameter_value` takes the pair that between them hold every value
-a lattice has: `full_expanded` for element parameters and `leftover` for
+a lattice has: `full_expanded` for element parameters and `adjunct` for
 constants, variables and unused definitions.
 
 ## Tracking a node across the trees
@@ -249,7 +249,7 @@ reconstructed afterwards by matching paths or names, so it survives the
 rearrangement that expansion does: one definition in `combined` maps to every
 copy expansion made of it.
 
-`original`, `combined`, `full_expanded` and `leftover` take part. `expanded`
+`original`, `combined`, `full_expanded` and `adjunct` take part. `expanded`
 does not: it is a pruned copy of `full_expanded` rather than a derivation of its
 own, so its nodes are found by path.
 

--- a/docs/src/guide/usage.md
+++ b/docs/src/guide/usage.md
@@ -23,7 +23,7 @@ separate, under `tests/lattices/`.
 `parse_and_expand_PALS` reads a lattice file, resolves its includes and loads,
 expands the selected lattice, and returns a `lattices` struct with five
 independent views —
-`original`, `combined`, `expanded`, `full_expanded`, and `leftover` (see
+`original`, `combined`, `expanded`, `full_expanded`, and `adjunct` (see
 [The five trees](trees.md)). Each is a `YAMLTreeHandle` and must be freed with
 `delete_tree`.
 
@@ -45,7 +45,7 @@ delete_tree(lat.original);
 delete_tree(lat.combined);
 delete_tree(lat.expanded);
 delete_tree(lat.full_expanded);
-delete_tree(lat.leftover);
+delete_tree(lat.adjunct);
 ```
 
 The second argument names the lattice to expand. Pass `nullptr` (or an empty
@@ -153,7 +153,7 @@ and `deep_copy_children`. Serialize with `node_to_string` / `tree_to_string`, or
 Three more entry points build on the expanded tree:
 
 - `build_correspondence_map` links a node across the derivation chain — `original`,
-  `combined`, `full_expanded` and `leftover` (their provenance is recorded as the
+  `combined`, `full_expanded` and `adjunct` (their provenance is recorded as the
   trees are derived from one another). `expanded` takes no part: it is a pruned
   copy of `full_expanded`, so its nodes are found by path.
 - `match_names` finds every named construct that a PALS *Name Matching* string
@@ -177,8 +177,8 @@ Three more entry points build on the expanded tree:
   else if (v.kind == PARAM_VALUE_STRING) { puts(v.string); yaml_free_string(v.string); }
   ```
 - `get_lattice_parameter_value` is the whole-lattice form: pass the `full_expanded`
-  and `leftover` handles from one `parse_and_expand_PALS()` result and it looks in
-  `full_expanded` first (element parameters), then `leftover` (constants, variables,
+  and `adjunct` handles from one `parse_and_expand_PALS()` result and it looks in
+  `full_expanded` first (element parameters), then `adjunct` (constants, variables,
   and unused definitions) — never in the raw `original`/`combined` trees. Values
   therefore come back already evaluated. Pass `full_expanded` rather than
   `expanded`: a dependent parameter is a legitimate thing to ask for, and only the

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,7 +46,7 @@ The result is returned as five independent views of the document:
 | `combined` | those files spliced into one document, still unevaluated |
 | `full_expanded` | one lattice, expanded, with every computed value |
 | `expanded` | the same lattice, back to the author's inputs |
-| `leftover` | everything the expanded trees do not carry — definitions, constants, controllers, unexpanded lattices |
+| `adjunct` | everything the expanded trees do not carry — definitions, constants, controllers, unexpanded lattices |
 
 See [The five trees](guide/trees.md) for what each one holds and which to reach
 for, [Building and using the library](guide/usage.md) to get started,
@@ -80,5 +80,5 @@ delete_tree(lat.original);
 delete_tree(lat.combined);
 delete_tree(lat.expanded);
 delete_tree(lat.full_expanded);
-delete_tree(lat.leftover);
+delete_tree(lat.adjunct);
 ```

--- a/examples/print_lattices.cpp
+++ b/examples/print_lattices.cpp
@@ -43,7 +43,7 @@ int main(int argc, char* argv[]) {
     std::cout << "========== Printing full expanded lattice ==========" << std::endl;
     std::cout << tree_to_string(lat.full_expanded) << std::endl << "\n\n";
 
-    std::cout << "========== Printing leftover ==========" << std::endl;
-    std::cout << tree_to_string(lat.leftover) << std::endl;
+    std::cout << "========== Printing adjunct ==========" << std::endl;
+    std::cout << tree_to_string(lat.adjunct) << std::endl;
     return 0;
 }

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -1,5 +1,5 @@
 // PALS lattice expansion pipeline: builds the four-tree representation
-// (original / combined / expanded / leftover) from a PALS YAML file. Splices
+// (original / combined / expanded / adjunct) from a PALS YAML file. Splices
 // includes, merges `load`ed files, expands the selected lattice (repeats,
 // inherits, forks), evaluates expressions into the expanded tree, and applies
 // the controllers that drive
@@ -46,7 +46,7 @@
 // prov[dst_node] = src_node for every copied node. The destination root keeps
 // no key even if src_node has one (a tree root cannot be keyed). `skip` names a
 // source node to leave out along with its descendants (ryml::NONE copies
-// everything); it is how the leftover tree is built as the document minus the
+// everything); it is how the adjunct tree is built as the document minus the
 // lattice that went into the expanded tree.
 static void deep_copy_tracked_except(ryml::Tree& dst_t, size_t dst_node,
                                      const ryml::Tree& src_t, size_t src_node,
@@ -89,7 +89,7 @@ static void deep_copy_tracked(ryml::Tree& dst_t, size_t dst_node,
 
 // Rewrite `prov` (ids -> ids in some intermediate tree) so that it points at
 // whatever that intermediate tree was itself derived from, using its own
-// provenance. This is what lets `expanded` and `leftover` be cut out of the
+// provenance. This is what lets `expanded` and `adjunct` be cut out of the
 // temporary work tree and still record provenance straight back to `combined`:
 // the work tree is discarded, so links through it would dangle. Nodes with no
 // entry in `via` (created during expansion, e.g. `destination_pointer`) have
@@ -4182,24 +4182,24 @@ static ParsedData* split_out_lattice(ryml::Tree& t, size_t lat_node,
     return out;
 }
 
-// Builds the `expanded`, `full_expanded` and `leftover` trees from `combined`.
+// Builds the `expanded`, `full_expanded` and `adjunct` trees from `combined`.
 //
 // Expansion has to run on the whole document at once — the lattice pulls in
 // element and beamline definitions from the rest of the file — so it happens on
 // a single throwaway work tree, which is then cut up: the root lattice is taken
 // twice, once whole as `full_expanded` and once pruned back to the author's
-// inputs as `expanded`, and `leftover` takes everything the lattice left behind.
+// inputs as `expanded`, and `adjunct` takes everything the lattice left behind.
 // All three record provenance straight back to `combined`, so the work tree can
 // be discarded.
-static void make_expanded_and_leftover(ParsedData* comb,
+static void make_expanded_and_adjunct(ParsedData* comb,
                                        const char* root_lattice,
                                        ProblemList& problems,
                                        YAMLTreeHandle& expanded_out,
                                        YAMLTreeHandle& full_expanded_out,
-                                       YAMLTreeHandle& leftover_out) {
+                                       YAMLTreeHandle& adjunct_out) {
     expanded_out = nullptr;
     full_expanded_out = nullptr;
-    leftover_out = nullptr;
+    adjunct_out = nullptr;
     if (!comb) return;
 
     ParsedData work;
@@ -4227,8 +4227,8 @@ static void make_expanded_and_leftover(ParsedData* comb,
     std::string name_str = root_lattice ? root_lattice : "";
     size_t lat_node = find_lattice(t, name_str);
 
-    // `skip` is the node the leftover tree must not copy: the lattice, together
-    // with the facility list entry wrapping it, so leftover is not left holding
+    // `skip` is the node the adjunct tree must not copy: the lattice, together
+    // with the facility list entry wrapping it, so adjunct is not left holding
     // an empty entry. A lattice that is not a lone entry under a wrapper (e.g.
     // one keyed directly into a map) is skipped on its own.
     size_t skip = ryml::NONE;
@@ -4332,7 +4332,7 @@ static void make_expanded_and_leftover(ParsedData* comb,
         prune_computed_params(mini->tree, entry, authored, mini->provenance);
     }
 
-    // leftover: the whole document minus what went to the expanded trees.
+    // adjunct: the whole document minus what went to the expanded trees.
     ParsedData* left = new ParsedData();
     left->tree.reserve(left->tree.capacity() + t.capacity() + 16);
     left->tree.reserve_arena(left->tree.arena_capacity() + t.arena_capacity());
@@ -4342,7 +4342,7 @@ static void make_expanded_and_leftover(ParsedData* comb,
 
     expanded_out = mini;
     full_expanded_out = full;
-    leftover_out = left;
+    adjunct_out = left;
 }
 
 /**
@@ -4466,7 +4466,7 @@ static struct lattices expand_document(ParsedData* src,
     ProblemList problems;
     // Built as a derivation chain so provenance can be recorded at each step:
     //   original --(splice includes, merge loads)--> combined
-    //   combined  --(expand, split)--> expanded, full_expanded, leftover
+    //   combined  --(expand, split)--> expanded, full_expanded, adjunct
     std::string parse_error;
     lat.original = make_original(src, top_path, parse_error);
     if (!parse_error.empty()) {
@@ -4487,9 +4487,9 @@ static struct lattices expand_document(ParsedData* src,
         // expansion made of it.
         check_pals_names(GET_TREE(lat.combined), problems);
 
-        make_expanded_and_leftover(static_cast<ParsedData*>(lat.combined),
+        make_expanded_and_adjunct(static_cast<ParsedData*>(lat.combined),
                                    root_lattice, problems, lat.expanded,
-                                   lat.full_expanded, lat.leftover);
+                                   lat.full_expanded, lat.adjunct);
     }
 
     // Hand the problem list to the caller as an owning C string array (freed
@@ -4543,10 +4543,10 @@ YAML_API double evaluate_pals_expression(const char* expr, bool* ok) {
 
 YAML_API struct correspondence_map build_correspondence_map(
     YAMLTreeHandle original, YAMLTreeHandle combined,
-    YAMLTreeHandle full_expanded, YAMLTreeHandle leftover) {
-    (void)original;  // provenance is in combined, full_expanded & leftover
+    YAMLTreeHandle full_expanded, YAMLTreeHandle adjunct) {
+    (void)original;  // provenance is in combined, full_expanded & adjunct
     struct correspondence_map out = {nullptr, 0};
-    if (!combined || (!full_expanded && !leftover)) return out;
+    if (!combined || (!full_expanded && !adjunct)) return out;
 
     ParsedData* comb = static_cast<ParsedData*>(combined);
     const std::map<size_t, size_t>& c2o = comb->provenance;  // combined->original
@@ -4557,7 +4557,7 @@ YAML_API struct correspondence_map build_correspondence_map(
     // exactly the live nodes are visited. Expansion splits the document in two,
     // so a link names a node in one derived tree and YAML_NULL_ID in the other;
     // the shared combined id is what ties the two sides together.
-    auto walk = [&](YAMLTreeHandle handle, bool is_leftover) {
+    auto walk = [&](YAMLTreeHandle handle, bool is_adjunct) {
         if (!handle) return;
         ParsedData* pd = static_cast<ParsedData*>(handle);
         const std::map<size_t, size_t>& d2c = pd->provenance;  // derived->combined
@@ -4570,8 +4570,8 @@ YAML_API struct correspondence_map build_correspondence_map(
             stack.pop_back();
 
             struct node_link link;
-            link.full_expanded = is_leftover ? YAML_NULL_ID : n;
-            link.leftover = is_leftover ? n : YAML_NULL_ID;
+            link.full_expanded = is_adjunct ? YAML_NULL_ID : n;
+            link.adjunct = is_adjunct ? n : YAML_NULL_ID;
             auto dc = d2c.find(n);
             if (dc != d2c.end()) {
                 link.combined = dc->second;
@@ -4590,7 +4590,7 @@ YAML_API struct correspondence_map build_correspondence_map(
     };
 
     walk(full_expanded, false);
-    walk(leftover, true);
+    walk(adjunct, true);
 
     out.count = links.size();
     if (out.count > 0) {

--- a/src/pals_match.cpp
+++ b/src/pals_match.cpp
@@ -368,7 +368,7 @@ static void match_const_var_in_pals(const ryml::Tree& t, size_t pals,
 }
 
 // Match constant/variable names across the tree. The PALS node sits at the root
-// in the combined, leftover and expanded views; in the `original` view it is
+// in the combined, adjunct and expanded views; in the `original` view it is
 // nested one level down under a per-file wrapper keyed by filename, and there
 // may be several (one per included file). Look in both places so a constant is
 // found in whichever tree actually holds it. The `seen` set keeps the root-level
@@ -517,14 +517,14 @@ YAML_API struct param_value get_parameter_value(YAMLTreeHandle tree,
 }
 
 YAML_API struct param_value get_lattice_parameter_value(
-    YAMLTreeHandle full_expanded, YAMLTreeHandle leftover,
+    YAMLTreeHandle full_expanded, YAMLTreeHandle adjunct,
     const char* match_string) {
     // Element parameters live in the expanded lattice; look there first.
     struct param_value v = get_parameter_value(full_expanded, match_string);
     if (v.kind != PARAM_VALUE_MISSING) return v;
     // Constants, variables and unused definitions live in the facility
-    // scaffolding kept by the leftover tree.
-    return get_parameter_value(leftover, match_string);
+    // scaffolding kept by the adjunct tree.
+    return get_parameter_value(adjunct, match_string);
 }
 
 }  // extern "C"

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -22,7 +22,7 @@
  *
  * @defgroup correspond Node correspondence
  * @brief Map a single logical node across the original, combined, full_expanded
- *        leftover trees.
+ *        adjunct trees.
  *
  * @defgroup namematch Name matching
  * @brief Resolve a PALS name-matching string to the nodes it selects.
@@ -106,7 +106,7 @@ struct lattices {
                                    ///< PALS/facility scaffolding it was defined
                                    ///< under. Every dependent parameter is
                                    ///< computed and present.
-    YAMLTreeHandle leftover;  ///< Everything the expanded trees do not carry —
+    YAMLTreeHandle adjunct;  ///< Everything the expanded trees do not carry —
                               ///< the whole PALS/facility document minus the
                               ///< root lattice, so element/beamline
                               ///< definitions, `use` statements, constants and
@@ -122,10 +122,10 @@ struct lattices {
  * @ingroup correspond
  *
  * The trees are built as a derivation chain (original -> combined ->
- * full_expanded and leftover), and provenance is recorded at every copy, so each
+ * full_expanded and adjunct), and provenance is recorded at every copy, so each
  * link records which node in each tree a single logical entity maps to.
  *
- * The mapping is functional per link: one full_expanded (or leftover) node maps
+ * The mapping is functional per link: one full_expanded (or adjunct) node maps
  * to at most one combined node, which maps to at most one original node. Because
  * expansion can duplicate nodes (scalar substitution, `repeat`, `inherit`,
  * forks), a single combined/original node may appear in several links — one per
@@ -134,10 +134,10 @@ struct lattices {
  * source).
  *
  * Expansion splits the document, so a link carries either a `full_expanded` id
- * or a `leftover` id, never both; the two are tied together through the
+ * or a `adjunct` id, never both; the two are tied together through the
  * `combined` id they share. A definition that was substituted into the lattice
  * therefore yields links on both sides: one for the copy in `full_expanded`, one
- * for the definition still standing in `leftover`.
+ * for the definition still standing in `adjunct`.
  *
  * The `expanded` tree is not mapped: it is a pruned copy of `full_expanded`, so
  * a node in it is found by the path it sits at, not by a recorded link.
@@ -147,7 +147,7 @@ struct node_link {
     YAMLNodeId combined;  ///< Node in the `combined` tree, or YAML_NULL_ID.
     YAMLNodeId full_expanded;  ///< Node in the `full_expanded` tree, or
                                ///< YAML_NULL_ID.
-    YAMLNodeId leftover;  ///< Node in the `leftover` tree, or YAML_NULL_ID.
+    YAMLNodeId adjunct;  ///< Node in the `adjunct` tree, or YAML_NULL_ID.
 };
 
 /**
@@ -155,7 +155,7 @@ struct node_link {
  * @ingroup correspond
  *
  * One link is emitted per node of the full_expanded tree and one per node of the
- * leftover tree. Free with free_correspondence_map().
+ * adjunct tree. Free with free_correspondence_map().
  */
 struct correspondence_map {
     struct node_link* links;  ///< The links (owning).
@@ -221,7 +221,7 @@ extern "C" {
  * both, with every `set` and ABSOLUTE controller applied. Use it to see what
  * was asked for rather than what it implies, or to write a lattice back out
  * without the derived values.
- *           - `leftover`: the rest of the document, keeping its PALS/facility
+ *           - `adjunct`: the rest of the document, keeping its PALS/facility
  * scaffolding: element and beamline definitions, `use` statements, constants,
  * and any Lattice that was not the one expanded. Definitions substituted into
  * the lattice are copies, so they appear in both trees.
@@ -304,7 +304,7 @@ YAML_API double evaluate_pals_expression(const char* expr, bool* ok);
  * @ingroup correspond
  *
  * Returns a flat list containing one `node_link` per node of the
- * `full_expanded` tree and one per node of the `leftover` tree. Each link gives
+ * `full_expanded` tree and one per node of the `adjunct` tree. Each link gives
  * the corresponding `combined` and `original` node ids (or YAML_NULL_ID where
  * none exists). Grouping the links by shared combined / original ids recovers,
  * for any node in any of those trees, the set of nodes it corresponds to in the
@@ -316,21 +316,21 @@ YAML_API double evaluate_pals_expression(const char* expr, bool* ok);
  * The handles must come from the same parse_and_expand_PALS() call — the
  * provenance recorded during that call is what makes the mapping exact. The
  * `original` handle is accepted for API symmetry; the mapping is derived from
- * the provenance stored in `combined`, `full_expanded` and `leftover`.
+ * the provenance stored in `combined`, `full_expanded` and `adjunct`.
  *
  * @param original      Handle to the `original` tree.
  * @param combined      Handle to the `combined` tree.
  * @param full_expanded Handle to the `full_expanded` tree.
- * @param leftover      Handle to the `leftover` tree. May be NULL, in which case
+ * @param adjunct      Handle to the `adjunct` tree. May be NULL, in which case
  *                      only the full_expanded tree is walked.
  * @return A correspondence_map. The caller must free it with
  *         free_correspondence_map(). `links` is NULL and `count` is 0 if
- *         `combined` is NULL, or if both `full_expanded` and `leftover` are
+ *         `combined` is NULL, or if both `full_expanded` and `adjunct` are
  *         NULL.
  */
 YAML_API struct correspondence_map build_correspondence_map(
     YAMLTreeHandle original, YAMLTreeHandle combined,
-    YAMLTreeHandle full_expanded, YAMLTreeHandle leftover);
+    YAMLTreeHandle full_expanded, YAMLTreeHandle adjunct);
 
 /**
  * Frees the link array owned by a correspondence_map. Passing a map with a NULL
@@ -430,7 +430,7 @@ struct param_value {
  * the `full_expanded` tree of a parse_and_expand_PALS() result, where constants and
  * variables referenced by a value have already been substituted; constants and
  * variables themselves live in the facility scaffolding, so look them up in any
- * view that keeps it — `original`, `combined`, or `leftover` — but not
+ * view that keeps it — `original`, `combined`, or `adjunct` — but not
  * the expanded trees, which drop it (exactly as with match_names()).
  *
  * The value is returned as stored; it is NOT evaluated. A plain numeric literal
@@ -464,14 +464,14 @@ YAML_API struct param_value get_parameter_value(YAMLTreeHandle tree,
 /**
  * Looks up a parameter value across the two trees of an expanded lattice that
  * carry live values: the `full_expanded` lattice (element parameters, already
- * evaluated) and the `leftover` facility scaffolding (constants, variables, and
+ * evaluated) and the `adjunct` facility scaffolding (constants, variables, and
  * any element/beamline definitions not spliced into the lattice).
  * @ingroup param
  *
  * This is the whole-lattice form of get_parameter_value(): the caller passes the
  * two relevant handles from a parse_and_expand_PALS() result instead of picking a
  * tree by hand. `full_expanded` is consulted first; only if it does not identify
- * the parameter is `leftover` tried. The `original` and `combined` trees are
+ * the parameter is `adjunct` tried. The `original` and `combined` trees are
  * deliberately not consulted — they hold raw, pre-expansion text, so a value read
  * from them would be unevaluated and, for reused definitions, duplicated. Pass
  * `full_expanded` rather than `expanded`: a dependent parameter is a legitimate
@@ -482,13 +482,13 @@ YAML_API struct param_value get_parameter_value(YAMLTreeHandle tree,
  * those of get_parameter_value().
  *
  * @param full_expanded Handle to the `full_expanded` tree (element parameters).
- * @param leftover      Handle to the `leftover` tree (constants/variables).
+ * @param adjunct      Handle to the `adjunct` tree (constants/variables).
  * @param match_string  Null-terminated name-matching string.
  * @return A param_value. If `kind` is PARAM_VALUE_STRING the caller must free
  *         `string` with yaml_free_string().
  */
 YAML_API struct param_value get_lattice_parameter_value(
-    YAMLTreeHandle full_expanded, YAMLTreeHandle leftover,
+    YAMLTreeHandle full_expanded, YAMLTreeHandle adjunct,
     const char* match_string);
 
 /**

--- a/src/yaml_tree.h
+++ b/src/yaml_tree.h
@@ -20,11 +20,11 @@
 // size_t within its tree.
 //
 // `provenance` links this tree back to the one it was derived from in the
-// original -> combined -> (expanded, full_expanded, leftover) chain: it maps a
+// original -> combined -> (expanded, full_expanded, adjunct) chain: it maps a
 // node id in *this* tree to the node id in the *source* tree it was copied from.
 // It is empty for trees that are not derived from another (e.g. `original`). For
 // `combined` it maps combined ids -> original ids; for the two expanded trees
-// and `leftover` alike it maps their ids -> combined ids.
+// and `adjunct` alike it maps their ids -> combined ids.
 struct ParsedData {
     ryml::Tree tree;
     std::string buffer;

--- a/tests/test_bookkeeper.cpp
+++ b/tests/test_bookkeeper.cpp
@@ -97,7 +97,7 @@ TEST_CASE("Bookkeeper fills reference energy, momentum, and time",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper accumulates s_position from element lengths",
@@ -119,7 +119,7 @@ TEST_CASE("Bookkeeper accumulates s_position from element lengths",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper derives the normalized multipole strength", "[bookkeeper]") {
@@ -141,7 +141,7 @@ TEST_CASE("Bookkeeper derives the normalized multipole strength", "[bookkeeper]"
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper caps each branch with a branch_end Placeholder",
@@ -175,7 +175,7 @@ TEST_CASE("Bookkeeper caps each branch with a branch_end Placeholder",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper numbers each element with its position in the branch",
@@ -207,7 +207,7 @@ TEST_CASE("Bookkeeper numbers each element with its position in the branch",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("element_index restarts at one in each branch", "[bookkeeper]") {
@@ -267,7 +267,7 @@ TEST_CASE("element_index restarts at one in each branch", "[bookkeeper]") {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // A branch with a single RFCavity, whose RFP body is spliced in from `rfp_body`
@@ -364,7 +364,7 @@ TEST_CASE("Bookkeeper derives RF voltage from gradient and active length",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper derives RF gradient from voltage and active length",
@@ -382,7 +382,7 @@ TEST_CASE("Bookkeeper derives RF gradient from voltage and active length",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper accepts consistent RF voltage and gradient",
@@ -402,7 +402,7 @@ TEST_CASE("Bookkeeper accepts consistent RF voltage and gradient",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper flags inconsistent RF voltage and gradient",
@@ -420,7 +420,7 @@ TEST_CASE("Bookkeeper flags inconsistent RF voltage and gradient",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper honors an explicit L_active for RF derivation",
@@ -440,7 +440,7 @@ TEST_CASE("Bookkeeper honors an explicit L_active for RF derivation",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper propagates floor coordinates through a bend",
@@ -474,7 +474,7 @@ TEST_CASE("Bookkeeper propagates floor coordinates through a bend",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper derives all bend strength forms from the angle",
@@ -512,7 +512,7 @@ TEST_CASE("Bookkeeper derives all bend strength forms from the angle",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper derives integrated and normalized multipole forms",
@@ -534,7 +534,7 @@ TEST_CASE("Bookkeeper derives integrated and normalized multipole forms",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper derives the integrated electric multipole", "[bookkeeper]") {
@@ -557,7 +557,7 @@ TEST_CASE("Bookkeeper derives the integrated electric multipole", "[bookkeeper]"
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper derives the bend length from its angle and radius",
@@ -592,7 +592,7 @@ TEST_CASE("Bookkeeper derives the bend length from its angle and radius",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper derives the bend angle from its chord", "[bookkeeper]") {
@@ -617,7 +617,7 @@ TEST_CASE("Bookkeeper derives the bend angle from its chord", "[bookkeeper]") {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper gives a straight bend three equal lengths",
@@ -642,7 +642,7 @@ TEST_CASE("Bookkeeper gives a straight bend three equal lengths",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper keeps the sagitta of a nearly straight bend",
@@ -669,7 +669,7 @@ TEST_CASE("Bookkeeper keeps the sagitta of a nearly straight bend",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper flags a chord that disagrees with the bend geometry",
@@ -692,7 +692,7 @@ TEST_CASE("Bookkeeper flags a chord that disagrees with the bend geometry",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper flags an inconsistent bend strength", "[bookkeeper]") {
@@ -712,7 +712,7 @@ TEST_CASE("Bookkeeper flags an inconsistent bend strength", "[bookkeeper]") {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper defaults the bend actual field from g_ref",
@@ -747,7 +747,7 @@ TEST_CASE("Bookkeeper defaults the bend actual field from g_ref",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper writes no actual field when Kn0_from_g_ref is false",
@@ -773,7 +773,7 @@ TEST_CASE("Bookkeeper writes no actual field when Kn0_from_g_ref is false",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper keeps an actual bend field the author set",
@@ -801,7 +801,7 @@ TEST_CASE("Bookkeeper keeps an actual bend field the author set",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper counts an integrated actual field as set",
@@ -827,7 +827,7 @@ TEST_CASE("Bookkeeper counts an integrated actual field as set",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper adds the actual field to a group of other multipoles",
@@ -852,7 +852,7 @@ TEST_CASE("Bookkeeper adds the actual field to a group of other multipoles",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper gives a straight bend no actual field", "[bookkeeper]") {
@@ -874,7 +874,7 @@ TEST_CASE("Bookkeeper gives a straight bend no actual field", "[bookkeeper]") {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper flags an inconsistent multipole component",
@@ -895,7 +895,7 @@ TEST_CASE("Bookkeeper flags an inconsistent multipole component",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper materializes RF enum defaults and L_active",
@@ -915,7 +915,7 @@ TEST_CASE("Bookkeeper materializes RF enum defaults and L_active",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Bookkeeper leaves absent parameter groups alone", "[bookkeeper]") {
@@ -937,5 +937,5 @@ TEST_CASE("Bookkeeper leaves absent parameter groups alone", "[bookkeeper]") {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }

--- a/tests/test_check.cpp
+++ b/tests/test_check.cpp
@@ -17,7 +17,7 @@ std::vector<std::string> problems_for(const char* yaml) {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
     return out;
 }
 

--- a/tests/test_controllers.cpp
+++ b/tests/test_controllers.cpp
@@ -33,7 +33,7 @@ void free_all(struct lattices& lat) {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // A one-branch lattice holding `body` elements, wrapped in the PALS/facility
@@ -121,46 +121,46 @@ TEST_CASE("parse_and_expand_PALS evaluates controller expressions",
                      "                      Kn0: 0.5\n");
 
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
-    REQUIRE(lat.leftover != nullptr);
+    REQUIRE(lat.adjunct != nullptr);
 
     const double cur1 = 0.023;
     const double cur2 = 1e8 / 2.99792458e8;
 
-    // Controllers are facility-level, so they are leftover rather than part of
+    // Controllers are facility-level, so they land in adjunct rather than in
     // the lattice; their expressions are evaluated all the same. An initial
     // value is a constant expression -- it may use the built-in and user
     // constants (c_light here) but no variable.
-    YAMLNodeId ps27 = facility_param(lat.leftover, "ps27");
+    YAMLNodeId ps27 = facility_param(lat.adjunct, "ps27");
     REQUIRE(ps27 != YAML_NULL_ID);
-    YAMLNodeId vars = get_child_by_key(lat.leftover, ps27, "variables");
-    REQUIRE(close(num_val(lat.leftover, get_child_by_key(lat.leftover, vars,
+    YAMLNodeId vars = get_child_by_key(lat.adjunct, ps27, "variables");
+    REQUIRE(close(num_val(lat.adjunct, get_child_by_key(lat.adjunct, vars,
                                                          "cur2")),
                   cur2));
 
     // Each control `expression` is computed and its value stored in place.
-    YAMLNodeId controls = get_child_by_key(lat.leftover, ps27, "controls");
-    YAMLNodeId c0 = get_child_by_index(lat.leftover, controls, 0);
-    REQUIRE(close(num_val(lat.leftover,
-                          get_child_by_key(lat.leftover, c0, "expression")),
+    YAMLNodeId controls = get_child_by_key(lat.adjunct, ps27, "controls");
+    YAMLNodeId c0 = get_child_by_index(lat.adjunct, controls, 0);
+    REQUIRE(close(num_val(lat.adjunct,
+                          get_child_by_key(lat.adjunct, c0, "expression")),
                   0.075 * std::sin(cur1) + 0.3 * cur2));
     // Control expressions may reference lattice constants (my_const = 2).
-    YAMLNodeId c1 = get_child_by_index(lat.leftover, controls, 1);
-    REQUIRE(close(num_val(lat.leftover,
-                          get_child_by_key(lat.leftover, c1, "expression")),
+    YAMLNodeId c1 = get_child_by_index(lat.adjunct, controls, 1);
+    REQUIRE(close(num_val(lat.adjunct,
+                          get_child_by_key(lat.adjunct, c1, "expression")),
                   cur1 * 2.0));
     // random_gauss() stays deferred, exactly as elsewhere.
-    YAMLNodeId c2 = get_child_by_index(lat.leftover, controls, 2);
-    REQUIRE(val_eq(lat.leftover, get_child_by_key(lat.leftover, c2, "expression"),
+    YAMLNodeId c2 = get_child_by_index(lat.adjunct, controls, 2);
+    REQUIRE(val_eq(lat.adjunct, get_child_by_key(lat.adjunct, c2, "expression"),
                    "0.01 + random_gauss()"));
 
     // The `parameter` target spec and `control_type` are names, left untouched,
     // and a MetaP rides along for documentation.
-    REQUIRE(val_eq(lat.leftover, get_child_by_key(lat.leftover, c0, "parameter"),
+    REQUIRE(val_eq(lat.adjunct, get_child_by_key(lat.adjunct, c0, "parameter"),
                    "Qa.*>MagneticMultipoleP.Ks2L"));
-    REQUIRE(val_eq(lat.leftover,
-                   get_child_by_key(lat.leftover, ps27, "control_type"),
+    REQUIRE(val_eq(lat.adjunct,
+                   get_child_by_key(lat.adjunct, ps27, "control_type"),
                    "ABSOLUTE"));
-    REQUIRE(get_child_by_key(lat.leftover, ps27, "MetaP") != YAML_NULL_ID);
+    REQUIRE(get_child_by_key(lat.adjunct, ps27, "MetaP") != YAML_NULL_ID);
 
     // The combined tree keeps the original controller expression text.
     YAMLNodeId c_ps27 = facility_param(lat.combined, "ps27");
@@ -252,9 +252,9 @@ TEST_CASE("several ABSOLUTE controllers on one parameter sum",
                   0.075 * std::sin(0.023) + 0.123 * 0.044));
 
     // An omitted control_type is materialized as the ABSOLUTE default.
-    YAMLNodeId ps1 = facility_param(lat.leftover, "ps1");
-    REQUIRE(val_eq(lat.leftover,
-                   get_child_by_key(lat.leftover, ps1, "control_type"),
+    YAMLNodeId ps1 = facility_param(lat.adjunct, "ps1");
+    REQUIRE(val_eq(lat.adjunct,
+                   get_child_by_key(lat.adjunct, ps1, "control_type"),
                    "ABSOLUTE"));
 
     free_all(lat);
@@ -346,11 +346,11 @@ TEST_CASE("a RELATIVE controller leaves the lattice alone",
                                  "Kn2L"),
                   0.33));
 
-    YAMLNodeId chrom = facility_param(lat.leftover, "chrom_a");
+    YAMLNodeId chrom = facility_param(lat.adjunct, "chrom_a");
     YAMLNodeId cc0 = get_child_by_index(
-        lat.leftover, get_child_by_key(lat.leftover, chrom, "controls"), 0);
-    REQUIRE(close(num_val(lat.leftover,
-                          get_child_by_key(lat.leftover, cc0, "expression")),
+        lat.adjunct, get_child_by_key(lat.adjunct, chrom, "controls"), 0);
+    REQUIRE(close(num_val(lat.adjunct,
+                          get_child_by_key(lat.adjunct, cc0, "expression")),
                   5.62 * 0.4 + 0.02 * 0.4 * 0.4));
 
     free_all(lat);
@@ -390,10 +390,10 @@ TEST_CASE("a controller drives another controller's variable",
     REQUIRE(close(expanded_param(lat.full_expanded, "Q1", "MagneticMultipoleP",
                                  "Kn1L"),
                   7.5));
-    YAMLNodeId low = facility_param(lat.leftover, "low");
-    YAMLNodeId lvars = get_child_by_key(lat.leftover, low, "variables");
-    REQUIRE(close(num_val(lat.leftover,
-                          get_child_by_key(lat.leftover, lvars, "cur")),
+    YAMLNodeId low = facility_param(lat.adjunct, "low");
+    YAMLNodeId lvars = get_child_by_key(lat.adjunct, low, "variables");
+    REQUIRE(close(num_val(lat.adjunct,
+                          get_child_by_key(lat.adjunct, lvars, "cur")),
                   0.75));
 
     free_all(lat);

--- a/tests/test_correspondence.cpp
+++ b/tests/test_correspondence.cpp
@@ -16,18 +16,18 @@ TEST_CASE("build_correspondence_map links the document roots", "[correspondence]
         parse_and_expand_PALS(lattice_file("ex.pals.yaml").c_str(), nullptr);
     struct correspondence_map m =
         build_correspondence_map(lat.original, lat.combined, lat.full_expanded,
-                                 lat.leftover);
+                                 lat.adjunct);
 
     REQUIRE(m.count > 0);
 
-    // leftover is what still carries the document root, so that is the node
+    // adjunct is what still carries the document root, so that is the node
     // corresponding to the combined root. (The expanded root is synthesised to
     // hold the lattice entry and has no counterpart — see below.)
-    YAMLNodeId left_root = get_root(lat.leftover);
+    YAMLNodeId left_root = get_root(lat.adjunct);
 
     bool found_root = false;
     for (size_t i = 0; i < m.count; i++) {
-        if (m.links[i].leftover == left_root) {
+        if (m.links[i].adjunct == left_root) {
             found_root = true;
             REQUIRE(m.links[i].combined == get_root(lat.combined));
             // The original tree's first child is the top-level file's contents.
@@ -38,7 +38,7 @@ TEST_CASE("build_correspondence_map links the document roots", "[correspondence]
         }
         // A link names a node in exactly one of the two derived trees.
         REQUIRE((m.links[i].full_expanded == YAML_NULL_ID) !=
-                (m.links[i].leftover == YAML_NULL_ID));
+                (m.links[i].adjunct == YAML_NULL_ID));
     }
     REQUIRE(found_root);
 
@@ -47,11 +47,11 @@ TEST_CASE("build_correspondence_map links the document roots", "[correspondence]
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // A definition that expansion substituted into the lattice is a copy: the
-// definition still stands in leftover, so the same combined node reaches both
+// definition still stands in adjunct, so the same combined node reaches both
 // trees.
 TEST_CASE("build_correspondence_map ties the two trees through combined",
           "[correspondence]") {
@@ -59,10 +59,10 @@ TEST_CASE("build_correspondence_map ties the two trees through combined",
         parse_and_expand_PALS(lattice_file("ex.pals.yaml").c_str(), "lat1");
     struct correspondence_map m =
         build_correspondence_map(lat.original, lat.combined, lat.full_expanded,
-                                 lat.leftover);
+                                 lat.adjunct);
 
     // inj_line is defined at facility level and used by lat1's branches, so it
-    // is expanded into lat1 while its definition stays in leftover.
+    // is expanded into lat1 while its definition stays in adjunct.
     std::map<YAMLNodeId, int> sides;  // combined id -> bitmask of trees reached
     for (size_t i = 0; i < m.count; i++) {
         if (m.links[i].combined == YAML_NULL_ID) continue;
@@ -80,14 +80,14 @@ TEST_CASE("build_correspondence_map ties the two trees through combined",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
     free_lattice_problems(lat.problems);
 }
 
 TEST_CASE("build_correspondence_map connects a node across trees by value",
           "[correspondence]") {
     // A constant that lives outside the expanded lattice is not part of it, so
-    // it lands in leftover; the map must still connect it back to combined and
+    // it lands in adjunct; the map must still connect it back to combined and
     // original.
     const char* doc =
         "PALS:\n"
@@ -110,20 +110,20 @@ TEST_CASE("build_correspondence_map connects a node across trees by value",
     struct lattices lat = expand_PALS_string(doc, nullptr);
     struct correspondence_map m =
         build_correspondence_map(lat.original, lat.combined, lat.full_expanded,
-                                 lat.leftover);
+                                 lat.adjunct);
 
-    // Locate a_const in the leftover tree: facility[0] -> constants -> a_const.
-    YAMLNodeId l_const = get_child_by_index(lat.leftover, facility_of(lat.leftover), 0);
+    // Locate a_const in the adjunct tree: facility[0] -> constants -> a_const.
+    YAMLNodeId l_const = get_child_by_index(lat.adjunct, facility_of(lat.adjunct), 0);
     YAMLNodeId l_a_const =
-        get_child_by_key(lat.leftover,
-                         get_child_by_key(lat.leftover, l_const, "constants"),
+        get_child_by_key(lat.adjunct,
+                         get_child_by_key(lat.adjunct, l_const, "constants"),
                          "a_const");
     REQUIRE(l_a_const != YAML_NULL_ID);
     // Expressions are evaluated across the whole document before it is split, so
-    // this constant holds a number in leftover too; the combined/original copies
+    // this constant holds a number in adjunct too; the combined/original copies
     // (checked below) still carry the original expression text.
     {
-        char* s = as_string(lat.leftover, l_a_const);
+        char* s = as_string(lat.adjunct, l_a_const);
         REQUIRE(s != nullptr);
         double got = std::strtod(s, nullptr);
         yaml_free_string(s);
@@ -136,7 +136,7 @@ TEST_CASE("build_correspondence_map connects a node across trees by value",
     // Find its link and follow it to the combined and original copies.
     bool found = false;
     for (size_t i = 0; i < m.count; i++) {
-        if (m.links[i].leftover != l_a_const) continue;
+        if (m.links[i].adjunct != l_a_const) continue;
         found = true;
         REQUIRE(m.links[i].full_expanded == YAML_NULL_ID);
         REQUIRE(m.links[i].combined != YAML_NULL_ID);
@@ -151,7 +151,7 @@ TEST_CASE("build_correspondence_map connects a node across trees by value",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("build_correspondence_map maps one source to many expanded copies",
@@ -182,7 +182,7 @@ TEST_CASE("build_correspondence_map maps one source to many expanded copies",
     struct lattices lat = expand_PALS_string(doc, nullptr);
     struct correspondence_map m =
         build_correspondence_map(lat.original, lat.combined, lat.full_expanded,
-                                 lat.leftover);
+                                 lat.adjunct);
 
     // Unrolling `repeat: 3` over a one-element cell produces three `d1` entries
     // in the expanded line, all copied from the same combined source. They are
@@ -192,7 +192,7 @@ TEST_CASE("build_correspondence_map maps one source to many expanded copies",
     // them without expanding them.)
     std::map<YAMLNodeId, int> combined_hits;
     for (size_t i = 0; i < m.count; i++) {
-        // Skip the leftover half of the map: those ids index a different tree.
+        // Skip the adjunct half of the map: those ids index a different tree.
         if (m.links[i].full_expanded == YAML_NULL_ID) continue;
         if (!key_eq(lat.full_expanded, m.links[i].full_expanded, "d1")) continue;
         REQUIRE(m.links[i].combined != YAML_NULL_ID);  // has a source
@@ -207,5 +207,5 @@ TEST_CASE("build_correspondence_map maps one source to many expanded copies",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }

--- a/tests/test_expanded_minus_dependent.cpp
+++ b/tests/test_expanded_minus_dependent.cpp
@@ -151,7 +151,7 @@ void free_all(struct lattices& lat) {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // True when `ele` in `t` carries `group`, and `group` carries `param`. A null

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -10,12 +10,12 @@ TEST_CASE("parse_and_expand_PALS returns four non-null handles", "[lattices]") {
     REQUIRE(lat.original != nullptr);
     REQUIRE(lat.combined != nullptr);
     REQUIRE(lat.full_expanded != nullptr);
-    REQUIRE(lat.leftover != nullptr);
+    REQUIRE(lat.adjunct != nullptr);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // The expanded tree holds the root lattice and nothing else: no PALS/facility
@@ -40,24 +40,24 @@ TEST_CASE("expanded holds only the root lattice", "[lattices]") {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
     free_lattice_problems(lat.problems);
 }
 
 // Everything else stays behind, under its PALS/facility scaffolding — including
 // the lattice that was not expanded.
-TEST_CASE("leftover keeps the rest of the document", "[lattices]") {
+TEST_CASE("adjunct keeps the rest of the document", "[lattices]") {
     struct lattices lat =
         parse_and_expand_PALS(lattice_file("ex.pals.yaml").c_str(), "lat1");
-    YAMLNodeId fac = facility_of(lat.leftover);
+    YAMLNodeId fac = facility_of(lat.adjunct);
     REQUIRE(fac != YAML_NULL_ID);
 
     bool saw_lat1 = false, saw_lat2 = false, saw_thingB = false;
-    for (size_t i = 0; i < get_size(lat.leftover, fac); i++) {
-        YAMLNodeId item = get_child_by_index(lat.leftover, fac, i);
-        if (get_size(lat.leftover, item) != 1) continue;
-        char* key = get_node_key(lat.leftover,
-                                 get_child_by_index(lat.leftover, item, 0));
+    for (size_t i = 0; i < get_size(lat.adjunct, fac); i++) {
+        YAMLNodeId item = get_child_by_index(lat.adjunct, fac, i);
+        if (get_size(lat.adjunct, item) != 1) continue;
+        char* key = get_node_key(lat.adjunct,
+                                 get_child_by_index(lat.adjunct, item, 0));
         std::string k(key ? key : "");
         yaml_free_string(key);
         if (k == "lat1") saw_lat1 = true;
@@ -66,14 +66,14 @@ TEST_CASE("leftover keeps the rest of the document", "[lattices]") {
     }
 
     REQUIRE_FALSE(saw_lat1);  // moved to expanded
-    REQUIRE(saw_lat2);        // a non-root Lattice is leftover like anything else
+    REQUIRE(saw_lat2);        // a non-root Lattice goes to adjunct like anything else
     REQUIRE(saw_thingB);      // element definitions stay put
 
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
     free_lattice_problems(lat.problems);
 }
 
@@ -111,7 +111,7 @@ TEST_CASE("destination_pointer resolves inside the expanded tree", "[lattices]")
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
     free_lattice_problems(lat.problems);
 }
 
@@ -204,10 +204,10 @@ TEST_CASE("Expansion drops `kind: BeamLine` from every branch", "[lattices]") {
                    "Quadrupole"));
 
     // Expansion copies a definition rather than moving it, and the definition
-    // left standing in leftover is a BeamLine still.
-    YAMLNodeId l_main = facility_param(lat.leftover, "main");
+    // left standing in adjunct is a BeamLine still.
+    YAMLNodeId l_main = facility_param(lat.adjunct, "main");
     REQUIRE(l_main != YAML_NULL_ID);
-    REQUIRE(val_eq(lat.leftover, get_child_by_key(lat.leftover, l_main, "kind"),
+    REQUIRE(val_eq(lat.adjunct, get_child_by_key(lat.adjunct, l_main, "kind"),
                    "BeamLine"));
 
     free_lattice_problems(lat.problems);
@@ -215,7 +215,7 @@ TEST_CASE("Expansion drops `kind: BeamLine` from every branch", "[lattices]") {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // A branch's `inherit` is optional and defaults to the branch's own name
@@ -284,7 +284,7 @@ TEST_CASE("A branch with no inherit takes its root BeamLine from its name",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // A written `inherit` names the root BeamLine outright, and the default must not
@@ -347,7 +347,7 @@ TEST_CASE("An explicit branch inherit wins over the branch name", "[lattices]") 
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // A branch that comes out of expansion with no elements is reported in its own
@@ -363,7 +363,7 @@ TEST_CASE("An empty branch is reported", "[lattices][problems]") {
         delete_tree(lat.combined);
         delete_tree(lat.expanded);
         delete_tree(lat.full_expanded);
-        delete_tree(lat.leftover);
+        delete_tree(lat.adjunct);
         return msgs;
     };
     auto has = [](const std::vector<std::string>& msgs, const char* needle) {
@@ -473,7 +473,7 @@ TEST_CASE("parse_and_expand_PALS reports expansion problems",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("repeat with an unusable count keeps the entry",
@@ -522,7 +522,7 @@ TEST_CASE("repeat with an unusable count keeps the entry",
         delete_tree(lat.combined);
         delete_tree(lat.expanded);
         delete_tree(lat.full_expanded);
-        delete_tree(lat.leftover);
+        delete_tree(lat.adjunct);
         return reported && kept;
     };
 
@@ -598,7 +598,7 @@ TEST_CASE("repeat expands the copies it splices", "[lattices]") {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("parse_and_expand_PALS reports a missing lattice",
@@ -615,18 +615,18 @@ TEST_CASE("parse_and_expand_PALS reports a missing lattice",
     REQUIRE(std::string(lat.problems.items[0]) == "lattice 'not_here' not found");
 
     // With no lattice to expand, expanded is an empty map and the whole document
-    // is leftover — both handles are still valid.
+    // lands in adjunct — both handles are still valid.
     REQUIRE(lat.full_expanded != nullptr);
-    REQUIRE(lat.leftover != nullptr);
+    REQUIRE(lat.adjunct != nullptr);
     REQUIRE(get_size(lat.full_expanded, get_root(lat.full_expanded)) == 0);
-    REQUIRE(facility_of(lat.leftover) != YAML_NULL_ID);
+    REQUIRE(facility_of(lat.adjunct) != YAML_NULL_ID);
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("a Fork with a ForkP sequence is reported as wrong-shape, not missing",
@@ -676,7 +676,7 @@ TEST_CASE("a Fork with a ForkP sequence is reported as wrong-shape, not missing"
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("a Fork needs only to_line; destination_element and new_branch default",
@@ -739,7 +739,7 @@ TEST_CASE("a Fork needs only to_line; destination_element and new_branch default
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // Helper: the keyed element definition of a branch's first line element.
@@ -826,7 +826,7 @@ TEST_CASE("a Fork propagates reference and floor into its new branch",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("propagate_reference: false leaves the new branch's reference unset",
@@ -889,7 +889,7 @@ TEST_CASE("propagate_reference: false leaves the new branch's reference unset",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("a half-declared branch reference is reported for what it lacks",
@@ -953,7 +953,7 @@ TEST_CASE("a half-declared branch reference is reported for what it lacks",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("new_branch: null forks into an existing branch, creating none",
@@ -1031,7 +1031,7 @@ TEST_CASE("new_branch: null forks into an existing branch, creating none",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("a destination of a kind that cannot be forked to is reported",
@@ -1095,7 +1095,7 @@ TEST_CASE("a destination of a kind that cannot be forked to is reported",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("a fork destination lists its incoming Forks in ForkFromP",
@@ -1167,7 +1167,7 @@ TEST_CASE("a fork destination lists its incoming Forks in ForkFromP",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // Read `ForkP.forked_to` off an element of a branch line.
@@ -1254,7 +1254,7 @@ TEST_CASE("a Fork names its destination in ForkP.forked_to", "[lattices]") {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("a Fork inside a forked-to branch resolves exactly once",
@@ -1334,7 +1334,7 @@ TEST_CASE("a Fork inside a forked-to branch resolves exactly once",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // Every node keyed `key` in the tree, in walk order.
@@ -1459,7 +1459,7 @@ TEST_CASE("a destination_pointer survives expression substitution intact",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("new_branch: null with a to_line that is not a branch is reported",
@@ -1505,7 +1505,7 @@ TEST_CASE("new_branch: null with a to_line that is not a branch is reported",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("a document held in a string expands like one read from a file",
@@ -1542,7 +1542,7 @@ TEST_CASE("a document held in a string expands like one read from a file",
         delete_tree(lat->combined);
         delete_tree(lat->expanded);
         delete_tree(lat->full_expanded);
-        delete_tree(lat->leftover);
+        delete_tree(lat->adjunct);
     }
 }
 
@@ -1581,7 +1581,7 @@ TEST_CASE("a malformed top-level file is a fatal parse problem, not a crash",
     REQUIRE(lat.original == nullptr);
     REQUIRE(lat.combined == nullptr);
     REQUIRE(lat.full_expanded == nullptr);
-    REQUIRE(lat.leftover == nullptr);
+    REQUIRE(lat.adjunct == nullptr);
 
     // A single problem, naming the file and the offending line.
     REQUIRE(lat.problems.count == 1);
@@ -1594,5 +1594,5 @@ TEST_CASE("a malformed top-level file is a fatal parse problem, not a crash",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }

--- a/tests/test_expressions.cpp
+++ b/tests/test_expressions.cpp
@@ -164,12 +164,12 @@ TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
     REQUIRE(val_eq(lat.full_expanded, kn2, "0.01 + 0.003*random_gauss()"));
 
     // Expressions are evaluated before the document is split, so a definition
-    // that stayed behind is evaluated in leftover just the same. `m_e` is not
-    // referenced by the lattice, so leftover is the only place it exists.
-    YAMLNodeId m_e = facility_param(lat.leftover, "m_e");
+    // that stayed behind is evaluated in adjunct just the same. `m_e` is not
+    // referenced by the lattice, so adjunct is the only place it exists.
+    YAMLNodeId m_e = facility_param(lat.adjunct, "m_e");
     REQUIRE(m_e != YAML_NULL_ID);
-    YAMLNodeId m_e_val = get_child_by_key(lat.leftover, m_e, "value");
-    REQUIRE(close(num_val(lat.leftover, m_e_val), 510998.95069000003));
+    YAMLNodeId m_e_val = get_child_by_key(lat.adjunct, m_e, "value");
+    REQUIRE(close(num_val(lat.adjunct, m_e_val), 510998.95069000003));
     REQUIRE(find_by_key(lat.full_expanded, "m_e") == YAML_NULL_ID);
 
     // The combined tree keeps the original expression text (evaluation happens
@@ -182,7 +182,7 @@ TEST_CASE("parse_and_expand_PALS evaluates expressions in the expanded tree",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("parse_and_expand_PALS resolves map-form constants/variables",
@@ -218,16 +218,16 @@ TEST_CASE("parse_and_expand_PALS resolves map-form constants/variables",
     const double a_const = 0.3 * evaluate_pals_expression("r_electron", nullptr);
 
     // constants/variables blocks are not part of the lattice, so they are
-    // leftover — evaluated all the same.
-    YAMLNodeId consts = facility_param(lat.leftover, "constants");
-    REQUIRE(close(num_val(lat.leftover,
-                          get_child_by_key(lat.leftover, consts, "a_const")),
+    // adjunct — evaluated all the same.
+    YAMLNodeId consts = facility_param(lat.adjunct, "constants");
+    REQUIRE(close(num_val(lat.adjunct,
+                          get_child_by_key(lat.adjunct, consts, "a_const")),
                   a_const));
 
     // a_var references the map-form constant a_const defined above it.
-    YAMLNodeId vars = facility_param(lat.leftover, "variables");
-    REQUIRE(close(num_val(lat.leftover,
-                          get_child_by_key(lat.leftover, vars, "a_var")),
+    YAMLNodeId vars = facility_param(lat.adjunct, "variables");
+    REQUIRE(close(num_val(lat.adjunct,
+                          get_child_by_key(lat.adjunct, vars, "a_var")),
                   a_const * a_const));
 
     // An element parameter may reference the map-form definitions too; this is
@@ -242,7 +242,7 @@ TEST_CASE("parse_and_expand_PALS resolves map-form constants/variables",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("parse_and_expand_PALS resolves element-parameter references",
@@ -294,7 +294,7 @@ TEST_CASE("parse_and_expand_PALS resolves element-parameter references",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
@@ -329,9 +329,9 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
 
     const double m_3he = 2809413528.3197904;  // mass_of("#3He"), CODATA 2022
 
-    YAMLNodeId consts = facility_param(lat.leftover, "constants");
-    REQUIRE(close(num_val(lat.leftover,
-                          get_child_by_key(lat.leftover, consts, "b_const")),
+    YAMLNodeId consts = facility_param(lat.adjunct, "constants");
+    REQUIRE(close(num_val(lat.adjunct,
+                          get_child_by_key(lat.adjunct, consts, "b_const")),
                   0.45 * m_3he));
 
     YAMLNodeId dh1a = find_by_key(lat.full_expanded, "DH1A");
@@ -349,8 +349,8 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
                    "#3He"));
 
     // The species constant itself stays as its (string) species name.
-    REQUIRE(val_eq(lat.leftover,
-                   get_child_by_key(lat.leftover, consts, "species"), "#3He"));
+    REQUIRE(val_eq(lat.adjunct,
+                   get_child_by_key(lat.adjunct, consts, "species"), "#3He"));
 
     // No spurious problems.
     REQUIRE(lat.problems.count == 0);
@@ -360,7 +360,7 @@ TEST_CASE("parse_and_expand_PALS resolves a species-name constant",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("parse_and_expand_PALS leaves root prose alone", "[expr][lattices]") {
@@ -403,7 +403,7 @@ TEST_CASE("parse_and_expand_PALS leaves root prose alone", "[expr][lattices]") {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 namespace {
@@ -440,7 +440,7 @@ std::vector<std::string> problems_for_value(const std::string& value) {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
     return out;
 }
 
@@ -530,5 +530,5 @@ TEST_CASE("a controller says why an expression failed", "[expr][controllers]") {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }

--- a/tests/test_key_order.cpp
+++ b/tests/test_key_order.cpp
@@ -129,5 +129,5 @@ TEST_CASE("Expansion preserves the key order of the source file", "[key_order]")
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }

--- a/tests/test_load.cpp
+++ b/tests/test_load.cpp
@@ -23,7 +23,7 @@ struct LoadCase {
         delete_tree(lat.combined);
         delete_tree(lat.expanded);
         delete_tree(lat.full_expanded);
-        delete_tree(lat.leftover);
+        delete_tree(lat.adjunct);
     }
 
     void parse(const std::string& rel, const char* root_lattice = nullptr) {

--- a/tests/test_multipass.cpp
+++ b/tests/test_multipass.cpp
@@ -73,7 +73,7 @@ TEST_CASE("Multipass sub-lines are numbered with a multipass_index",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 TEST_CASE("Nested multipass lines: the nearest multipass line wins",
@@ -127,5 +127,5 @@ TEST_CASE("Nested multipass lines: the nearest multipass line wins",
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }

--- a/tests/test_parameters.cpp
+++ b/tests/test_parameters.cpp
@@ -138,10 +138,10 @@ TEST_CASE("constants are found under the original tree's per-file wrapper",
     delete_tree(t);
 }
 
-TEST_CASE("get_lattice_parameter_value tries expanded, then leftover",
+TEST_CASE("get_lattice_parameter_value tries expanded, then adjunct",
           "[param]") {
     // Stand-ins for the two live trees of a parse_and_expand_PALS() result: the
-    // expanded lattice carries element parameters; the leftover facility carries
+    // expanded lattice carries element parameters; the adjunct facility carries
     // constants and variables.
     YAMLTreeHandle expanded = parse_string(
         "fodo:\n"
@@ -150,7 +150,7 @@ TEST_CASE("get_lattice_parameter_value tries expanded, then leftover",
         "    - main:\n"
         "        line:\n"
         "          - Q1: {kind: Quadrupole, length: 0.5}\n");
-    YAMLTreeHandle leftover = parse_string(
+    YAMLTreeHandle adjunct = parse_string(
         "PALS:\n"
         "  facility:\n"
         "    - constants:\n"
@@ -158,21 +158,21 @@ TEST_CASE("get_lattice_parameter_value tries expanded, then leftover",
 
     // An element parameter is found in the expanded tree.
     struct param_value v =
-        get_lattice_parameter_value(expanded, leftover, "Q1>length");
+        get_lattice_parameter_value(expanded, adjunct, "Q1>length");
     REQUIRE(v.kind == PARAM_VALUE_NUMBER);
     REQUIRE(v.number == Catch::Approx(0.5));
 
-    // A constant is not in expanded, so leftover is consulted.
-    v = get_lattice_parameter_value(expanded, leftover, "a_two");
+    // A constant is not in expanded, so adjunct is consulted.
+    v = get_lattice_parameter_value(expanded, adjunct, "a_two");
     REQUIRE(v.kind == PARAM_VALUE_NUMBER);
     REQUIRE(v.number == Catch::Approx(5.0));
 
     // Found in neither -> missing.
-    REQUIRE(get_lattice_parameter_value(expanded, leftover, "nope>x").kind ==
+    REQUIRE(get_lattice_parameter_value(expanded, adjunct, "nope>x").kind ==
             PARAM_VALUE_MISSING);
 
     // Either handle may be NULL.
-    REQUIRE(get_lattice_parameter_value(nullptr, leftover, "a_two").kind ==
+    REQUIRE(get_lattice_parameter_value(nullptr, adjunct, "a_two").kind ==
             PARAM_VALUE_NUMBER);
     REQUIRE(get_lattice_parameter_value(expanded, nullptr, "Q1>length").kind ==
             PARAM_VALUE_NUMBER);
@@ -180,7 +180,7 @@ TEST_CASE("get_lattice_parameter_value tries expanded, then leftover",
             PARAM_VALUE_MISSING);
 
     delete_tree(expanded);
-    delete_tree(leftover);
+    delete_tree(adjunct);
 }
 
 TEST_CASE("get_parameter_value collapses agreeing matches, rejects conflicts",

--- a/tests/test_sets.cpp
+++ b/tests/test_sets.cpp
@@ -31,7 +31,7 @@ void free_all(struct lattices& lat) {
     delete_tree(lat.combined);
     delete_tree(lat.expanded);
     delete_tree(lat.full_expanded);
-    delete_tree(lat.leftover);
+    delete_tree(lat.adjunct);
 }
 
 // A file whose `facility` list is exactly `body` (10-space indented entries),


### PR DESCRIPTION
Renames the tree that holds everything the expanded views do not carry from `leftover` to `adjunct`.

Mechanical rename, no behavior change:
- `struct lattices::leftover` and `struct node_link::leftover` (`src/yaml_c_wrapper.h`)
- the `leftover` parameters of `build_correspondence_map()` and `get_lattice_parameter_value()`
- internal uses in `src/pals_expand.cpp` and `src/pals_match.cpp`
- `examples/print_lattices.cpp`, `docs/src/*`, and the tests

Three comments where the old word doubled as an adjective ("they are leftover rather than part of the lattice") were reworded rather than substituted.

The companion rename in PALSJulia.jl is in pals-project/PALSJulia.jl.

Builds clean; all 1443 assertions in 246 test cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)