### PR TITLE
Reflect a negative `repeat` count, and accept `periodic` on a BeamLine

### DIFF
--- a/src/pals_check.cpp
+++ b/src/pals_check.cpp
@@ -317,7 +317,7 @@ const std::set<std::string>& element_params(const std::string& kind) {
         "multipass_index", "element_index"};
     static const std::set<std::string> beamline = [] {
         std::set<std::string> s = base;
-        s.insert({"line", "multipass", "zero_point", "repeat"});
+        s.insert({"line", "multipass", "zero_point", "periodic", "repeat"});
         return s;
     }();
     static const std::set<std::string> lattice = [] {

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -467,11 +467,19 @@ static void stamp_multipass_pass(ryml::Tree& t, size_t first, size_t stop,
         set_multipass_index(t, e, pass);
 }
 
+static void expand_seq_range(ryml::Tree& t, size_t node, size_t first,
+                             size_t stop, std::map<std::string, size_t>& emap,
+                             std::map<size_t, size_t>& prov,
+                             ProblemList& problems, size_t branches,
+                             std::map<size_t, int>& mp_pass,
+                             std::set<size_t>& done);
+
 /**
  * Perform lattice expansion on the element `node`.
  * 1. Substitute scalar elements with their full definition taken from emap.
- * 2. Beamlines that contain "repeat: n" have their contents repeated n times,
- *    each copy expanded in turn like any other entry of the enclosing line.
+ * 2. Beamlines that contain "repeat: n" have their contents repeated |n| times,
+ *    each copy expanded in turn like any other entry of the enclosing line. A
+ *    negative n reflects: the repeated elements come out in reverse order.
  * 3. Elements that contain "inherit: ancestor" have the contents of ancestor
  * copied into element.
  * 4. A beamline referenced by bare name inside a `line:` is a sub-line: its
@@ -496,115 +504,8 @@ static void expand(ryml::Tree& t, size_t node,
 
     // Sequence — handle 'repeat'
     if (t.is_seq(node)) {
-        size_t child = t.first_child(node);
-        // loop over all children
-        while (child != ryml::NONE) {
-            size_t next = t.next_sibling(child);
-            if (t.is_map(child) && t.has_children(child)) {
-                // first_child because elements are defined as maps with only
-                // one key
-                size_t entry = t.first_child(child);
-                if (t.has_key(entry) && t.is_map(entry)) {
-                    size_t repeat_id =
-                        t.find_child(entry, ryml::to_csubstr("repeat"));
-                    if (repeat_id != ryml::NONE && t.has_val(repeat_id)) {
-                        std::string cnt_txt(t.val(repeat_id).str,
-                                            t.val(repeat_id).len);
-                        std::string target(t.key(entry).str, t.key(entry).len);
-
-                        // stoi stops at the first character it cannot use and
-                        // reports how far it got, so require the whole value to
-                        // be consumed: "3x" is a typo, not a count of 3. A
-                        // negative count is meaningless too. Both land on
-                        // count < 0 and are reported the same way.
-                        int count = -1;
-                        try {
-                            size_t used = 0;
-                            count = std::stoi(cnt_txt, &used);
-                            if (used != cnt_txt.size()) count = -1;
-                        } catch (...) {
-                            count = -1;
-                        }
-
-                        if (count < 0) {
-                            add_problem(problems, "repeat: invalid count '" +
-                                                      cnt_txt + "' for '" +
-                                                      target + "'");
-                        } else if (!emap.count(target)) {
-                            // check if the beamline to be repeated has been
-                            // defined in the file
-                            add_problem(problems, "repeat: beamline '" + target +
-                                                      "' is not defined");
-                        } else {
-                            size_t def = emap[target];
-                            size_t line_id =
-                                t.find_child(def, ryml::to_csubstr("line"));
-                            // `before`/`next` bracket the run about to be
-                            // spliced in: both are outside it and stay put
-                            // while it is built, so they still bracket it once
-                            // `child` itself is gone.
-                            size_t before = t.prev_sibling(child);
-                            size_t after = before;
-                            // if beamline to be repeated has a line, duplicate
-                            // it `count` times, else just duplicate the name of
-                            // the beamline `count` times
-                            if (line_id != ryml::NONE && t.is_seq(line_id)) {
-                                for (int r = 0; r < count; r++)
-                                    for (size_t c2 = t.first_child(line_id);
-                                         c2 != ryml::NONE;
-                                         c2 = t.next_sibling(c2)) {
-                                        ensure_capacity(t, 2);
-                                        after = duplicate_tracked(t, c2, node,
-                                                                  after, prov);
-                                    }
-                            } else {
-                                for (int r = 0; r < count; r++) {
-                                    ensure_capacity(t, 2);
-                                    size_t wrapper =
-                                        t.insert_child(node, after);
-                                    t.ref(wrapper) |= ryml::MAP;
-                                    duplicate_tracked(t, def, wrapper,
-                                                      ryml::NONE, prov);
-                                    after = wrapper;
-                                }
-                            }
-                            erase_prov_subtree(t, child, prov);
-                            t.remove(child);
-
-                            // Expand the copies just spliced in. They are
-                            // duplicates of the repeated definition's own
-                            // entries -- element references and nested
-                            // sub-lines -- so they need exactly the expansion
-                            // the enclosing loop would have given them had they
-                            // been written out by hand. Skipping them left a
-                            // branch of bare names that extracted as an empty
-                            // lattice, and reported nothing.
-                            for (size_t cur = (before == ryml::NONE)
-                                                  ? t.first_child(node)
-                                                  : t.next_sibling(before);
-                                 cur != ryml::NONE && cur != next;) {
-                                size_t nx = t.next_sibling(cur);
-                                expand(t, cur, emap, prov, problems, branches,
-                                       mp_pass, done);
-                                cur = nx;
-                            }
-
-                            child = next;
-                            continue;
-                        }
-                        // Either problem path falls through to leave the entry
-                        // exactly as written. Only a repeat we fully understood
-                        // removes it: dropping an entry on the strength of a
-                        // count we could not read would delete part of the
-                        // lattice, leaving a plausible-looking `line: []` that
-                        // is only explained by a problem the caller may not
-                        // check.
-                    }
-                }
-            }
-            expand(t, child, emap, prov, problems, branches, mp_pass, done);
-            child = next;
-        }
+        expand_seq_range(t, node, t.first_child(node), ryml::NONE, emap, prov,
+                         problems, branches, mp_pass, done);
         return;
     }
 
@@ -712,6 +613,161 @@ static void expand(ryml::Tree& t, size_t node,
         for (size_t i = 0; i < original_size && c != ryml::NONE;
              i++, c = t.next_sibling(c))
             expand(t, c, emap, prov, problems, node_branches, mp_pass, done);
+    }
+}
+
+/**
+ * Expand the entries [`first`, `stop`) of the sequence `node` -- `stop` ==
+ * ryml::NONE meaning "to the end" -- handling the `repeat` of each entry.
+ *
+ * Split out of expand() because `repeat` belongs to a line *entry* but is read
+ * from the sequence holding it: expanding an entry on its own walks straight
+ * past it. The copies a `repeat` splices in are entries of that same sequence
+ * and may carry `repeat`s of their own, so they go back through this loop
+ * rather than being expanded one at a time.
+ */
+static void expand_seq_range(ryml::Tree& t, size_t node, size_t first,
+                             size_t stop, std::map<std::string, size_t>& emap,
+                             std::map<size_t, size_t>& prov,
+                             ProblemList& problems, size_t branches,
+                             std::map<size_t, int>& mp_pass,
+                             std::set<size_t>& done) {
+    size_t child = first;
+    // loop over all children
+    while (child != ryml::NONE && child != stop) {
+        size_t next = t.next_sibling(child);
+        if (t.is_map(child) && t.has_children(child)) {
+            // first_child because elements are defined as maps with only
+            // one key
+            size_t entry = t.first_child(child);
+            if (t.has_key(entry) && t.is_map(entry)) {
+                size_t repeat_id =
+                    t.find_child(entry, ryml::to_csubstr("repeat"));
+                if (repeat_id != ryml::NONE && t.has_val(repeat_id)) {
+                    std::string cnt_txt(t.val(repeat_id).str,
+                                        t.val(repeat_id).len);
+                    std::string target(t.key(entry).str, t.key(entry).len);
+
+                    // stoll stops at the first character it cannot use and
+                    // reports how far it got, so require the whole value to be
+                    // consumed: "3x" is a typo, not a count of 3.
+                    //
+                    // A negative count is a reflection: |count| copies whose
+                    // elements come out in reverse order (beamlines.md,
+                    // s:repetition). Reversed order is not direction reversal
+                    // -- that is the separate `direction` component -- so the
+                    // copies themselves are left untouched and only their order
+                    // is turned around, below.
+                    bool count_ok = true;
+                    long long count = 0;
+                    try {
+                        size_t used = 0;
+                        count = std::stoll(cnt_txt, &used);
+                        if (used != cnt_txt.size()) count_ok = false;
+                    } catch (...) {
+                        count_ok = false;
+                    }
+                    const bool reflect = count < 0;
+                    const long long copies = reflect ? -count : count;
+
+                    if (!count_ok) {
+                        add_problem(problems, "repeat: invalid count '" +
+                                                  cnt_txt + "' for '" +
+                                                  target + "'");
+                    } else if (!emap.count(target)) {
+                        // check if the beamline to be repeated has been
+                        // defined in the file
+                        add_problem(problems, "repeat: beamline '" + target +
+                                                  "' is not defined");
+                    } else {
+                        size_t def = emap[target];
+                        size_t line_id =
+                            t.find_child(def, ryml::to_csubstr("line"));
+                        // `before`/`next` bracket the run about to be
+                        // spliced in: both are outside it and stay put
+                        // while it is built, so they still bracket it once
+                        // `child` itself is gone.
+                        size_t before = t.prev_sibling(child);
+                        size_t after = before;
+                        // if beamline to be repeated has a line, duplicate
+                        // it `copies` times, else just duplicate the name
+                        // of the beamline `copies` times
+                        if (line_id != ryml::NONE && t.is_seq(line_id)) {
+                            for (long long r = 0; r < copies; r++)
+                                for (size_t c2 = t.first_child(line_id);
+                                     c2 != ryml::NONE;
+                                     c2 = t.next_sibling(c2)) {
+                                    ensure_capacity(t, 2);
+                                    after = duplicate_tracked(t, c2, node,
+                                                              after, prov);
+                                }
+                        } else {
+                            for (long long r = 0; r < copies; r++) {
+                                ensure_capacity(t, 2);
+                                size_t wrapper =
+                                    t.insert_child(node, after);
+                                t.ref(wrapper) |= ryml::MAP;
+                                duplicate_tracked(t, def, wrapper,
+                                                  ryml::NONE, prov);
+                                after = wrapper;
+                            }
+                        }
+                        erase_prov_subtree(t, child, prov);
+                        t.remove(child);
+
+                        // Expand the copies just spliced in. They are
+                        // duplicates of the repeated definition's own
+                        // entries -- element references, nested sub-lines,
+                        // and `repeat`s of their own -- so they get exactly
+                        // the pass this loop would have given them had they
+                        // been written out by hand. Skipping them left a
+                        // branch of bare names that extracted as an empty
+                        // lattice, and reported nothing.
+                        expand_seq_range(t, node,
+                                         (before == ryml::NONE)
+                                             ? t.first_child(node)
+                                             : t.next_sibling(before),
+                                         next, emap, prov, problems, branches,
+                                         mp_pass, done);
+
+                        // A negative count reflects the run just spliced in.
+                        // Reversing it only now, after the copies are expanded,
+                        // is what makes this a reversal of *elements*: by this
+                        // point every sub-line the copies held has been spliced
+                        // inline, so the run is the flat element list the
+                        // standard defines the reflection on, and a reflection
+                        // nested inside this one has already turned its own
+                        // stretch around.
+                        if (reflect) {
+                            std::vector<size_t> run;
+                            for (size_t cur =
+                                     (before == ryml::NONE)
+                                         ? t.first_child(node)
+                                         : t.next_sibling(before);
+                                 cur != ryml::NONE && cur != next;
+                                 cur = t.next_sibling(cur))
+                                run.push_back(cur);
+                            // Moving each entry in turn to the head of the
+                            // run leaves them in the opposite order.
+                            for (size_t i = 1; i < run.size(); i++)
+                                t.move(run[i], before);
+                        }
+
+                        child = next;
+                        continue;
+                    }
+                    // Either problem path falls through to leave the entry
+                    // exactly as written. Only a repeat we fully understood
+                    // removes it: dropping an entry on the strength of a
+                    // count we could not read would delete part of the
+                    // lattice, leaving a plausible-looking `line: []` that
+                    // is only explained by a problem the caller may not
+                    // check.
+                }
+            }
+        }
+        expand(t, child, emap, prov, problems, branches, mp_pass, done);
+        child = next;
     }
 }
 
@@ -1407,7 +1463,8 @@ static size_t find_lattice(ryml::Tree& t, const std::string& name) {
  * the file. Last expansion performs the following:
  * 1. Substitute scalar elements with their full definition, if defined in the
  * file outside the lattice.
- * 2. Beamlines that contain "repeat: n" have their contents repeated n times.
+ * 2. Beamlines that contain "repeat: n" have their contents repeated |n| times,
+ * in reverse order when n is negative.
  * 3. Elements that contain "inherit: ancestor" have the contents of ancestor
  * copied into element.
  */

--- a/tests/test_check.cpp
+++ b/tests/test_check.cpp
@@ -230,6 +230,32 @@ TEST_CASE("a misspelled element parameter is reported", "[check][problems]") {
     REQUIRE(count_with(ps, "unknown parameter") == 1);
 }
 
+TEST_CASE("the components of a BeamLine are all accepted",
+          "[check][problems]") {
+    // The full component list of a BeamLine (beamlines.md,
+    // s:beamline.components). `periodic` used to be missing from it, so a
+    // storage ring saying it was one was told the component did not exist.
+    auto ps = problems_for("PALS:\n"
+                           "  facility:\n"
+                           "    - m1:\n"
+                           "        kind: Marker\n"
+                           "    - q1:\n"
+                           "        kind: Quadrupole\n"
+                           "        length: 1\n"
+                           "    - ring:\n"
+                           "        kind: BeamLine\n"
+                           "        name: ring\n"
+                           "        multipass: false\n"
+                           "        length: 1\n"
+                           "        periodic: true\n"
+                           "        zero_point: m1\n"
+                           "        line:\n"
+                           "          - m1\n"
+                           "          - q1\n");
+
+    REQUIRE(count_with(ps, "unknown parameter") == 0);
+}
+
 TEST_CASE("groups with no fixed vocabulary are left alone",
           "[check][problems]") {
     // MetaP may hold arbitrary metadata beyond its six components (meta.md) and

--- a/tests/test_expansion.cpp
+++ b/tests/test_expansion.cpp
@@ -528,7 +528,9 @@ TEST_CASE("repeat with an unusable count keeps the entry",
 
     REQUIRE(counts_rejected("bogus"));  // not a number at all
     REQUIRE(counts_rejected("3x"));     // stoi would stop early and return 3
-    REQUIRE(counts_rejected("-1"));     // parses, but meaningless
+    REQUIRE(counts_rejected("1.5"));    // a count is a whole number
+    // A negative count is not an unusable one: it is the reflection spelling
+    // (beamlines.md, s:repetition), covered by the reflection cases below.
 }
 
 TEST_CASE("repeat expands the copies it splices", "[lattices]") {
@@ -592,6 +594,155 @@ TEST_CASE("repeat expands the copies it splices", "[lattices]") {
         REQUIRE(val_eq(lat.expanded, get_child_by_key(lat.expanded, def, "kind"),
                        even ? "Drift" : "Quadrupole"));
     }
+
+    free_lattice_problems(lat.problems);
+    delete_tree(lat.original);
+    delete_tree(lat.combined);
+    delete_tree(lat.expanded);
+    delete_tree(lat.full_expanded);
+    delete_tree(lat.adjunct);
+}
+
+// The names of the branch entries of an expanded document, in order. The
+// reflection cases below are entirely about order, so this is all they ask for.
+static std::vector<std::string> line_names(YAMLTreeHandle tree) {
+    std::vector<std::string> names;
+    YAMLNodeId line = find_by_key(tree, "line");
+    if (line == YAML_NULL_ID) return names;
+    for (size_t i = 0; i < get_size(tree, line); i++) {
+        YAMLNodeId entry = get_child_by_index(tree, line, i);
+        YAMLNodeId def = get_child_by_index(tree, entry, 0);
+        char* key = get_node_key(tree, def);
+        names.push_back(key ? key : "");
+        yaml_free_string(key);
+    }
+    return names;
+}
+
+TEST_CASE("a negative repeat count reflects the elements it repeats",
+          "[lattices]") {
+    // `repeat: -n` is the reflection spelling (beamlines.md, s:repetition): n
+    // copies whose elements come out in reverse order. It used to be rejected
+    // as an unusable count, which left the entry unexpanded and the branch a
+    // bare beamline name -- an error on a lattice the standard allows.
+    //
+    // `inner` is nested inside the reflected `cell` to pin the point that what
+    // is reversed is the *expanded* elements: the sub-line flattens first, so
+    // the elements it contributes are reversed along with the rest, rather than
+    // the sub-line staying forward as one lump.
+    auto doc = [](const char* count) {
+        return std::string(
+                   "PALS:\n"
+                   "  facility:\n"
+                   "    - a:\n"
+                   "        kind: Drift\n"
+                   "        length: 1.0\n"
+                   "    - b:\n"
+                   "        kind: Drift\n"
+                   "        length: 1.0\n"
+                   "    - c:\n"
+                   "        kind: Drift\n"
+                   "        length: 1.0\n"
+                   "    - inner:\n"
+                   "        kind: BeamLine\n"
+                   "        line:\n"
+                   "          - b\n"
+                   "          - c\n"
+                   "    - cell:\n"
+                   "        kind: BeamLine\n"
+                   "        line:\n"
+                   "          - a\n"
+                   "          - inner\n"
+                   "    - main_line:\n"
+                   "        kind: BeamLine\n"
+                   "        line:\n"
+                   "          - cell:\n"
+                   "              repeat: ") +
+               count + "\n" +
+               "    - lat1:\n"
+               "        kind: Lattice\n"
+               "        branches:\n"
+               "          - main_line\n"
+               "    - use: \"lat1\"\n";
+    };
+
+    auto expanded_names = [&](const char* count) {
+        struct lattices lat = expand_PALS_string(doc(count).c_str(), nullptr);
+        REQUIRE(lat.full_expanded != nullptr);
+        for (size_t i = 0; i < lat.problems.count; ++i)
+            REQUIRE(std::string(lat.problems.items[i].message).find("repeat") ==
+                    std::string::npos);
+        std::vector<std::string> names = line_names(lat.expanded);
+        free_lattice_problems(lat.problems);
+        delete_tree(lat.original);
+        delete_tree(lat.combined);
+        delete_tree(lat.expanded);
+        delete_tree(lat.full_expanded);
+        delete_tree(lat.adjunct);
+        return names;
+    };
+
+    // `cell` expands to a b c, so a single reflection is c b a ...
+    REQUIRE(expanded_names("-1") == std::vector<std::string>{"c", "b", "a"});
+    // ... and each of n reflected copies is reversed in its turn, the whole run
+    // reading as the reverse of the n unreflected copies.
+    REQUIRE(expanded_names("-3") ==
+            std::vector<std::string>{"c", "b", "a", "c", "b", "a", "c", "b",
+                                     "a"});
+    // The positive count is the same list forwards, and -0 is 0: nothing.
+    REQUIRE(expanded_names("2") ==
+            std::vector<std::string>{"a", "b", "c", "a", "b", "c"});
+    REQUIRE(expanded_names("-0").empty());
+}
+
+TEST_CASE("a reflection nested inside a reflection is undone", "[lattices]") {
+    // Reflection composes: a line reflecting a sub-line that itself reflects
+    // one puts that innermost stretch back the way it was written. This only
+    // works because the outer reflection reverses the run *after* the copies
+    // are expanded -- by then the inner reflection has already turned its own
+    // stretch around, and the outer pass reverses the result.
+    const char* doc =
+        "PALS:\n"
+        "  facility:\n"
+        "    - a:\n"
+        "        kind: Drift\n"
+        "        length: 1.0\n"
+        "    - b:\n"
+        "        kind: Drift\n"
+        "        length: 1.0\n"
+        "    - c:\n"
+        "        kind: Drift\n"
+        "        length: 1.0\n"
+        "    - inner:\n"
+        "        kind: BeamLine\n"
+        "        line:\n"
+        "          - b\n"
+        "          - c\n"
+        "    - cell:\n"          // a, then inner reflected: a c b
+        "        kind: BeamLine\n"
+        "        line:\n"
+        "          - a\n"
+        "          - inner:\n"
+        "              repeat: -1\n"
+        "    - main_line:\n"     // cell reflected: b c a
+        "        kind: BeamLine\n"
+        "        line:\n"
+        "          - cell:\n"
+        "              repeat: -1\n"
+        "    - lat1:\n"
+        "        kind: Lattice\n"
+        "        branches:\n"
+        "          - main_line\n"
+        "    - use: \"lat1\"\n";
+
+    struct lattices lat = expand_PALS_string(doc, nullptr);
+    REQUIRE(lat.full_expanded != nullptr);
+    for (size_t i = 0; i < lat.problems.count; ++i)
+        REQUIRE(std::string(lat.problems.items[i].message).find("repeat") ==
+                std::string::npos);
+
+    REQUIRE(line_names(lat.expanded) ==
+            std::vector<std::string>{"b", "c", "a"});
 
     free_lattice_problems(lat.problems);
     delete_tree(lat.original);


### PR DESCRIPTION
Two things the standard allows that pals-cpp reported as errors. Both show up on the same file: `PALSJulia/alocal/iota.pals.yaml`, the IOTA ring, which is a periodic BeamLine built as a half plus its reflection.

### `repeat: -n` is a reflection, not an invalid count

`repeat` parsing used `count < 0` as the sentinel for a count it could not read, with the comment "A negative count is meaningless too". So `repeat: -1` — the reflection spelling of beamlines.md, s:repetition — was reported as `repeat: invalid count '-1'` and the entry was left unexpanded.

Parsing now separates "could not read this" from the sign. `3x` and `1.5` are still rejected and still leave the entry in place; `repeat: -n` splices `n` copies and then reverses the run.

The reversal happens **after** the copies are expanded, which is what makes it a reversal of *elements*: by that point any sub-line among the copies has been flattened inline, so it reverses along with everything else, and a reflection nested inside a reflection composes (the inner stretch ends up back the way it was written). Order reversal only — no direction reversal, so a `Bend` keeps `e1` on its upstream side, per the standard.

### A nested `repeat` was never unrolled

Fixing the above exposed a second defect. `repeat` belongs to a line *entry* but is read from the sequence holding it, and the re-expansion of spliced copies called `expand()` on each copy individually — which walks straight past a nested `repeat`. A `repeat` inside a repeated line was silently never unrolled. This was invisible before because a reflection, the natural way to hit it, was rejected outright.

The sequence loop is now `expand_seq_range(t, node, first, stop, ...)`, and the spliced copies go back through it rather than being expanded one at a time.

### `periodic` on a BeamLine

The accepted-component set for `kind: BeamLine` listed `line`, `multipass`, `zero_point`, `repeat` but not `periodic`, so a storage ring saying it was one got `unknown parameter 'periodic'`. beamlines.md, s:beamline.components lists it.

### Verification

`iota.pals.yaml` now reports 0 problems, and the ring expands to the forward half, `qe3`, then the half mirrored (`... dre2 qe2 dre3 qe3 dre3 qe2 dre2 ...` down to `dra1`), matching the ImpactX `second_half.reverse = true` it was translated from.

Tests: 257 pass. `repeat with an unusable count keeps the entry` asserted that `-1` was rejected — that test encoded the bug, so `-1` is replaced with `1.5` there. New cases cover reflection of `-1`/`-3`/`2`/`-0` with a sub-line nested inside the reflected line, reflection-inside-reflection, and the full BeamLine component list.

Note for downstream: PALSJulia builds against pals-cpp `main`, so this lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)