### PR TITLE
Say what kind of problem each problem is

### DIFF
--- a/docs/src/guide/usage.md
+++ b/docs/src/guide/usage.md
@@ -38,7 +38,7 @@ yaml_free_string(s);
 
 // Report any problems met while expanding (see below), then free everything.
 for (size_t i = 0; i < lat.problems.count; ++i)
-    std::fprintf(stderr, "  - %s\n", lat.problems.items[i]);
+    std::fprintf(stderr, "  - %s\n", lat.problems.items[i].message);
 free_lattice_problems(lat.problems);
 
 delete_tree(lat.original);
@@ -70,11 +70,26 @@ file that made it.
 ### Problems found during expansion
 
 Expansion does not abort on a recoverable problem. It leaves the offending
-value as it found it, carries on with the rest of the lattice, and appends a
-human‑readable message to `lat.problems`, an owning `string_list`. The list is
-empty when expansion was clean. The library never prints — the caller decides
-whether to report, save, or ignore the messages — and must release the list
-with `free_lattice_problems`.
+value as it found it, carries on with the rest of the lattice, and appends an
+entry to `lat.problems`, an owning `problem_list`. The list is empty when
+expansion was clean. The library never prints — the caller decides whether to
+report, save, or ignore what it finds — and must release the list with
+`free_lattice_problems`.
+
+Each entry carries more than its `message`. A `path` gives the logical spot it
+was found at (`q1>ApertureP.shape`), empty when the problem is not tied to one
+place. The other two answer questions a caller usually has to guess at:
+
+- `severity` — `PROBLEM_ERROR` when the trees can no longer be trusted around
+  the fault, `PROBLEM_WARNING` when expansion produced a sound result anyway.
+- `origin` — `PROBLEM_INPUT` when the lattice author can fix it,
+  `PROBLEM_UNSUPPORTED` when it is valid PALS this library does not implement
+  yet, and `PROBLEM_UNSPECIFIED` when the standard does not define the case, so
+  nothing was invented.
+
+Editing the lattice can only ever clear a `PROBLEM_INPUT`, which is what makes
+the distinction worth carrying: a tool that fails a build on any problem at all
+will fail on lattices whose author has nothing left to fix.
 
 Expansion is therefore always worth reading: a lattice with problems still
 comes back expanded as far as it could be, with the trees around the fault

--- a/src/pals_check.cpp
+++ b/src/pals_check.cpp
@@ -112,6 +112,58 @@ const std::map<std::string, std::set<std::string>>& group_params() {
     return p;
 }
 
+// The parameters whose value is drawn from a fixed set of words rather than
+// being a number, string or expression -- the ones the spec marks `[enum]` --
+// and every word each accepts, from the "Possible settings are" list in its
+// section under source/parameters.
+//
+// These are worth checking for the same reason a misspelled group name is: an
+// unrecognised word is valid YAML, so nothing downstream objects to it. It is
+// worse than a misspelled name, though, because the parameter that holds it does
+// exist and does have a default: `shape: ELLIPTICAL` written as `shape:
+// eliptical` leaves an aperture silently keeping its default shape rather than
+// taking the one the author asked for.
+//
+// A parameter absent from this table takes a value no fixed list can describe.
+// `kind` is a fixed list too but is checked against known_kinds() instead, since
+// it is not a parameter group component.
+const std::map<std::string, std::map<std::string, std::set<std::string>>>&
+enum_values() {
+    static const std::map<std::string,
+                          std::map<std::string, std::set<std::string>>>
+        e = {
+            {"ApertureP",
+             {{"location",
+               {"ENTRANCE_END", "CENTER", "EXIT_END", "BOTH_ENDS", "NOWHERE",
+                "EVERYWHERE"}},
+              {"shape",
+               {"RECTANGULAR", "ELLIPTICAL", "VERTICES", "CUSTOM_SHAPE"}}}},
+            {"BendP",
+             {// multipole_geometry has no ARC setting: with `ref_geometry: ARC`
+              // the FOLLOWS_REF_GEOMETRY default already means vertically pure.
+              {"multipole_geometry",
+               {"FOLLOWS_REF_GEOMETRY", "VERTICALLY_PURE", "HORIZONTALLY_PURE",
+                "CHORD", "ENTRANCE_COORDS", "EXIT_COORDS"}},
+              {"ref_geometry",
+               {"ARC", "CHORD", "ENTRANCE_COORDS", "EXIT_COORDS"}}}},
+            {"ForkP", {{"direction", {"FORWARDS", "BACKWARDS"}}}},
+            {"PatchP", {{"ref_coords", {"ENTRANCE_END", "EXIT_END"}}}},
+            {"RFP",
+             {{"cavity_type", {"STANDING_WAVE", "TRAVELING_WAVE"}},
+              {"zero_phase",
+               {"ACCELERATING", "BELOW_TRANSITION", "ABOVE_TRANSITION"}}}}};
+    return e;
+}
+
+// The words `param` of `group` accepts, or null when it is not an enum.
+const std::set<std::string>* enum_domain(const std::string& group,
+                                         const std::string& param) {
+    auto g = enum_values().find(group);
+    if (g == enum_values().end()) return nullptr;
+    auto p = g->second.find(param);
+    return p == g->second.end() ? nullptr : &p->second;
+}
+
 // The parameter groups each element kind may carry, from the "Element parameter
 // groups associated with this element kind are" list in its section of
 // lattice-element-kinds.md.
@@ -403,16 +455,36 @@ std::string suggest(const std::string& bad, const std::set<std::string>& known,
     return best_d <= cap ? best : std::string();
 }
 
-// Append a problem, skipping exact duplicates (mirrors expansion's add_problem).
-void add(std::vector<std::string>& problems, const std::string& msg) {
-    for (const std::string& p : problems)
-        if (p == msg) return;
-    problems.push_back(msg);
+// Append a problem, skipping exact duplicates.
+//
+// Everything this file reports is a name or value that PALS does not define, so
+// the kind is the same at every call site and is fixed here rather than passed
+// in: the author's, and fatal. Fatal even though a misspelling parses as good
+// YAML and expansion carries it through untouched -- what the author asked for
+// is not what the trees come back holding, and nothing downstream will say so.
+// A `FlorP` group is dropped on the floor; a `shape: eliptical` leaves the
+// aperture silently at its default. Both are wrong answers rather than
+// blemishes, so a caller that stops on PROBLEM_ERROR should stop on these.
+void add(pals::ProblemList& problems, const std::string& msg,
+         const std::string& path = "") {
+    pals::add_problem(problems, msg, path, pals::Severity::Error,
+                      pals::Origin::Input);
 }
 
-// "element 'q1': " when the map is keyed, "" when it is not. `group` names the
-// parameter group being looked at, and is empty at element level; it joins the
-// element name with the same `>` the parameter paths use: "element 'q1>ForkP': ".
+// The bare location of `node`: "q1", or "q1>ForkP" when `group` names the
+// parameter group being looked at (empty at element level), joined with the
+// same `>` the parameter paths use. Empty when the map is not keyed. This is
+// what goes in a problem's `path`; where() wraps it for the prose message.
+std::string path_of(const ryml::Tree& t, size_t node,
+                    const std::string& group) {
+    std::string name;
+    if (t.has_key(node)) name = std::string(t.key(node).str, t.key(node).len);
+    if (name.empty()) return group;
+    if (!group.empty()) name += ">" + group;
+    return name;
+}
+
+// "element 'q1': " when the map is keyed, "" when it is not.
 std::string where(const ryml::Tree& t, size_t node, const std::string& group) {
     std::string name;
     if (t.has_key(node)) name = std::string(t.key(node).str, t.key(node).len);
@@ -421,14 +493,36 @@ std::string where(const ryml::Tree& t, size_t node, const std::string& group) {
     return "element '" + name + "': ";
 }
 
-void report(std::vector<std::string>& problems, const ryml::Tree& t,
+void report(pals::ProblemList& problems, const ryml::Tree& t,
             size_t node, const std::string& group, const std::string& what,
             const std::string& bad, const std::set<std::string>& known) {
     std::string msg =
         where(t, node, group) + "unknown " + what + " '" + bad + "'";
     std::string fix = suggest(bad, known);
     if (!fix.empty()) msg += "; did you mean '" + fix + "'?";
-    add(problems, msg);
+    add(problems, msg, path_of(t, node, group));
+}
+
+// Check the value held by `node`, a component of `group` named `param` that has
+// already been recognised as a real parameter, against the words it accepts.
+// Does nothing for a parameter that is not an enum.
+void check_enum_value(const ryml::Tree& t, size_t owner, size_t node,
+                      const std::string& group, const std::string& param,
+                      pals::ProblemList& problems) {
+    const std::set<std::string>* domain = enum_domain(group, param);
+    if (!domain) return;
+    // Only a plain scalar can be checked. A null value means "unset", which is
+    // how the parameter arrives before a default is written into it, and is not
+    // the author naming a word that does not exist.
+    if (!t.has_val(node) || t.val_is_null(node)) return;
+    std::string v(t.val(node).str, t.val(node).len);
+    if (v.empty() || domain->count(v) != 0) return;
+
+    std::string msg = where(t, owner, group) + "'" + param +
+                      "' is set to '" + v + "', which is not one of its values";
+    std::string fix = suggest(v, *domain);
+    if (!fix.empty()) msg += "; did you mean '" + fix + "'?";
+    add(problems, msg, path_of(t, owner, group) + "." + param);
 }
 
 // Check the entries of one parameter group. `owner` is the element the group
@@ -436,7 +530,7 @@ void report(std::vector<std::string>& problems, const ryml::Tree& t,
 // name the group in the message.
 void check_group(const ryml::Tree& t, size_t owner, size_t group_node,
                  const std::string& group, const Extensions& ext,
-                 std::vector<std::string>& problems) {
+                 pals::ProblemList& problems) {
     auto entry = group_params().find(group);
     bool listed = entry != group_params().end();
     bool multipole = group == "MagneticMultipoleP" ||
@@ -465,8 +559,10 @@ void check_group(const ryml::Tree& t, size_t owner, size_t group_node,
             std::string k(t.key(c).str, t.key(c).len);
             if (ext.marks(k) || is_group_meta_key(k)) continue;
             if (multipole ? is_multipole_param(group, k)
-                          : entry->second.count(k) != 0)
+                          : entry->second.count(k) != 0) {
+                check_enum_value(t, owner, c, group, k, problems);
                 continue;
+            }
             // A multipole name is generated, so there is no table to suggest
             // from -- the nearest listed name would be a guess at a different
             // order, which is worse than no guess at all.
@@ -479,7 +575,7 @@ void check_group(const ryml::Tree& t, size_t owner, size_t group_node,
 // Check the parameters an element carries outside any parameter group.
 void check_element(const ryml::Tree& t, size_t node, const std::string& kind,
                    const Extensions& ext,
-                   std::vector<std::string>& problems) {
+                   pals::ProblemList& problems) {
     const std::set<std::string>& known = element_params(kind);
     for (size_t c = t.first_child(node); c != ryml::NONE;
          c = t.next_sibling(c)) {
@@ -498,7 +594,7 @@ void check_element(const ryml::Tree& t, size_t node, const std::string& kind,
 }
 
 void walk(const ryml::Tree& t, size_t node, const Extensions& ext,
-          std::vector<std::string>& problems) {
+          pals::ProblemList& problems) {
     if (node == ryml::NONE) return;
 
     std::string ele_kind;  // set when this map is an element definition
@@ -573,7 +669,7 @@ void walk(const ryml::Tree& t, size_t node, const Extensions& ext,
 // Anything outside the `PALS` node is outside the standard and ignored
 // (fundamentals.md, s:palsroot), so only this node's own keys are checked.
 void check_pals_root(const ryml::Tree& t, const Extensions& ext,
-                     std::vector<std::string>& problems) {
+                     pals::ProblemList& problems) {
     size_t pals = t.find_child(t.root_id(), ryml::to_csubstr("PALS"));
     if (pals == ryml::NONE || !t.is_map(pals)) return;
     for (size_t c = t.first_child(pals); c != ryml::NONE;
@@ -593,7 +689,7 @@ void check_pals_root(const ryml::Tree& t, const Extensions& ext,
 
 }  // namespace
 
-void check_pals_names(const ryml::Tree& t, std::vector<std::string>& problems) {
+void check_pals_names(const ryml::Tree& t, pals::ProblemList& problems) {
     Extensions ext = collect_extensions(t);
     check_pals_root(t, ext, problems);
     walk(t, t.root_id(), ext, problems);

--- a/src/pals_check.h
+++ b/src/pals_check.h
@@ -1,10 +1,13 @@
 #ifndef PALS_CHECK_H
 #define PALS_CHECK_H
 
-// Spelling checks against the fixed vocabulary PALS defines: element kinds and
-// parameter group names. A misspelling is not a structural error -- a `FlorP`
-// group or a `kind: marker` parses as valid YAML and simply goes unrecognised
-// later -- so it is caught here and reported rather than silently ignored.
+// Checks against the fixed vocabularies PALS defines: element kinds, parameter
+// group names, and the words an enumerated parameter accepts. Nothing here is a
+// structural fault -- a `FlorP` group, a `kind: marker` or a `shape: eliptical`
+// all parse as valid YAML and simply go unrecognised later -- which is exactly
+// why they are caught here. Expansion has nothing to object to, so the trees
+// come back sound but holding something other than what the author wrote, with
+// no other pass to notice. Reported as PROBLEM_ERROR for that reason.
 // Not part of the public C API declared in yaml_c_wrapper.h.
 
 #include <string>
@@ -12,11 +15,13 @@
 
 #include <ryml.hpp>
 
+#include "pals_problem.h"
+
 // Check every `kind` value and every parameter group name in `t`, appending one
 // message per unrecognised name to `problems` (with a "did you mean" suggestion
 // where a near match exists). Extension data, which is outside the standard by
 // definition, is skipped: a dictionary holding an `extension` key, and any name
 // registered under `PALS: extension_labels`.
-void check_pals_names(const ryml::Tree& t, std::vector<std::string>& problems);
+void check_pals_names(const ryml::Tree& t, pals::ProblemList& problems);
 
 #endif  // PALS_CHECK_H

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -11,6 +11,7 @@
 #include "pals_util.h"
 #include "pals_floor.h"
 #include "pals_check.h"
+#include "pals_problem.h"
 
 #include "apc/apc.h"
 
@@ -181,20 +182,16 @@ static void make_ele_map(std::map<std::string, size_t>& emap,
         make_ele_map(emap, t, c);
 }
 
-// A list of human-readable problems found while building the expanded tree
-// (undefined lattice, dangling references, undefined inherit/repeat/fork
-// targets, un-evaluable expressions, ...). Returned to the caller so it can
-// decide whether to print, save, or ignore them.
-using ProblemList = std::vector<std::string>;
-
-// Append a problem, skipping exact duplicates. Expansion copies a definition
-// into every use, so the same underlying issue can be reached many times; the
-// shallow locations used below keep those copies collapsing to one message.
-static void add_problem(ProblemList& problems, const std::string& msg) {
-    for (const std::string& p : problems)
-        if (p == msg) return;
-    problems.push_back(msg);
-}
+// The problems found while building the expanded tree (undefined lattice,
+// dangling references, undefined inherit/repeat/fork targets, un-evaluable
+// expressions, ...), returned to the caller so it can decide whether to print,
+// save, or ignore them. Defined in pals_problem.h, which pals_check.cpp reports
+// into as well; pulled into this file's scope so the call sites below read as
+// they did when the list was local.
+using pals::add_problem;
+using pals::Origin;
+using pals::ProblemList;
+using pals::Severity;
 
 // A short "group.param" (or just "param") location for a value node, for use in
 // problem messages. Deliberately shallow so the identical parameter reached
@@ -2667,10 +2664,12 @@ static void execute_set(ryml::Tree& t, const SetCommand& cmd,
     // never invents randomness (random()/random_gauss() are deferred for the
     // same reason). The deterministic value is written and the error is not.
     if (cmd.has_error)
-        add_problem(problems, what +
-                                  ": absolute_error/relative_error are not "
-                                  "applied -- the standard does not specify "
-                                  "the error distribution");
+        add_problem(problems,
+                    what +
+                        ": absolute_error/relative_error are not "
+                        "applied -- the standard does not specify "
+                        "the error distribution",
+                    cmd.param, Severity::Warning, Origin::Unspecified);
 
     // Only a pre-expansion set needs the element map, to spot a reference to a
     // parameter whose value has still to be derived.
@@ -3028,8 +3027,10 @@ static RefState downstream_ref(const ryml::Tree& t, size_t ele,
         std::string ename = t.has_key(ele) ? std::string(t.key(ele).str,
                                                           t.key(ele).len)
                                            : "<foil>";
-        add_problem(problems, "Foil element '" + ename +
-                                  "': downstream species change is not computed");
+        add_problem(problems,
+                    "Foil element '" + ename +
+                        "': downstream species change is not computed",
+                    ename, Severity::Warning, Origin::Unsupported);
     }
 
     complete_energy(down);  // refill whichever of E/pc a change above cleared
@@ -4455,6 +4456,15 @@ static YAMLTreeHandle make_original(ParsedData* src,
 // read with parse_and_expand_PALS, which resolves them against itself.
 static const char* STRING_DOC_PATH = "<string>";
 
+// An owning C copy of `s`, for handing a std::string across the C API. Always
+// returns a string, empty rather than null, so a caller reading `path` never
+// has to null-check before comparing.
+static char* dup_cstr(const std::string& s) {
+    char* out = new char[s.size() + 1];
+    std::memcpy(out, s.c_str(), s.size() + 1);
+    return out;
+}
+
 // The whole of parse_and_expand_PALS below the reading of the top-level
 // document: `src` is that document parsed (null if it could not be), `top_path`
 // the path it is keyed by, and `source_name` what a parse failure calls it.
@@ -4475,8 +4485,9 @@ static struct lattices expand_document(ParsedData* src,
         // location as the single problem so the caller can pinpoint the fault.
         delete_tree(lat.original);
         lat.original = nullptr;
-        problems.push_back("could not parse '" + source_name +
-                           "': " + parse_error);
+        add_problem(problems,
+                    "could not parse '" + source_name + "': " + parse_error,
+                    source_name);
     } else {
         lat.combined = make_combined_from_original(
             static_cast<ParsedData*>(lat.original), top_path, problems);
@@ -4492,16 +4503,29 @@ static struct lattices expand_document(ParsedData* src,
                                    lat.full_expanded, lat.adjunct);
     }
 
-    // Hand the problem list to the caller as an owning C string array (freed
-    // with free_lattice_problems). The library never prints — the caller
-    // decides whether to report, save, or ignore.
+    // Hand the problem list to the caller as an owning C array (freed with
+    // free_lattice_problems). The library never prints — the caller decides
+    // whether to report, save, or ignore.
     lat.problems.count = problems.size();
     lat.problems.items =
-        problems.empty() ? nullptr : new char*[problems.size()];
+        problems.empty() ? nullptr : new struct problem[problems.size()];
     for (size_t i = 0; i < problems.size(); ++i) {
-        lat.problems.items[i] = new char[problems[i].size() + 1];
-        std::memcpy(lat.problems.items[i], problems[i].c_str(),
-                    problems[i].size() + 1);
+        lat.problems.items[i].message = dup_cstr(problems[i].message);
+        lat.problems.items[i].path = dup_cstr(problems[i].path);
+        lat.problems.items[i].severity =
+            problems[i].severity == Severity::Warning ? PROBLEM_WARNING
+                                                      : PROBLEM_ERROR;
+        switch (problems[i].origin) {
+            case Origin::Unsupported:
+                lat.problems.items[i].origin = PROBLEM_UNSUPPORTED;
+                break;
+            case Origin::Unspecified:
+                lat.problems.items[i].origin = PROBLEM_UNSPECIFIED;
+                break;
+            case Origin::Input:
+                lat.problems.items[i].origin = PROBLEM_INPUT;
+                break;
+        }
     }
     return lat;
 }
@@ -4525,8 +4549,11 @@ YAML_API struct lattices expand_PALS_string(const char* yaml_str,
                            STRING_DOC_PATH, STRING_DOC_PATH, root_lattice);
 }
 
-YAML_API void free_lattice_problems(struct string_list problems) {
-    for (size_t i = 0; i < problems.count; ++i) delete[] problems.items[i];
+YAML_API void free_lattice_problems(struct problem_list problems) {
+    for (size_t i = 0; i < problems.count; ++i) {
+        delete[] problems.items[i].message;
+        delete[] problems.items[i].path;
+    }
     delete[] problems.items;
 }
 

--- a/src/pals_problem.h
+++ b/src/pals_problem.h
@@ -1,0 +1,56 @@
+#ifndef PALS_PROBLEM_H
+#define PALS_PROBLEM_H
+
+// The internal form of a problem found while reading or expanding a document,
+// and the one funnel every part of the library reports through. Converted to
+// the C `struct problem_list` at the end of parse_and_expand_PALS.
+//
+// Kept in its own header, rather than in pals_expand.cpp where the expander's
+// problems are raised, because the name checks in pals_check.cpp report into
+// the same list. Not part of the public C API declared in yaml_c_wrapper.h.
+
+#include <string>
+#include <vector>
+
+#include "yaml_c_wrapper.h"
+
+namespace pals {
+
+// Mirrors the C enums of the same names; see yaml_c_wrapper.h for what the
+// values mean. Kept as a scoped enum internally so an unannotated call site
+// cannot silently pass the wrong one -- the two are both small ints, and the
+// argument order would not protect us.
+enum class Severity { Error, Warning };
+enum class Origin { Input, Unsupported, Unspecified };
+
+struct Problem {
+    std::string message;
+    std::string path;  // Shallow "group.param"; empty when not tied to a node.
+    Severity severity = Severity::Error;
+    Origin origin = Origin::Input;
+};
+
+using ProblemList = std::vector<Problem>;
+
+// Append a problem, skipping exact duplicates. Expansion copies a definition
+// into every use, so the same underlying issue can be reached many times; the
+// shallow paths used at the call sites keep those copies collapsing to one
+// entry.
+//
+// The defaults say "the document is wrong and the output cannot be trusted",
+// which is what the great majority of problems are. Only the handful that are
+// this library's limitation, or the standard's silence, name their kind -- so a
+// call site that says nothing is making the common claim, not skipping the
+// question.
+inline void add_problem(ProblemList& problems, const std::string& msg,
+                        const std::string& path = "",
+                        Severity severity = Severity::Error,
+                        Origin origin = Origin::Input) {
+    for (const Problem& p : problems)
+        if (p.message == msg) return;
+    problems.push_back(Problem{msg, path, severity, origin});
+}
+
+}  // namespace pals
+
+#endif  // PALS_PROBLEM_H

--- a/src/yaml_c_wrapper.h
+++ b/src/yaml_c_wrapper.h
@@ -68,17 +68,75 @@ typedef size_t YAMLNodeId;
 #define YAML_END YAML_NULL_ID
 
 /**
- * @brief A flat, owning list of C strings.
+ * @brief Whether a problem stops the expanded trees from being trustworthy.
+ * @ingroup parse
+ */
+enum problem_severity {
+    /**
+     * The document is wrong here and the expansion could not work around it: a
+     * value is missing, unresolved, or left at a stand-in. Do not trust the
+     * affected part of `expanded` / `full_expanded`.
+     */
+    PROBLEM_ERROR = 0,
+    /**
+     * Expansion produced a usable result. Something was assumed, skipped, or
+     * merely looks wrong -- worth reporting, but the trees are still sound.
+     */
+    PROBLEM_WARNING = 1
+};
+
+/**
+ * @brief Who has to act on a problem.
  * @ingroup parse
  *
- * Used to return the human-readable problems encountered while building the
- * `full_expanded` tree (undefined lattice, dangling element/line references,
- * undefined `inherit`/`repeat`/`Fork` targets, expressions that could not be
- * evaluated, ...). Free with free_lattice_problems().
+ * Separated from @ref problem_severity because the two answer different
+ * questions: severity says whether the output can be trusted, origin says
+ * whether the lattice author can do anything about it. A caller writing a
+ * lattice editor wants to underline @ref PROBLEM_INPUT and stay quiet about the
+ * rest; a caller filing bug reports wants the opposite.
  */
-struct string_list {
-    char** items;  ///< The strings (owning).
-    size_t count;  ///< Number of strings in @ref items.
+enum problem_origin {
+    /** The document is wrong. The author can fix it. */
+    PROBLEM_INPUT = 0,
+    /** Valid PALS that this library does not implement yet. Not the author's
+     *  fault, and not fixable by editing the lattice. */
+    PROBLEM_UNSUPPORTED = 1,
+    /** The PALS standard does not define this case, so nothing was invented.
+     *  Neither the author nor this library is in the wrong. */
+    PROBLEM_UNSPECIFIED = 2
+};
+
+/**
+ * @brief One problem found while reading or expanding a document.
+ * @ingroup parse
+ */
+struct problem {
+    char* message;  ///< Human-readable description, always present (owning).
+    /**
+     * Logical location within the document -- typically `group.parameter` or an
+     * element name -- or the empty string when the problem is not tied to one
+     * spot. Deliberately shallow, so a definition reached through several
+     * expansion copies reports one location rather than one per copy. This is
+     * not a file name or a line number; @ref message already names the file
+     * where the file is the point.
+     */
+    char* path;
+    enum problem_severity severity;  ///< Is the output still trustworthy?
+    enum problem_origin origin;      ///< Whose problem is it?
+};
+
+/**
+ * @brief A flat, owning list of problems.
+ * @ingroup parse
+ *
+ * Used to return everything encountered while building the `full_expanded` tree
+ * (undefined lattice, dangling element/line references, undefined
+ * `inherit`/`repeat`/`Fork` targets, expressions that could not be evaluated,
+ * ...). Free with free_lattice_problems().
+ */
+struct problem_list {
+    struct problem* items;  ///< The problems (owning).
+    size_t count;           ///< Number of entries in @ref items.
 };
 
 /**
@@ -111,9 +169,9 @@ struct lattices {
                               ///< root lattice, so element/beamline
                               ///< definitions, `use` statements, constants and
                               ///< any non-root Lattice.
-    struct string_list problems;  ///< Problems found while building
-                                  ///< `full_expanded`; free with
-                                  ///< free_lattice_problems().
+    struct problem_list problems;  ///< Problems found while building
+                                   ///< `full_expanded`; free with
+                                   ///< free_lattice_problems().
 };
 
 /**
@@ -227,14 +285,16 @@ extern "C" {
  * the lattice are copies, so they appear in both trees.
  *         All five handles must be freed individually with delete_tree().
  *
- *         The returned struct also carries `problems`: an owning list of
- *         human-readable messages for every issue met while building the
- *         `full_expanded` tree (undefined lattice, dangling element/line
- *         references, undefined `inherit`/`repeat`/`Fork` targets, and
- *         expressions that could not be evaluated). It is empty when expansion
- *         was clean. The caller owns it and must release it with
- *         free_lattice_problems(). The library does not print — the caller
- *         decides whether to report.
+ *         The returned struct also carries `problems`: an owning list of every
+ *         issue met while building the `full_expanded` tree (undefined lattice,
+ *         dangling element/line references, undefined `inherit`/`repeat`/`Fork`
+ *         targets, and expressions that could not be evaluated). Each carries a
+ *         message, a shallow logical path, a @ref problem_severity saying
+ *         whether the trees can still be trusted, and a @ref problem_origin
+ *         saying whether the lattice author can do anything about it. The list
+ *         is empty when expansion was clean. The caller owns it and must
+ *         release it with free_lattice_problems(). The library does not print —
+ *         the caller decides whether to report.
  */
 YAML_API struct lattices parse_and_expand_PALS(const char* filename,
                                       const char* root_lattice);
@@ -264,7 +324,8 @@ YAML_API struct lattices expand_PALS_string(const char* yaml_str,
                                             const char* root_lattice);
 
 /**
- * Frees the string array owned by the `problems` list of a `lattices` value.
+ * Frees the problem array owned by the `problems` list of a `lattices` value,
+ * along with the strings each entry holds.
  * @ingroup parse
  *
  * Passing a list with a NULL `items` pointer (e.g. when there were no problems)
@@ -272,7 +333,7 @@ YAML_API struct lattices expand_PALS_string(const char* yaml_str,
  *
  * @param problems The `lattices::problems` list to free (passed by value).
  */
-YAML_API void free_lattice_problems(struct string_list problems);
+YAML_API void free_lattice_problems(struct problem_list problems);
 
 /**
  * Evaluates a single PALS mathematical expression to a double.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(tests
   test_bookkeeper.cpp
   test_expanded_minus_dependent.cpp
   test_check.cpp
+  test_problems.cpp
   test_load.cpp
   test_floor.cpp
   # pals_floor.cpp carries hidden visibility in the shared library, so its

--- a/tests/test_bookkeeper.cpp
+++ b/tests/test_bookkeeper.cpp
@@ -305,7 +305,7 @@ static struct lattices expand_rf(const std::string& rfp_body) {
 
 static bool any_problem_contains(struct lattices& lat, const char* needle) {
     for (size_t i = 0; i < lat.problems.count; ++i)
-        if (std::string(lat.problems.items[i]).find(needle) != std::string::npos)
+        if (std::string(lat.problems.items[i].message).find(needle) != std::string::npos)
             return true;
     return false;
 }

--- a/tests/test_check.cpp
+++ b/tests/test_check.cpp
@@ -11,7 +11,7 @@ std::vector<std::string> problems_for(const char* yaml) {
     struct lattices lat = expand_PALS_string(yaml, nullptr);
     std::vector<std::string> out;
     for (size_t i = 0; i < lat.problems.count; ++i)
-        out.push_back(lat.problems.items[i]);
+        out.push_back(lat.problems.items[i].message);
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
@@ -475,4 +475,82 @@ TEST_CASE("an unrecognisable name is reported without a guess",
 
     REQUIRE(has(ps, "element 'x1': unknown kind 'Zzzyzx'"));
     REQUIRE(!has(ps, "'Zzzyzx'; did you mean"));
+}
+
+// ============================================================
+// Enumerated parameter values (the spec's `[enum]` parameters)
+// ============================================================
+
+TEST_CASE("a misspelled enumerated value is reported with a suggestion",
+          "[check][problems]") {
+    // Worse than a misspelled parameter name: `shape` really does exist and
+    // really does have a default, so `eliptical` leaves the aperture silently
+    // ELLIPTICAL rather than failing anywhere the author would notice.
+    auto ps = problems_for("PALS:\n"
+                           "  facility:\n"
+                           "    - q1:\n"
+                           "        kind: Quadrupole\n"
+                           "        length: 1\n"
+                           "        ApertureP:\n"
+                           "          shape: eliptical\n");
+
+    REQUIRE(has(ps,
+                "element 'q1>ApertureP': 'shape' is set to 'eliptical', which "
+                "is not one of its values; did you mean 'ELLIPTICAL'?"));
+}
+
+TEST_CASE("every documented enumerated value is accepted",
+          "[check][problems]") {
+    // The point of the table is to reject words PALS does not define, so a typo
+    // in the table itself would reject words it does -- the more damaging
+    // failure, since it is a valid lattice that gets the complaint. One
+    // non-default value from each enum, which is where such a typo would hide:
+    // the defaults are exercised by every other test in the suite.
+    auto ps = problems_for("PALS:\n"
+                           "  facility:\n"
+                           "    - b1:\n"
+                           "        kind: Bend\n"
+                           "        length: 1\n"
+                           "        BendP:\n"
+                           "          ref_geometry: CHORD\n"
+                           "          multipole_geometry: HORIZONTALLY_PURE\n"
+                           "    - q1:\n"
+                           "        kind: Quadrupole\n"
+                           "        length: 1\n"
+                           "        ApertureP:\n"
+                           "          shape: CUSTOM_SHAPE\n"
+                           "          location: BOTH_ENDS\n"
+                           "    - c1:\n"
+                           "        kind: RFCavity\n"
+                           "        length: 1\n"
+                           "        RFP:\n"
+                           "          cavity_type: TRAVELING_WAVE\n"
+                           "          zero_phase: BELOW_TRANSITION\n"
+                           "    - p1:\n"
+                           "        kind: Patch\n"
+                           "        PatchP:\n"
+                           "          ref_coords: ENTRANCE_END\n"
+                           "    - f1:\n"
+                           "        kind: Fork\n"
+                           "        ForkP:\n"
+                           "          to_line: somewhere\n"
+                           "          direction: BACKWARDS\n");
+
+    REQUIRE(count_with(ps, "not one of its values") == 0);
+}
+
+TEST_CASE("an unset enumerated value is not reported", "[check][problems]") {
+    // A parameter written with no value is how it arrives before a default is
+    // materialised into it. That is not the author naming a word that does not
+    // exist, so it must not be reported as one.
+    auto ps = problems_for("PALS:\n"
+                           "  facility:\n"
+                           "    - q1:\n"
+                           "        kind: Quadrupole\n"
+                           "        length: 1\n"
+                           "        ApertureP:\n"
+                           "          shape:\n"
+                           "          location: null\n");
+
+    REQUIRE(count_with(ps, "not one of its values") == 0);
 }

--- a/tests/test_controllers.cpp
+++ b/tests/test_controllers.cpp
@@ -7,17 +7,17 @@
 namespace {
 
 // Every problem message parse_and_expand_PALS reported, as strings.
-std::vector<std::string> problem_list(const struct lattices& lat) {
+std::vector<std::string> problem_messages(const struct lattices& lat) {
     std::vector<std::string> msgs;
     for (size_t i = 0; i < lat.problems.count; ++i)
-        msgs.emplace_back(lat.problems.items[i]);
+        msgs.emplace_back(lat.problems.items[i].message);
     return msgs;
 }
 
 // The problems as one string, so a failing REQUIRE shows what they were.
 std::string joined(const struct lattices& lat) {
     std::string s;
-    for (const std::string& m : problem_list(lat)) s += m + "; ";
+    for (const std::string& m : problem_messages(lat)) s += m + "; ";
     return s;
 }
 
@@ -449,7 +449,7 @@ TEST_CASE("controller expressions may not reach outside their controller",
                      "                      Kn1L: 0.0\n");
 
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
-    std::vector<std::string> msgs = problem_list(lat);
+    std::vector<std::string> msgs = problem_messages(lat);
     REQUIRE(any_contains(msgs, "variable 'derived' may not reference"));
     REQUIRE(any_contains(msgs, "control expression may not reference"));
 
@@ -481,7 +481,7 @@ TEST_CASE("a variable initial value may not reference a variable",
                      "                      Kn1L: 0.0\n");
 
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
-    REQUIRE(any_contains(problem_list(lat),
+    REQUIRE(any_contains(problem_messages(lat),
                          "variable 'cur2': an initial value may not reference "
                          "the variable 'cur1'"));
 
@@ -542,7 +542,7 @@ TEST_CASE("a circular control hierarchy is reported",
                      "                    kind: Quadrupole\n");
 
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
-    REQUIRE(any_contains(problem_list(lat),
+    REQUIRE(any_contains(problem_messages(lat),
                          "circular control hierarchy: 'a', 'b'"));
 
     free_all(lat);
@@ -570,7 +570,7 @@ TEST_CASE("a parameter may not be driven by both controller types",
                      "                      Kn1L: 0.11\n");
 
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
-    REQUIRE(any_contains(problem_list(lat),
+    REQUIRE(any_contains(problem_messages(lat),
                          "Q1>MagneticMultipoleP.Kn1L is controlled by both an "
                          "ABSOLUTE and a RELATIVE controller"));
     // Neither is applied, so the element keeps its own value.
@@ -595,7 +595,7 @@ TEST_CASE("a controlled parameter may not also be delayed",
                      "                      Kn1L: expr(0.1 + 0.2)\n");
 
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
-    REQUIRE(any_contains(problem_list(lat),
+    REQUIRE(any_contains(problem_messages(lat),
                          "Q1>MagneticMultipoleP.Kn1L is both controlled and "
                          "assigned a delayed evaluation expression"));
 
@@ -614,7 +614,7 @@ TEST_CASE("a controller target that matches nothing is reported",
                      "                    kind: Quadrupole\n");
 
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
-    REQUIRE(any_contains(problem_list(lat),
+    REQUIRE(any_contains(problem_messages(lat),
                          "target 'nosuch>MagneticMultipoleP.Kn1L' matches "
                          "nothing in the expanded lattice"));
 
@@ -660,7 +660,7 @@ TEST_CASE("a controller reaches an element in a branch named by its key",
         "    - use: \"machine\"\n";
 
     struct lattices lat = expand_PALS_string(doc, nullptr);
-    REQUIRE_FALSE(any_contains(problem_list(lat), "matches nothing"));
+    REQUIRE_FALSE(any_contains(problem_messages(lat), "matches nothing"));
     REQUIRE(joined(lat).find("branch 'ln'") == std::string::npos);
     REQUIRE(close(expanded_param(lat.full_expanded, "q", "MagneticMultipoleP", "Kn1"),
                   16.0));
@@ -682,7 +682,7 @@ TEST_CASE("an unknown control_type is reported",
                      "                    length: 0.2\n");
 
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
-    REQUIRE(any_contains(problem_list(lat),
+    REQUIRE(any_contains(problem_messages(lat),
                          "control_type must be ABSOLUTE or RELATIVE, not "
                          "SOMETHING"));
 

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -276,7 +276,7 @@ TEST_CASE("A branch with no inherit takes its root BeamLine from its name",
 
     // Nothing about the branch is a problem.
     for (size_t i = 0; i < lat.problems.count; ++i)
-        REQUIRE(std::string(lat.problems.items[i]).find("branch 'ln'") ==
+        REQUIRE(std::string(lat.problems.items[i].message).find("branch 'ln'") ==
                 std::string::npos);
 
     free_lattice_problems(lat.problems);
@@ -357,7 +357,7 @@ TEST_CASE("An empty branch is reported", "[lattices][problems]") {
         struct lattices lat = expand_PALS_string(yaml, nullptr);
         std::vector<std::string> msgs;
         for (size_t i = 0; i < lat.problems.count; ++i)
-            msgs.emplace_back(lat.problems.items[i]);
+            msgs.emplace_back(lat.problems.items[i].message);
         free_lattice_problems(lat.problems);
         delete_tree(lat.original);
         delete_tree(lat.combined);
@@ -444,7 +444,7 @@ TEST_CASE("parse_and_expand_PALS reports expansion problems",
     // Collect the messages so the assertions do not depend on their order.
     std::vector<std::string> msgs;
     for (size_t i = 0; i < lat.problems.count; ++i)
-        msgs.emplace_back(lat.problems.items[i]);
+        msgs.emplace_back(lat.problems.items[i].message);
 
     auto has = [&](const std::string& needle) {
         for (const std::string& m : msgs)
@@ -508,7 +508,7 @@ TEST_CASE("repeat with an unusable count keeps the entry",
 
         bool reported = false;
         for (size_t i = 0; i < lat.problems.count; ++i)
-            if (std::string(lat.problems.items[i])
+            if (std::string(lat.problems.items[i].message)
                     .find("repeat: invalid count") != std::string::npos)
                 reported = true;
 
@@ -573,7 +573,7 @@ TEST_CASE("repeat expands the copies it splices", "[lattices]") {
     REQUIRE(lat.full_expanded != nullptr);
 
     for (size_t i = 0; i < lat.problems.count; ++i)
-        REQUIRE(std::string(lat.problems.items[i]).find("repeat") ==
+        REQUIRE(std::string(lat.problems.items[i].message).find("repeat") ==
                 std::string::npos);
 
     // Three copies of a two-element cell, flattened: d1 q1 d1 q1 d1 q1.
@@ -612,7 +612,7 @@ TEST_CASE("parse_and_expand_PALS reports a missing lattice",
 
     struct lattices lat = expand_PALS_string(doc, "not_here");
     REQUIRE(lat.problems.count == 1);
-    REQUIRE(std::string(lat.problems.items[0]) == "lattice 'not_here' not found");
+    REQUIRE(std::string(lat.problems.items[0].message) == "lattice 'not_here' not found");
 
     // With no lattice to expand, expanded is an empty map and the whole document
     // lands in adjunct — both handles are still valid.
@@ -662,7 +662,7 @@ TEST_CASE("a Fork with a ForkP sequence is reported as wrong-shape, not missing"
     bool wrong_shape = false;
     bool missing = false;
     for (size_t i = 0; i < lat.problems.count; ++i) {
-        std::string msg = lat.problems.items[i];
+        std::string msg = lat.problems.items[i].message;
         if (msg.find("f1") != std::string::npos) {
             if (msg.find("must be a map") != std::string::npos) wrong_shape = true;
             if (msg.find("missing ForkP") != std::string::npos) missing = true;
@@ -717,7 +717,7 @@ TEST_CASE("a Fork needs only to_line; destination_element and new_branch default
     REQUIRE(lat.full_expanded != nullptr);
 
     for (size_t i = 0; i < lat.problems.count; ++i)
-        REQUIRE(std::string(lat.problems.items[i]).find("f1") ==
+        REQUIRE(std::string(lat.problems.items[i].message).find("f1") ==
                 std::string::npos);
 
     // The fork resolved to a target, so its ForkP carries a
@@ -879,7 +879,7 @@ TEST_CASE("propagate_reference: false leaves the new branch's reference unset",
 
     // `ring` has its reference from `begin`; only `extraction` is reported.
     REQUIRE(lat.problems.count == 1);
-    REQUIRE(std::string(lat.problems.items[0]) ==
+    REQUIRE(std::string(lat.problems.items[0].message) ==
             "branch 'extraction': first element 'm1' has no reference species "
             "or energy, and none was propagated into the branch; the reference "
             "parameters cannot be computed");
@@ -940,7 +940,7 @@ TEST_CASE("a half-declared branch reference is reported for what it lacks",
 
     std::vector<std::string> msgs;
     for (size_t i = 0; i < lat.problems.count; ++i)
-        msgs.emplace_back(lat.problems.items[i]);
+        msgs.emplace_back(lat.problems.items[i].message);
     REQUIRE(msgs.size() == 2);
 
     REQUIRE(msgs[0].find("branch 'line_a': first element 'no_energy' has no "
@@ -1000,7 +1000,7 @@ TEST_CASE("new_branch: null forks into an existing branch, creating none",
     REQUIRE(lat.full_expanded != nullptr);
 
     for (size_t i = 0; i < lat.problems.count; ++i)
-        REQUIRE(std::string(lat.problems.items[i]).find("f1") ==
+        REQUIRE(std::string(lat.problems.items[i].message).find("f1") ==
                 std::string::npos);
 
     // Exactly the two declared branches: the Fork added none.
@@ -1076,7 +1076,7 @@ TEST_CASE("a destination of a kind that cannot be forked to is reported",
 
     int reported = 0;
     for (size_t i = 0; i < lat.problems.count; ++i) {
-        std::string p(lat.problems.items[i]);
+        std::string p(lat.problems.items[i].message);
         if (p.find("must be a Marker") != std::string::npos) {
             REQUIRE(p.find("'d1'") != std::string::npos);
             REQUIRE(p.find("'Drift'") != std::string::npos);
@@ -1495,7 +1495,7 @@ TEST_CASE("new_branch: null with a to_line that is not a branch is reported",
 
     bool reported = false;
     for (size_t i = 0; i < lat.problems.count; ++i)
-        if (std::string(lat.problems.items[i]).find("is not an existing branch") !=
+        if (std::string(lat.problems.items[i].message).find("is not an existing branch") !=
             std::string::npos)
             reported = true;
     REQUIRE(reported);
@@ -1559,7 +1559,7 @@ TEST_CASE("a malformed document held in a string is a fatal parse problem",
 
     REQUIRE(lat.original == nullptr);
     REQUIRE(lat.problems.count == 1);
-    std::string msg = lat.problems.items[0];
+    std::string msg = lat.problems.items[0].message;
     REQUIRE(msg.find("<string>") != std::string::npos);
     REQUIRE(msg.find("line") != std::string::npos);
 
@@ -1585,7 +1585,7 @@ TEST_CASE("a malformed top-level file is a fatal parse problem, not a crash",
 
     // A single problem, naming the file and the offending line.
     REQUIRE(lat.problems.count == 1);
-    std::string msg = lat.problems.items[0];
+    std::string msg = lat.problems.items[0].message;
     REQUIRE(msg.find(path) != std::string::npos);
     REQUIRE(msg.find("line") != std::string::npos);
 

--- a/tests/test_expressions.cpp
+++ b/tests/test_expressions.cpp
@@ -434,7 +434,7 @@ std::vector<std::string> problems_for_value(const std::string& value) {
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
     std::vector<std::string> out;
     for (size_t i = 0; i < lat.problems.count; ++i)
-        out.push_back(lat.problems.items[i]);
+        out.push_back(lat.problems.items[i].message);
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);
     delete_tree(lat.combined);
@@ -518,7 +518,7 @@ TEST_CASE("a controller says why an expression failed", "[expr][controllers]") {
     struct lattices lat = expand_PALS_string(doc, nullptr);
     std::vector<std::string> ps;
     for (size_t i = 0; i < lat.problems.count; ++i)
-        ps.push_back(lat.problems.items[i]);
+        ps.push_back(lat.problems.items[i].message);
 
     REQUIRE(any_has(ps, "variable 'vv': could not evaluate"));
     REQUIRE(any_has(ps, "unknown constant or variable 'C_LIGHT'"));

--- a/tests/test_load.cpp
+++ b/tests/test_load.cpp
@@ -34,7 +34,7 @@ struct LoadCase {
     std::vector<std::string> problems() const {
         std::vector<std::string> out;
         for (size_t i = 0; i < lat.problems.count; ++i)
-            out.emplace_back(lat.problems.items[i]);
+            out.emplace_back(lat.problems.items[i].message);
         return out;
     }
 

--- a/tests/test_problems.cpp
+++ b/tests/test_problems.cpp
@@ -1,0 +1,178 @@
+#include "test_helpers.h"
+
+// ============================================================
+// The classification carried on each problem (severity / origin / path)
+// ============================================================
+//
+// Every problem the library reports says more than what went wrong: whether the
+// expanded trees can still be trusted (severity) and whether the lattice author
+// is the one who can fix it (origin). A caller that only prints the message does
+// not care, but one deciding whether to fail a build, or where to put a squiggle
+// in an editor, does. These tests pin the classification of one case of each
+// kind, since nothing else in the suite reads those fields.
+
+namespace {
+
+// The single problem whose message contains `needle`. Fails the test if the
+// document produced no such problem, so every assertion below is about a
+// problem that was actually raised rather than a default-constructed struct.
+struct problem find(const struct lattices& lat, const char* needle) {
+    for (size_t i = 0; i < lat.problems.count; ++i)
+        if (std::string(lat.problems.items[i].message).find(needle) !=
+            std::string::npos)
+            return lat.problems.items[i];
+    std::string all;
+    for (size_t i = 0; i < lat.problems.count; ++i)
+        all += std::string("\n  ") + lat.problems.items[i].message;
+    FAIL("no problem matching '" << needle << "'; got:" << all);
+    return lat.problems.items[0];  // unreachable; FAIL throws
+}
+
+void free_all(struct lattices& lat) {
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
+    delete_tree(lat.adjunct);
+}
+
+const char* BEGIN_ENTRY =
+    "          - begin:\n"
+    "              kind: BeginningEle\n"
+    "              ReferenceP:\n"
+    "                species_ref: \"electron\"\n"
+    "                E_tot_ref: 1.0e9\n";
+
+std::string facility_file(const std::string& body) {
+    return "PALS:\n"
+           "  facility:\n" +
+           body +
+           "    - lat1:\n"
+           "        kind: Lattice\n"
+           "        branches:\n"
+           "          - main\n"
+           "    - use: \"lat1\"\n";
+}
+
+}  // namespace
+
+TEST_CASE("a dangling reference is a fatal problem the author can fix",
+          "[problems]") {
+    // Nothing can be expanded in place of an element that does not exist, so the
+    // lattice really is missing a piece: PROBLEM_ERROR. And the document is what
+    // is wrong, so it is the author who can fix it: PROBLEM_INPUT.
+    struct lattices lat = expand_PALS_string(
+        facility_file("    - main:\n"
+                      "        kind: BeamLine\n"
+                      "        line:\n" +
+                      std::string(BEGIN_ENTRY) + "          - nosuchele\n")
+            .c_str(),
+        nullptr);
+
+    struct problem p = find(lat, "undefined element or line");
+    REQUIRE(p.severity == PROBLEM_ERROR);
+    REQUIRE(p.origin == PROBLEM_INPUT);
+
+    free_all(lat);
+}
+
+TEST_CASE("a misspelled name is fatal, not advisory", "[problems][check]") {
+    // `Quadrapole` is valid YAML that expansion carries through untouched, so
+    // the trees come back structurally sound -- but holding something other than
+    // what the author asked for, with nothing downstream to say so. That is a
+    // wrong answer rather than a blemish, so it is PROBLEM_ERROR, and the author
+    // is the one who can fix it.
+    struct lattices lat = expand_PALS_string("PALS:\n"
+                                             "  facility:\n"
+                                             "    - q1:\n"
+                                             "        kind: Quadrapole\n",
+                                             nullptr);
+
+    struct problem p = find(lat, "unknown kind 'Quadrapole'");
+    REQUIRE(p.severity == PROBLEM_ERROR);
+    REQUIRE(p.origin == PROBLEM_INPUT);
+    REQUIRE(std::string(p.path) == "q1");
+
+    free_all(lat);
+}
+
+TEST_CASE("a gap in this library is not blamed on the document",
+          "[problems]") {
+    // A Foil changes the species passing through it, and this library does not
+    // compute that change. The lattice is valid PALS: editing it cannot make the
+    // message go away, so the origin must not point at the author.
+    struct lattices lat = expand_PALS_string(
+        facility_file("    - main:\n"
+                      "        kind: BeamLine\n"
+                      "        line:\n" +
+                      std::string(BEGIN_ENTRY) +
+                      "          - fl:\n"
+                      "              kind: Foil\n"
+                      "              length: 0.1\n")
+            .c_str(),
+        nullptr);
+
+    struct problem p = find(lat, "downstream species change is not computed");
+    REQUIRE(p.origin == PROBLEM_UNSUPPORTED);
+    // The upstream species is carried through unchanged rather than guessed at,
+    // so everything else in the trees still holds.
+    REQUIRE(p.severity == PROBLEM_WARNING);
+
+    free_all(lat);
+}
+
+TEST_CASE("a gap in the standard is blamed on neither side", "[problems]") {
+    // The standard gives an error magnitude but not its distribution, so there
+    // is nothing for the author to fix and nothing for this library to
+    // implement. The deterministic value is still written, hence WARNING.
+    struct lattices lat = expand_PALS_string(
+        facility_file("    - Q1:\n"
+                      "        kind: Quadrupole\n"
+                      "        length: 0.5\n"
+                      "        MagneticMultipoleP:\n"
+                      "          Kn1L: 0.4\n"
+                      "    - set:\n"
+                      "        parameter: Q1>MagneticMultipoleP.Kn1L\n"
+                      "        value: PARAMETER\n"
+                      "        relative_error: 1e-4\n"
+                      "    - main:\n"
+                      "        kind: BeamLine\n"
+                      "        line:\n" +
+                      std::string(BEGIN_ENTRY) + "          - Q1\n")
+            .c_str(),
+        nullptr);
+
+    struct problem p = find(lat, "absolute_error/relative_error are not");
+    REQUIRE(p.origin == PROBLEM_UNSPECIFIED);
+    REQUIRE(p.severity == PROBLEM_WARNING);
+
+    free_all(lat);
+}
+
+TEST_CASE("every problem carries readable strings, never null", "[problems]") {
+    // `path` is empty rather than null when a problem is not tied to one spot,
+    // so a caller can read both fields without a null check. A document with
+    // several unrelated faults is used so this covers more than one code path.
+    struct lattices lat = expand_PALS_string(
+        facility_file("    - q1:\n"
+                      "        kind: Quadrapole\n"
+                      "        FlorP:\n"
+                      "          x: 1\n"
+                      "    - main:\n"
+                      "        kind: BeamLine\n"
+                      "        line:\n" +
+                      std::string(BEGIN_ENTRY) + "          - nosuchele\n")
+            .c_str(),
+        nullptr);
+
+    REQUIRE(lat.problems.count > 1);
+    for (size_t i = 0; i < lat.problems.count; ++i) {
+        INFO("problem " << i);
+        REQUIRE(lat.problems.items[i].message != nullptr);
+        REQUIRE(lat.problems.items[i].path != nullptr);
+        REQUIRE(std::string(lat.problems.items[i].message).size() > 0);
+    }
+
+    free_all(lat);
+}

--- a/tests/test_sets.cpp
+++ b/tests/test_sets.cpp
@@ -6,16 +6,16 @@
 
 namespace {
 
-std::vector<std::string> problem_list(const struct lattices& lat) {
+std::vector<std::string> problem_messages(const struct lattices& lat) {
     std::vector<std::string> msgs;
     for (size_t i = 0; i < lat.problems.count; ++i)
-        msgs.emplace_back(lat.problems.items[i]);
+        msgs.emplace_back(lat.problems.items[i].message);
     return msgs;
 }
 
 std::string joined(const struct lattices& lat) {
     std::string s;
-    for (const std::string& m : problem_list(lat)) s += m + "; ";
+    for (const std::string& m : problem_messages(lat)) s += m + "; ";
     return s;
 }
 
@@ -225,7 +225,7 @@ TEST_CASE("reading a not-yet-derived parameter in a set is an error",
                       "main");
 
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
-    REQUIRE(any_contains(problem_list(lat),
+    REQUIRE(any_contains(problem_messages(lat),
                          "'Q1>MagneticMultipoleP.Bs1' has no value yet"));
 
     free_all(lat);
@@ -519,7 +519,7 @@ TEST_CASE("a set with an error term reports that it is not applied",
                       "main");
 
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
-    REQUIRE(any_contains(problem_list(lat),
+    REQUIRE(any_contains(problem_messages(lat),
                          "absolute_error/relative_error are not applied"));
     REQUIRE(close(one_param(lat.full_expanded, "Q1", "MagneticMultipoleP", "Kn1L"),
                   0.4));
@@ -540,7 +540,7 @@ TEST_CASE("a set whose target matches nothing is reported",
                       "main");
 
     struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
-    REQUIRE(any_contains(problem_list(lat),
+    REQUIRE(any_contains(problem_messages(lat),
                          "set 'nosuch>length': target matches nothing defined "
                          "before it"));
 


### PR DESCRIPTION
Follows the discussion in #91: the validation-ergonomics complaint there is real, even though reflect-cpp is not the way to address it.

## What changed

Every problem came back as a bare string, so a caller could print it and nothing else. These sat side by side, indistinguishable:

```
'q1>ForkP': ForkP is missing the required field 'to_line'
absolute_error/relative_error are not applied -- the standard does not specify
Foil element 'fl': downstream species change is not computed
```

The first is the author's to fix, the second is the standard's silence, the third is a gap in this library. Only the first can be cleared by editing the lattice — so a tool that fails a build on any problem at all will fail on lattices whose author has nothing left to fix.

`struct string_list problems` becomes `struct problem_list`, each entry carrying:

| field | |
|---|---|
| `message` | as before |
| `path` | logical spot, e.g. `q1>ApertureP.shape`; empty when not tied to one |
| `severity` | `PROBLEM_ERROR` / `PROBLEM_WARNING` — can the trees still be trusted? |
| `origin` | `PROBLEM_INPUT` / `PROBLEM_UNSUPPORTED` / `PROBLEM_UNSPECIFIED` — whose problem is it? |

Everything already funnelled through one `add_problem`, so the new arguments default to the common claim and only the two sites making a different claim name their kind.

## Enumerated parameter values

Nothing checked these. The vocabulary tables caught a misspelled `ApertureP`, but `shape: eliptical` inside a correctly spelled one went straight through and left the aperture silently `ELLIPTICAL`. The eight `[enum]` parameters and their domains are taken from the spec — not inferred, since a wrong domain rejects valid lattices — and reuse the existing suggestions:

```
element 'q1>ApertureP': 'shape' is set to 'eliptical', which is not one
of its values; did you mean 'ELLIPTICAL'?
```

## Misspellings are now errors

Reversing what the `pals_check.h` comment used to claim. Expansion has nothing to object to, so the trees come back sound but holding something other than what was written, with no other pass to notice.

## Notes

- **ABI break.** The matching PALSJulia.jl update lands alongside this.
- `path` is populated by the checker and two expander sites; the other ~51 bake their location into the message prose. Extracting those is follow-up work.
- File/line locations on problems are deliberately out of scope — that needs byte offsets threaded through `deep_copy_recursive`'s arena copies, which is a bigger and riskier change.

## Testing

254/254 passing (246 before). New `tests/test_problems.cpp` pins the classification of one case of each kind; the enum check is verified to fire for all eight parameters rather than trusting a negative assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
