### PR TITLE
Rename to PALSParserCpp; add the `facility>>` scope and settable line references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(YAMLWrapper)
+project(PALSParserCpp)
 
 # Default to Release when no build type is given. This is not just about
 # optimization: an empty build type leaves NDEBUG undefined, and c4core (vendored
@@ -43,7 +43,7 @@ FetchContent_Declare(
   GIT_TAG pcre2-10.44
 )
 # Build only the 8-bit library, statically, and skip the tooling/tests so the
-# regex code is embedded directly into libyaml_c_wrapper.
+# regex code is embedded directly into libPALSParserCpp.
 set(PCRE2_BUILD_PCRE2_8 ON CACHE BOOL "" FORCE)
 set(PCRE2_BUILD_PCRE2_16 OFF CACHE BOOL "" FORCE)
 set(PCRE2_BUILD_PCRE2_32 OFF CACHE BOOL "" FORCE)
@@ -74,21 +74,21 @@ FetchContent_MakeAvailable(apc)
 file(COPY ${CMAKE_SOURCE_DIR}/lattice_files/
      DESTINATION ${CMAKE_BINARY_DIR}/lattice_files/)
 
-add_library(yaml_c_wrapper SHARED
-  src/yaml_c_wrapper.cpp
+add_library(PALSParserCpp SHARED
+  src/PALSParserCpp.cpp
   src/pals_expand.cpp
   src/pals_match.cpp
   src/pals_util.cpp
   src/pals_expression.cpp
   src/pals_floor.cpp
   src/pals_check.cpp)
-target_link_libraries(yaml_c_wrapper PUBLIC ryml PRIVATE pcre2-8-static apc)
+target_link_libraries(PALSParserCpp PUBLIC ryml PRIVATE pcre2-8-static apc)
 
 add_executable(example_rw examples/example_rw.cpp)
-target_link_libraries(example_rw yaml_c_wrapper ryml)
+target_link_libraries(example_rw PALSParserCpp ryml)
 
 add_executable(print_lattices examples/print_lattices.cpp)
-target_link_libraries(print_lattices yaml_c_wrapper ryml)
+target_link_libraries(print_lattices PALSParserCpp ryml)
 
-# Must come after yaml_c_wrapper is defined: tests/CMakeLists.txt links it.
+# Must come after PALSParserCpp is defined: tests/CMakeLists.txt links it.
 add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Introduction
-Pals-cpp is a parser library for [PALS](https://github.com/pals-project/pals) accelerator lattice files. 
+PALSParserCpp is a parser library for [PALS](https://github.com/pals-project/pals) accelerator lattice files. 
 It uses rapidyaml https://github.com/biojppm/rapidyaml to read lattices into memory and provides 
 additional capabilities like printing to console, writing to files, and searching for elements. 
 One major component is performing lattice expansion following the PALS specifications.
@@ -14,7 +14,7 @@ cmake -S . -B build
 cmake --build build
 ```
 
-This builds `libyaml_c_wrapper.dylib`, a shared object library that can interface with other languages. Make sure to rebuild after making any changes to files, and before running tests. All lattice files should go in `lattice_files/`.
+This builds `libPALSParserCpp.dylib`, a shared object library that can interface with other languages. Make sure to rebuild after making any changes to files, and before running tests. All lattice files should go in `lattice_files/`.
 
 ### Example 1
 `examples/example_rw.cpp` contains examples for how to use the library API to read lattice files, perform basic manipulations (adding and removing elements, renaming, etc.), print to console, and write the lattice back to a file. The example uses `ex.pals.yaml` and writes to `expand.pals.yaml`. To see the consle output, navigate to the build directory and run  
@@ -43,9 +43,9 @@ To see the console output, in the build directory, run
 
 ## Extensions
 
-The [PALSJulia.jl](https://github.com/pals-project/PALSJulia.jl) package is an extension of `pals-cpp` to:
+The [PALSJulia.jl](https://github.com/pals-project/PALSJulia.jl) package is an extension of `PALSParserCpp` to:
 
-- Provide a Julia interface for `pals-cpp` C++ functions.
+- Provide a Julia interface for `PALSParserCpp` C++ functions.
 - Provide a translator from `PALS` files to [`Bmad`](https://github.com/bmad-sim/bmad-ecosystem) lattice files.
 - Provide a translator from `PALS` files to [`SciBmad`](https://github.com/bmad-sim/SciBmad.jl) lattice files.
 
@@ -53,9 +53,9 @@ The [PALSJulia.jl](https://github.com/pals-project/PALSJulia.jl) package is an e
 
 The full documentation — the user guide, the five-tree model, the expression
 evaluation rules, and the generated C API reference — is at
-<https://pals-project.github.io/pals-cpp/>.
+<https://pals-project.github.io/PALSParserCpp/>.
 
 Notes for working on the library itself (source layout, memory model, running
 the tests, building the docs) are on the
-[Working on pals-cpp](https://pals-project.github.io/pals-cpp/develop.html)
+[Working on PALSParserCpp](https://pals-project.github.io/PALSParserCpp/develop.html)
 page.

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,4 +1,4 @@
-# Doxygen configuration for the pals-cpp documentation site.
+# Doxygen configuration for the PALSParserCpp documentation site.
 #
 # This produces *XML only*: the narrative site is built by Sphinx (MyST + Furo)
 # and the C/C++ API is pulled in from this XML by the Breathe extension. See
@@ -6,11 +6,11 @@
 #
 # Unset options take Doxygen's defaults.
 
-PROJECT_NAME           = "pals-cpp"
+PROJECT_NAME           = "PALSParserCpp"
 PROJECT_BRIEF          = "A C++ parser for the PALS accelerator-lattice language"
 
 # Document the public headers (the C API and the expression evaluator).
-INPUT                  = ../src/yaml_c_wrapper.h ../src/pals_expression.h
+INPUT                  = ../src/PALSParserCpp.h ../src/pals_expression.h
 FILE_PATTERNS          = *.h *.hpp
 RECURSIVE              = NO
 

--- a/docs/build.py
+++ b/docs/build.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build the pals-cpp documentation.
+"""Build the PALSParserCpp documentation.
 
 Runs Doxygen (C/C++ API -> XML) and then Sphinx (MyST + Furo narrative, with the
 API embedded via Breathe). The finished site is written to ``docs/build/html``.

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,6 +1,6 @@
 # API Reference
 
-The public interface is the C API declared in `yaml_c_wrapper.h`, together with
+The public interface is the C API declared in `PALSParserCpp.h`, together with
 the expression evaluator in `pals_expression.h`. Everything below is generated
 from the header doc comments by [Doxygen](https://www.doxygen.nl) and embedded
 with [Breathe](https://breathe.readthedocs.io).
@@ -24,19 +24,19 @@ with its matching `free_*` function. See
 The opaque handles and sentinel values shared across the API.
 
 ```{doxygentypedef} YAMLTreeHandle
-:project: pals-cpp
+:project: PALSParserCpp
 ```
 
 ```{doxygentypedef} YAMLNodeId
-:project: pals-cpp
+:project: PALSParserCpp
 ```
 
 ```{doxygendefine} YAML_NULL_ID
-:project: pals-cpp
+:project: PALSParserCpp
 ```
 
 ```{doxygendefine} YAML_END
-:project: pals-cpp
+:project: PALSParserCpp
 ```
 
 ## Parsing & expansion
@@ -45,7 +45,7 @@ Read PALS/YAML from disk or memory and expand a lattice into its four
 representations (`original`, `combined`, `expanded`, `adjunct`).
 
 ```{doxygengroup} parse
-:project: pals-cpp
+:project: PALSParserCpp
 :content-only:
 :members:
 ```
@@ -56,7 +56,7 @@ Map a single logical node across the four trees produced by
 {cpp:func}`parse_and_expand_PALS`.
 
 ```{doxygengroup} correspond
-:project: pals-cpp
+:project: PALSParserCpp
 :content-only:
 :members:
 ```
@@ -66,7 +66,7 @@ Map a single logical node across the four trees produced by
 Resolve a PALS name-matching string to the nodes it selects.
 
 ```{doxygengroup} namematch
-:project: pals-cpp
+:project: PALSParserCpp
 :content-only:
 :members:
 ```
@@ -76,7 +76,7 @@ Resolve a PALS name-matching string to the nodes it selects.
 Look up the stored value of a single element parameter, constant, or variable.
 
 ```{doxygengroup} param
-:project: pals-cpp
+:project: PALSParserCpp
 :content-only:
 :members:
 ```
@@ -86,7 +86,7 @@ Look up the stored value of a single element parameter, constant, or variable.
 Walk a tree, read node keys and values, and test node types.
 
 ```{doxygengroup} nav
-:project: pals-cpp
+:project: PALSParserCpp
 :content-only:
 :members:
 ```
@@ -96,7 +96,7 @@ Walk a tree, read node keys and values, and test node types.
 Create trees and add, set, copy, or remove nodes.
 
 ```{doxygengroup} edit
-:project: pals-cpp
+:project: PALSParserCpp
 :content-only:
 :members:
 ```
@@ -106,7 +106,7 @@ Create trees and add, set, copy, or remove nodes.
 Emit a node or whole tree back to YAML text or a file.
 
 ```{doxygengroup} emit
-:project: pals-cpp
+:project: PALSParserCpp
 :content-only:
 :members:
 ```
@@ -119,7 +119,7 @@ Release the handles and strings the API returns. (The subsystem-specific
 {cpp:func}`free_name_matches`.)
 
 ```{doxygengroup} lifecycle
-:project: pals-cpp
+:project: PALSParserCpp
 :content-only:
 :members:
 ```
@@ -127,12 +127,12 @@ Release the handles and strings the API returns. (The subsystem-specific
 ## Expression evaluation
 
 The recursive-descent evaluator behind the PALS expression grammar. The C entry
-point {cpp:func}`evaluate_pals_expression` (declared in `yaml_c_wrapper.h`)
+point {cpp:func}`evaluate_pals_expression` (declared in `PALSParserCpp.h`)
 evaluates a standalone string; the `pals::` interface in `pals_expression.h` is
 the C++ evaluator it and lattice expansion are built on.
 
 ```{doxygengroup} expr
-:project: pals-cpp
+:project: PALSParserCpp
 :content-only:
 :members:
 ```

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -8,9 +8,9 @@
 import os
 
 # -- Project information -----------------------------------------------------
-project = 'pals-cpp'
-copyright = '2026, pals-cpp Contributors'
-author = 'pals-cpp Contributors'
+project = 'PALSParserCpp'
+copyright = '2026, PALSParserCpp Contributors'
+author = 'PALSParserCpp Contributors'
 
 # -- General configuration ---------------------------------------------------
 extensions = [
@@ -25,8 +25,8 @@ numfig = True
 # -- Breathe (Doxygen bridge) ------------------------------------------------
 # Doxygen writes its XML to docs/doxygen/xml (see docs/Doxyfile and build.py).
 # The path is relative to this conf.py, which lives in docs/src.
-breathe_projects = {'pals-cpp': '../doxygen/xml'}
-breathe_default_project = 'pals-cpp'
+breathe_projects = {'PALSParserCpp': '../doxygen/xml'}
+breathe_default_project = 'PALSParserCpp'
 breathe_domain_by_extension = {'h': 'cpp', 'hpp': 'cpp'}
 breathe_show_include = False
 
@@ -43,7 +43,7 @@ myst_heading_anchors = 3
 # -- HTML output (Furo) ------------------------------------------------------
 html_theme = 'furo'
 html_theme_options = {
-    'source_repository': 'https://github.com/pals-project/pals-cpp',
+    'source_repository': 'https://github.com/pals-project/PALSParserCpp',
     'source_branch': 'main',
     'source_directory': 'docs/src/',
     'navigation_with_keys': True,
@@ -53,7 +53,7 @@ html_theme_options = {
     'footer_icons': [
         {
             'name': 'GitHub',
-            'url': 'https://github.com/pals-project/pals-cpp',
+            'url': 'https://github.com/pals-project/PALSParserCpp',
             'html': """
                 <svg stroke="currentColor" fill="currentColor" stroke-width="0"
                      viewBox="0 0 16 16">
@@ -64,4 +64,4 @@ html_theme_options = {
         },
     ],
 }
-html_title = 'pals-cpp'
+html_title = 'PALSParserCpp'

--- a/docs/src/develop.md
+++ b/docs/src/develop.md
@@ -1,4 +1,4 @@
-# Working on pals-cpp
+# Working on PALSParserCpp
 
 Notes for working on the library itself: where the code lives, how trees are
 held in memory, how to run the tests, and how to build this documentation.
@@ -7,9 +7,9 @@ held in memory, how to run the tests, and how to build this documentation.
 
 The library sources live in `src/`, split by concern:
 
-- **`yaml_c_wrapper.h`** — the public C API: the opaque handle types and every
+- **`PALSParserCpp.h`** — the public C API: the opaque handle types and every
   exported function. This is the only header consumers include.
-- **`yaml_c_wrapper.cpp`** — the generic YAML tree wrapper over rapidyaml
+- **`PALSParserCpp.cpp`** — the generic YAML tree wrapper over rapidyaml
   (parse, traverse, query, modify, emit). Knows nothing about PALS.
 - **`yaml_tree.h`** — internal declarations shared between the wrapper and the
   PALS code: the tree representation behind `YAMLTreeHandle` (`ParsedData`)
@@ -37,7 +37,7 @@ The library sources live in `src/`, split by concern:
 - **`pals_expression.{h,cpp}`** — the standalone PALS expression grammar and
   evaluator (arithmetic, functions, built-in constants, particle-data lookups).
 
-Everything builds into `libyaml_c_wrapper`; see `CMakeLists.txt`.
+Everything builds into `libPALSParserCpp`; see `CMakeLists.txt`.
 
 ## Memory model
 
@@ -103,7 +103,7 @@ a different story: `example_rw` and `print_lattices` reach their lattices throug
 
 The site is built with Sphinx (MyST Markdown + the Furo theme), with the C/C++
 API pulled in from Doxygen via [Breathe](https://breathe.readthedocs.io). The
-published site is at <https://pals-project.github.io/pals-cpp/>.
+published site is at <https://pals-project.github.io/PALSParserCpp/>.
 
 To build and preview it locally (requires `doxygen` and `python3`):
 
@@ -117,5 +117,5 @@ This runs `docs/build.py` — Doxygen (API → XML), then Sphinx →
 elsewhere.
 
 Narrative pages live in `docs/src/`; the API reference is generated from the
-doc comments in `src/yaml_c_wrapper.h` and `src/pals_expression.h`, so API
+doc comments in `src/PALSParserCpp.h` and `src/pals_expression.h`, so API
 documentation is edited in the headers themselves.

--- a/docs/src/guide/expressions.md
+++ b/docs/src/guide/expressions.md
@@ -18,7 +18,7 @@ Constant values come from
 [AtomicAndPhysicalConstantsCLib](https://github.com/pals-project/AtomicAndPhysicalConstantsCLib)
 (APC — a C++ mirror of
 [AtomicAndPhysicalConstants.jl](https://github.com/bmad-sim/AtomicAndPhysicalConstants.jl),
-CODATA 2022), fetched automatically by CMake, so pals-cpp shares one set of
+CODATA 2022), fetched automatically by CMake, so PALSParserCpp shares one set of
 numbers with the rest of the toolchain.
 
 ## Where the standard leaves a choice

--- a/docs/src/guide/trees.md
+++ b/docs/src/guide/trees.md
@@ -8,7 +8,7 @@ actually is.
 
 The PALS standard deliberately leaves this open — it says what lattice expansion
 must produce, not how a parser must hold the result. The five trees are this
-library's answer, and everything on this page is pals-cpp's own arrangement
+library's answer, and everything on this page is PALSParserCpp's own arrangement
 rather than part of the standard.
 
 | Tree | Holds |
@@ -122,7 +122,7 @@ put them.
 
 ### What the expansion adds
 
-Everything below is written by pals-cpp into `full_expanded` and appears in no
+Everything below is written by PALSParserCpp into `full_expanded` and appears in no
 other tree.
 
 **Per element, from the element bookkeeper:**

--- a/docs/src/guide/usage.md
+++ b/docs/src/guide/usage.md
@@ -9,7 +9,7 @@ cmake -S . -B build
 cmake --build build
 ```
 
-This builds `libyaml_c_wrapper` (`.dylib`/`.so`), a shared library that other
+This builds `libPALSParserCpp` (`.dylib`/`.so`), a shared library that other
 languages can load. CMake fetches the dependencies —
 [rapidyaml](https://github.com/biojppm/rapidyaml),
 [PCRE2](https://www.pcre.org), and
@@ -28,7 +28,7 @@ independent views —
 `delete_tree`.
 
 ```cpp
-#include "yaml_c_wrapper.h"
+#include "PALSParserCpp.h"
 
 struct lattices lat = parse_and_expand_PALS("ex.pals.yaml", nullptr);
 
@@ -224,7 +224,7 @@ The `examples/` directory contains runnable programs:
 
 ## Extensions
 
-[PALSJulia](https://github.com/pals-project/PALSJulia) extends pals-cpp with a
+[PALSJulia](https://github.com/pals-project/PALSJulia) extends PALSParserCpp with a
 Julia interface to the C API and translators from PALS to
 [Bmad](https://github.com/bmad-sim/bmad-ecosystem) and
 [SciBmad](https://github.com/bmad-sim/SciBmad.jl) lattice files.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,11 +1,11 @@
-# pals-cpp
+# PALSParserCpp
 
-**pals-cpp** is a C++ parser library for the Particle Accelerator Lattice
+**PALSParserCpp** is a C++ parser library for the Particle Accelerator Lattice
 Standard ([PALS](https://github.com/pals-project/pals)). It reads PALS-format
 YAML lattice files with [rapidyaml](https://github.com/biojppm/rapidyaml),
 expands a lattice according to the PALS specification, evaluates the
 mathematical expressions in the expanded lattice, and exposes everything through
-a C API (`yaml_c_wrapper.h`) that other languages — such as
+a C API (`PALSParserCpp.h`) that other languages — such as
 [PALSJulia](https://github.com/pals-project/PALSJulia) — wrap.
 
 ```{toctree}
@@ -52,7 +52,7 @@ See [The five trees](guide/trees.md) for what each one holds and which to reach
 for, [Building and using the library](guide/usage.md) to get started,
 [Evaluating expressions](guide/expressions.md) for this library's evaluation
 model, and the [API Reference](api.md) for the full C interface.
-[Working on pals-cpp](develop.md) covers the source layout, the memory model,
+[Working on PALSParserCpp](develop.md) covers the source layout, the memory model,
 the tests, and building this site.
 
 The PALS standard itself — the schema, the element kinds and parameter groups,
@@ -67,10 +67,10 @@ cmake -S . -B build
 cmake --build build
 ```
 
-This builds `libyaml_c_wrapper`, a shared library other languages can load.
+This builds `libPALSParserCpp`, a shared library other languages can load.
 
 ```cpp
-#include "yaml_c_wrapper.h"
+#include "PALSParserCpp.h"
 
 struct lattices lat = parse_and_expand_PALS("ex.pals.yaml", nullptr);
 char* s = tree_to_string(lat.full_expanded);  // the expanded lattice as YAML

--- a/examples/example_rw.cpp
+++ b/examples/example_rw.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-#include "../src/yaml_c_wrapper.h"
+#include "../src/PALSParserCpp.h"
 
 int main(int argc, char* argv[]) {
     std::cout << "============ Printing Developer Information ============" << std::endl;

--- a/examples/print_lattices.cpp
+++ b/examples/print_lattices.cpp
@@ -3,7 +3,7 @@
 #include <ryml.hpp>
 #include <ryml_std.hpp>
 
-#include "../src/yaml_c_wrapper.h"
+#include "../src/PALSParserCpp.h"
 
 int main(int argc, char* argv[]) {
     const char* file_name = nullptr;

--- a/src/PALSParserCpp.cpp
+++ b/src/PALSParserCpp.cpp
@@ -3,7 +3,7 @@
 // lattice logic that builds on it lives in pals_lattice.cpp. Declarations
 // shared between the two are in yaml_tree.h.
 
-#include "yaml_c_wrapper.h"
+#include "PALSParserCpp.h"
 #include "yaml_tree.h"
 
 #include <cstring>

--- a/src/PALSParserCpp.h
+++ b/src/PALSParserCpp.h
@@ -1,8 +1,8 @@
-#ifndef YAML_C_WRAPPER_H
-#define YAML_C_WRAPPER_H
+#ifndef PALS_PARSER_CPP_H
+#define PALS_PARSER_CPP_H
 
 /**
- * @file yaml_c_wrapper.h
+ * @file PALSParserCpp.h
  * @brief Public C API for parsing and manipulating PALS YAML lattices.
  */
 
@@ -416,6 +416,18 @@ YAML_API void free_correspondence_map(struct correspondence_map map);
  * omitted or empty pattern component matches any name at that level. `{branch}`
  * matches an element if any enclosing BeamLine/Branch name matches, so elements
  * in sub-lines are included.
+ *
+ * A line entry written as a bare reference (`- q1`) is matched only through a
+ * `{branch}` qualifier. It holds no parameters of its own until something writes
+ * one — `- q1: {length: 0.6}` is the same entry with room for them — so
+ * unqualified, `q1` is the definition it points at rather than the reference.
+ *
+ * `facility` is reserved as a `{branch}` name: it selects the element
+ * definitions held directly by the `facility` list rather than the elements of
+ * any branch, and being a keyword it is matched literally, not as a pattern.
+ * Definitions written inline inside a beamline are not reached by it — they
+ * belong to that beamline — and neither is anything when a `{lattice}`
+ * qualifier is also given, since a definition belongs to no lattice.
  *
  * The node returned for each match is whatever the string resolves to: the
  * element node (no parameter path), the parameter-group or parameter node (with
@@ -908,4 +920,4 @@ YAML_API void yaml_free_string(char* str);
 }
 #endif
 
-#endif  // YAML_C_WRAPPER_H
+#endif  // PALS_PARSER_CPP_H

--- a/src/pals_check.cpp
+++ b/src/pals_check.cpp
@@ -660,6 +660,39 @@ void walk(const ryml::Tree& t, size_t node, const Extensions& ext,
     }
 }
 
+// Collect every construct wrongly named `facility`. The word is reserved: in a
+// name-matching string `facility>>q1` selects the `q1` held by the facility node
+// itself rather than any branch's (lattice-elements.md), so an element, BeamLine
+// or Lattice answering to `facility` would make the qualifier ambiguous.
+//
+// The three places a construct is given a name are an entry of the `facility`
+// list, an entry of a `line`, and an entry of `branches` -- each a sequence of
+// anonymous maps wrapping one keyed definition. Looking for the shape rather
+// than for a `kind` is what also catches a branch that only `inherit`s a
+// beamline, which carries no kind of its own. Node ids are collected in a set so
+// a construct reachable two ways is still reported once.
+void collect_reserved_names(const ryml::Tree& t, size_t node,
+                            std::set<size_t>& bad) {
+    if (node == ryml::NONE) return;
+
+    if (t.is_seq(node) && t.has_key(node)) {
+        std::string k(t.key(node).str, t.key(node).len);
+        if (k == "facility" || k == "line" || k == "branches") {
+            for (size_t e = t.first_child(node); e != ryml::NONE;
+                 e = t.next_sibling(e)) {
+                if (!t.is_map(e)) continue;
+                size_t def = t.first_child(e);
+                if (def == ryml::NONE || !t.has_key(def)) continue;
+                if (std::string(t.key(def).str, t.key(def).len) == "facility")
+                    bad.insert(def);
+            }
+        }
+    }
+
+    for (size_t c = t.first_child(node); c != ryml::NONE; c = t.next_sibling(c))
+        collect_reserved_names(t, c, bad);
+}
+
 // Check the keys of the `PALS` root node itself. walk() judges what is below it
 // in context, but the root's own vocabulary is closed and small, and a
 // misspelling there is otherwise silent: `extension_names` registers no
@@ -693,4 +726,20 @@ void check_pals_names(const ryml::Tree& t, pals::ProblemList& problems) {
     Extensions ext = collect_extensions(t);
     check_pals_root(t, ext, problems);
     walk(t, t.root_id(), ext, problems);
+
+    // One problem however many constructs are misnamed: the name, the reason
+    // and the fix are the same for all of them, so a message per occurrence
+    // would repeat itself word for word. The count is what varies, so that is
+    // what the message carries.
+    std::set<size_t> reserved;
+    collect_reserved_names(t, t.root_id(), reserved);
+    if (!reserved.empty()) {
+        std::string msg =
+            "'facility' is a reserved name and cannot name an element, "
+            "BeamLine or Lattice: 'facility>>' selects the definitions the "
+            "facility node itself holds";
+        if (reserved.size() > 1)
+            msg += " (" + std::to_string(reserved.size()) + " uses)";
+        add(problems, msg, "facility");
+    }
 }

--- a/src/pals_check.h
+++ b/src/pals_check.h
@@ -8,7 +8,7 @@
 // why they are caught here. Expansion has nothing to object to, so the trees
 // come back sound but holding something other than what the author wrote, with
 // no other pass to notice. Reported as PROBLEM_ERROR for that reason.
-// Not part of the public C API declared in yaml_c_wrapper.h.
+// Not part of the public C API declared in PALSParserCpp.h.
 
 #include <string>
 #include <vector>

--- a/src/pals_expand.cpp
+++ b/src/pals_expand.cpp
@@ -4,9 +4,9 @@
 // inherits, forks), evaluates expressions into the expanded tree, and applies
 // the controllers that drive
 // its parameters. Name matching and parameter lookup live in pals_match.cpp;
-// the generic YAML tree wrapper in yaml_c_wrapper.cpp.
+// the generic YAML tree wrapper in PALSParserCpp.cpp.
 
-#include "yaml_c_wrapper.h"
+#include "PALSParserCpp.h"
 #include "yaml_tree.h"
 #include "pals_util.h"
 #include "pals_floor.h"
@@ -2694,6 +2694,24 @@ struct SetCommand {
 // `written`, when given, collects one target per parameter actually written --
 // what the `expanded` tree needs in order to tell a post-expansion set's input
 // apart from a value the bookkeeper derived from it (see AuthoredParams).
+// Give a bare line reference somewhere to hold a parameter, returning the node
+// the parameter hangs off. `- q1` and `- q1:` are the same entry -- the second
+// just has room for values of its own -- so a `set` naming the first rewrites it
+// into the second rather than refusing the write. The node comes back unchanged
+// when it is already keyed, which every other kind of match is.
+//
+// The new nodes carry no provenance, like the ReferenceP/FloorP the bookkeeper
+// adds: they answer to nothing in the source, since the source did not write
+// them.
+static size_t materialize_line_reference(ryml::Tree& t, size_t node) {
+    if (node == ryml::NONE || t.has_key(node) || !t.has_val(node)) return node;
+    std::string name(t.val(node).str, t.val(node).len);
+    t.to_map(node);  // the seq entry becomes the anonymous wrapper map
+    size_t def = t.append_child(node);
+    t.to_map(def, t.to_arena(ryml::to_csubstr(name)));
+    return def;
+}
+
 static void execute_set(ryml::Tree& t, const SetCommand& cmd,
                         const ElementMatches& matches, bool pre,
                         const pals::SymbolLookup& resolve,
@@ -2733,7 +2751,8 @@ static void execute_set(ryml::Tree& t, const SetCommand& cmd,
     std::map<std::string, size_t> emap;
     if (pre) make_ele_map(emap, t, t.root_id());
 
-    for (size_t ele : matches.elements) {
+    for (size_t match : matches.elements) {
+        size_t ele = materialize_line_reference(t, match);
         SetTarget tg = make_target(ele, matches.path);
         std::string ename(t.key(ele).str, t.key(ele).len);
         std::string where = what + " on '" + ename + "'";

--- a/src/pals_expression.h
+++ b/src/pals_expression.h
@@ -19,7 +19,7 @@
 
 namespace pals {
 
-// The `expr` group is defined in yaml_c_wrapper.h (@defgroup expr); the symbols
+// The `expr` group is defined in PALSParserCpp.h (@defgroup expr); the symbols
 // below join it so the C entry point and this C++ interface document together.
 
 /**

--- a/src/pals_match.cpp
+++ b/src/pals_match.cpp
@@ -1,10 +1,10 @@
 // PALS name matching and parameter lookup: resolves a PALS name-matching
-// string (see match_names in yaml_c_wrapper.h) against a tree using PCRE2, and
+// string (see match_names in PALSParserCpp.h) against a tree using PCRE2, and
 // reads the value of a matched element parameter, constant, or variable. The
 // lattice expansion that produces the trees this runs on lives in
-// pals_expand.cpp; the generic YAML tree wrapper in yaml_c_wrapper.cpp.
+// pals_expand.cpp; the generic YAML tree wrapper in PALSParserCpp.cpp.
 
-#include "yaml_c_wrapper.h"
+#include "PALSParserCpp.h"
 #include "yaml_tree.h"
 #include "pals_util.h"
 
@@ -40,6 +40,11 @@
 // parameter path — additionally matches constants and variables. The node
 // returned for a match is whatever the string resolves to: the element node,
 // the parameter-group or parameter node, or the constant/variable node.
+//
+// `facility` as the branch name is the one reserved word here: it selects
+// element *definitions* held by the `facility` list rather than elements of any
+// branch (lattice-elements.md). That is why no element, BeamLine or Lattice may
+// be named `facility` — pals_check.cpp reports one that is.
 //
 // Not yet implemented from Element Name Matching: '#N' instance selection,
 // '{e1}:{e2}' ranges, ',' unions, and '&' intersections.
@@ -89,6 +94,7 @@ struct NameSelector {
     std::string kind;
     bool lattice_present = false;
     bool branch_present = false;
+    bool facility_scope = false;  // the branch qualifier was `facility`
     bool has_kind = false;
     bool has_param = false;
     std::vector<std::string> path;
@@ -121,6 +127,13 @@ static NameSelector parse_selector(const std::string& spec) {
         branch = s.substr(0, p2);
         s = s.substr(p2 + 2);
         sel.branch_present = true;
+        // `facility` names the facility node, not a branch, so it is taken as
+        // the literal word rather than compiled as a pattern: a branch pattern
+        // wide enough to cover it (`.*`) still means branches only.
+        if (branch == "facility") {
+            sel.facility_scope = true;
+            branch.clear();
+        }
     }
     size_t p1 = s.find('>');
     std::string elem_part;
@@ -294,13 +307,31 @@ static void match_elements(const ryml::Tree& t, size_t node,
         if (lattice_ok && branch_ok) {
             for (size_t entry = t.first_child(line); entry != ryml::NONE;
                  entry = t.next_sibling(entry)) {
-                // A named element is a map whose first child is keyed with the
-                // element name; bare scalar entries are unresolved references
-                // with no parameters, so they are skipped.
-                if (!t.is_map(entry)) continue;
-                size_t def = t.first_child(entry);
-                if (def == ryml::NONE || !t.has_key(def)) continue;
-                if (!full_match(sel.name, node_key_str(t, def))) continue;
+                // A line entry is either a map whose first child is keyed with
+                // the element name -- an inline definition, or a reference
+                // carrying values of its own -- or a bare scalar naming an
+                // element defined elsewhere.
+                size_t def = ryml::NONE;
+                std::string ename;
+                if (t.is_map(entry)) {
+                    def = t.first_child(entry);
+                    if (def == ryml::NONE || !t.has_key(def)) continue;
+                    ename = node_key_str(t, def);
+                } else if (t.has_val(entry) && sel.branch_present) {
+                    // A bare `- q1` holds no parameters of its own, but it can
+                    // be given them -- `- q1: {length: 0.6}` is the same entry
+                    // written longhand -- so it is a settable element, not a
+                    // dead reference. It answers only to a name qualified by the
+                    // line it sits in: unqualified, `q1` is the definition it
+                    // points at, and a `set` before expansion "targets the
+                    // single q1 definition" (lattice-construction.md,
+                    // s:expand.lat) with every reference following along.
+                    def = entry;
+                    ename = std::string(t.val(entry).str, t.val(entry).len);
+                } else {
+                    continue;
+                }
+                if (!full_match(sel.name, ename)) continue;
                 if (sel.has_kind && child_val_str(t, def, "kind") != sel.kind)
                     continue;
                 size_t hit = (sel.has_param && resolve_params)
@@ -315,6 +346,63 @@ static void match_elements(const ryml::Tree& t, size_t node,
     for (size_t c = t.first_child(node); c != ryml::NONE; c = t.next_sibling(c))
         match_elements(t, c, cur_lattice, cur_beamlines, sel, resolve_params,
                        out, seen);
+}
+
+// Match the element definitions held directly by one `facility` list -- what the
+// reserved branch name `facility` selects. Each entry is an anonymous map
+// wrapping a single keyed definition, the shape match_definition_parameters
+// walks. Elements written inside a beamline's `line` under this facility are
+// deliberately out of reach: it is the definition standing *outside* the
+// beamlines that `facility>>` names, and match_elements already covers the rest.
+static void match_facility_entries(const ryml::Tree& t, size_t fac,
+                                   const NameSelector& sel, bool resolve_params,
+                                   std::vector<size_t>& out,
+                                   std::set<size_t>& seen) {
+    for (size_t w = t.first_child(fac); w != ryml::NONE; w = t.next_sibling(w)) {
+        if (!t.is_map(w)) continue;
+        size_t def = t.first_child(w);
+        if (def == ryml::NONE || !t.has_key(def) || !t.is_map(def)) continue;
+        if (!full_match(sel.name, node_key_str(t, def))) continue;
+        if (sel.has_kind && child_val_str(t, def, "kind") != sel.kind) continue;
+        size_t hit = (sel.has_param && resolve_params)
+                         ? resolve_param_path(t, def, sel.path)
+                         : def;
+        if (hit != ryml::NONE && seen.insert(hit).second) out.push_back(hit);
+    }
+}
+
+// Every `facility` list in the tree. There is one per PALS node, and the PALS
+// node sits at the root in most views but one level down per included file in
+// `original`, so the whole tree is walked rather than a fixed path guessed at.
+static void match_facility(const ryml::Tree& t, size_t node,
+                           const NameSelector& sel, bool resolve_params,
+                           std::vector<size_t>& out, std::set<size_t>& seen) {
+    if (node == ryml::NONE) return;
+    if (t.is_seq(node) && node_key_str(t, node) == "facility") {
+        match_facility_entries(t, node, sel, resolve_params, out, seen);
+        return;  // a `facility` nested under a facility is not one
+    }
+    for (size_t c = t.first_child(node); c != ryml::NONE; c = t.next_sibling(c))
+        match_facility(t, c, sel, resolve_params, out, seen);
+}
+
+// Send `sel` to whichever population of elements it names: the definitions under
+// `facility`, or the elements sitting in beamlines below `root`.
+//
+// A `facility>>` selector ignores `root`. Callers scope `root` to the expanded
+// lattice, and the definitions the qualifier asks for are outside it by
+// construction -- naming them is the whole point of the qualifier. A lattice
+// qualifier alongside it matches nothing, since a definition belongs to no
+// lattice until the lattice is expanded.
+static void match_selected(const ryml::Tree& t, size_t root,
+                           const NameSelector& sel, bool resolve_params,
+                           std::vector<size_t>& out, std::set<size_t>& seen) {
+    if (sel.facility_scope) {
+        if (!sel.lattice_present)
+            match_facility(t, t.root_id(), sel, resolve_params, out, seen);
+        return;
+    }
+    match_elements(t, root, "", {}, sel, resolve_params, out, seen);
 }
 
 // Classify a single keyed node as a constant/variable and, if its name matches,
@@ -395,8 +483,8 @@ ElementMatches match_element_parameters(const ryml::Tree& t, size_t root,
     out.path = sel.path;
     if (sel.valid) {
         std::set<size_t> seen;
-        match_elements(t, root == ryml::NONE ? t.root_id() : root, "", {}, sel,
-                       false, out.elements, seen);
+        match_selected(t, root == ryml::NONE ? t.root_id() : root, sel, false,
+                       out.elements, seen);
     }
     free_selector(sel);
     return out;
@@ -407,7 +495,12 @@ ElementMatches match_definition_parameters(const ryml::Tree& t,
                                            const std::string& spec) {
     ElementMatches out;
     NameSelector sel = parse_selector(spec);
-    out.valid = sel.valid && !sel.lattice_present && !sel.branch_present;
+    // A `{lattice}>>>` qualifier still cannot apply: no lattice has been built
+    // yet, so nothing here belongs to one. A `{branch}>>` qualifier does apply,
+    // to the beamlines these entries define -- `myline>>q1` is the q1 sitting in
+    // myline's line, whether that entry is written out in full or is the bare
+    // reference `- q1`.
+    out.valid = sel.valid && !sel.lattice_present;
     out.has_param = sel.has_param;
     out.path = sel.path;
     if (out.valid) {
@@ -419,14 +512,20 @@ ElementMatches match_definition_parameters(const ryml::Tree& t,
             if (entry == ryml::NONE || !t.is_map(entry)) continue;
             size_t def = t.first_child(entry);
             if (def == ryml::NONE || !t.has_key(def) || !t.is_map(def)) continue;
-            if (full_match(sel.name, node_key_str(t, def)) &&
+            // A definition standing as an entry of its own is inside no
+            // beamline, so a `{branch}>>` qualifier passes it over -- except
+            // `facility>>`, which names exactly these.
+            if ((!sel.branch_present || sel.facility_scope) &&
+                full_match(sel.name, node_key_str(t, def)) &&
                 !(sel.has_kind && child_val_str(t, def, "kind") != sel.kind) &&
                 seen.insert(def).second)
                 out.elements.push_back(def);
             // An element may equally be defined inline inside a beamline of
             // this entry rather than as an entry of its own, and it is just as
-            // much "defined by this point" in the list.
-            match_elements(t, entry, "", {}, sel, false, out.elements, seen);
+            // much "defined by this point" in the list -- but it is inside a
+            // beamline, which is what `facility>>` excludes.
+            if (!sel.facility_scope)
+                match_elements(t, entry, "", {}, sel, false, out.elements, seen);
         }
     }
     free_selector(sel);
@@ -446,7 +545,7 @@ YAML_API struct name_matches match_names(YAMLTreeHandle tree,
     std::set<size_t> seen;
 
     if (sel.valid) {
-        match_elements(t, t.root_id(), "", {}, sel, true, hits, seen);
+        match_selected(t, t.root_id(), sel, true, hits, seen);
 
         // A bare name (no lattice/branch/kind qualifier and no parameter path)
         // also matches constants and variables directly by name.
@@ -493,7 +592,7 @@ YAML_API struct param_value get_parameter_value(YAMLTreeHandle tree,
         sel.has_param = false;
         std::vector<size_t> eles;
         std::set<size_t> seen;
-        match_elements(t, t.root_id(), "", {}, sel, true, eles, seen);
+        match_selected(t, t.root_id(), sel, true, eles, seen);
         free_selector(sel);
         if (eles.empty()) return out;  // no such element -> missing
         for (size_t ele : eles)

--- a/src/pals_problem.h
+++ b/src/pals_problem.h
@@ -7,16 +7,16 @@
 //
 // Kept in its own header, rather than in pals_expand.cpp where the expander's
 // problems are raised, because the name checks in pals_check.cpp report into
-// the same list. Not part of the public C API declared in yaml_c_wrapper.h.
+// the same list. Not part of the public C API declared in PALSParserCpp.h.
 
 #include <string>
 #include <vector>
 
-#include "yaml_c_wrapper.h"
+#include "PALSParserCpp.h"
 
 namespace pals {
 
-// Mirrors the C enums of the same names; see yaml_c_wrapper.h for what the
+// Mirrors the C enums of the same names; see PALSParserCpp.h for what the
 // values mean. Kept as a scoped enum internally so an unannotated call site
 // cannot silently pass the wrong one -- the two are both small ints, and the
 // argument order would not protect us.

--- a/src/pals_util.h
+++ b/src/pals_util.h
@@ -4,7 +4,7 @@
 // Small helpers shared between the PALS expansion pipeline (pals_expand.cpp)
 // and PALS name matching / parameter lookup (pals_match.cpp): dotted
 // parameter-path utilities and the expr(...) unwrapper. Not part of the public
-// C API declared in yaml_c_wrapper.h.
+// C API declared in PALSParserCpp.h.
 
 #include <cstddef>
 #include <string>
@@ -28,7 +28,7 @@ size_t resolve_param_path(const ryml::Tree& t, size_t ele,
 // it. `was_expr` reports whether an `expr(...)` wrapper was present.
 std::string strip_expr_wrapper(const std::string& s, bool& was_expr);
 
-// What a PALS name-matching string (match_names syntax, see yaml_c_wrapper.h)
+// What a PALS name-matching string (match_names syntax, see PALSParserCpp.h)
 // selected, reported as the element definitions it matched plus the parameter
 // path it named. Elements are listed whether or not they carry that parameter,
 // so a caller that *writes* the parameter -- a controller driving it -- can
@@ -43,7 +43,8 @@ struct ElementMatches {
 // Run a name-matching string over the subtree at `root` (ryml::NONE for the
 // whole tree). Scoping to the expanded lattice node is what keeps a controller
 // from also matching the unexpanded element definitions still sitting in
-// `facility`.
+// `facility`. The `facility>>` qualifier is the deliberate exception: it asks
+// for those definitions by name, so it looks outside `root`.
 ElementMatches match_element_parameters(const ryml::Tree& t, size_t root,
                                         const std::string& spec);
 
@@ -52,8 +53,11 @@ ElementMatches match_element_parameters(const ryml::Tree& t, size_t root,
 // each an anonymous wrapper map holding one keyed definition. This is what a
 // `set` ahead of `expand_lattice` acts on, so passing only the entries that
 // precede the set is what restricts it to the elements defined by that point.
-// A `{lattice}>>>` or `{branch}>>` qualifier cannot apply to a definition and
-// makes the match string invalid here.
+// A `{lattice}>>>` qualifier cannot apply -- no lattice has been built yet --
+// and makes the match string invalid here. A `{branch}>>` one does apply, to the
+// beamlines these entries define, and then excludes the entries themselves; the
+// exception is `facility>>`, which names exactly those and nothing inside a
+// beamline.
 ElementMatches match_definition_parameters(const ryml::Tree& t,
                                            const std::vector<size_t>& entries,
                                            const std::string& spec);

--- a/src/yaml_tree.h
+++ b/src/yaml_tree.h
@@ -3,9 +3,9 @@
 
 // The concrete YAML tree representation (the type behind the opaque
 // YAMLTreeHandle) and its low-level helpers, shared between the generic YAML
-// tree wrapper (yaml_c_wrapper.cpp) and the PALS lattice logic
+// tree wrapper (PALSParserCpp.cpp) and the PALS lattice logic
 // (pals_lattice.cpp). This header is not installed and is not part of the
-// public C API declared in yaml_c_wrapper.h.
+// public C API declared in PALSParserCpp.h.
 
 #include <cstddef>
 #include <map>
@@ -13,7 +13,7 @@
 
 #include <ryml.hpp>
 
-#include "yaml_c_wrapper.h"
+#include "PALSParserCpp.h"
 
 // Underlying object for YAMLTreeHandle. Contains the parsed YAML tree and the
 // string buffer it was parsed from. Nodes are identied by their index (of type

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(tests
 
 target_link_libraries(tests
   PRIVATE
-  yaml_c_wrapper
+  PALSParserCpp
   Catch2::Catch2WithMain
 )
 

--- a/tests/test_check.cpp
+++ b/tests/test_check.cpp
@@ -256,6 +256,51 @@ TEST_CASE("the components of a BeamLine are all accepted",
     REQUIRE(count_with(ps, "unknown parameter") == 0);
 }
 
+TEST_CASE("`facility` is rejected as the name of anything",
+          "[check][problems]") {
+    // lattice-elements.md: `facility` where a branch name goes selects the
+    // definitions the facility node itself holds, so nothing else may answer to
+    // it. Reported wherever a construct is named -- a facility entry, a `line`
+    // entry, or a branch, the last of which carries no kind to be found by.
+    auto ps = problems_for("PALS:\n"
+                           "  facility:\n"
+                           "    - facility:\n"
+                           "        kind: Quadrupole\n"
+                           "        length: 1\n");
+    REQUIRE(count_with(ps, "reserved name") == 1);
+
+    ps = problems_for("PALS:\n"
+                      "  facility:\n"
+                      "    - main:\n"
+                      "        kind: BeamLine\n"
+                      "        line:\n"
+                      "          - facility:\n"
+                      "              kind: Marker\n");
+    REQUIRE(count_with(ps, "reserved name") == 1);
+
+    ps = problems_for("PALS:\n"
+                      "  facility:\n"
+                      "    - main:\n"
+                      "        kind: BeamLine\n"
+                      "        line:\n"
+                      "          - m1:\n"
+                      "              kind: Marker\n"
+                      "    - lat:\n"
+                      "        kind: Lattice\n"
+                      "        branches:\n"
+                      "          - facility:\n"
+                      "              inherit: main\n");
+    REQUIRE(count_with(ps, "reserved name") == 1);
+
+    // The `facility` list itself is not a construct named `facility`.
+    ps = problems_for("PALS:\n"
+                      "  facility:\n"
+                      "    - q1:\n"
+                      "        kind: Quadrupole\n"
+                      "        length: 1\n");
+    REQUIRE(count_with(ps, "reserved name") == 0);
+}
+
 TEST_CASE("groups with no fixed vocabulary are left alone",
           "[check][problems]") {
     // MetaP may hold arbitrary metadata beyond its six components (meta.md) and

--- a/tests/test_floor.cpp
+++ b/tests/test_floor.cpp
@@ -10,7 +10,7 @@
 //
 // pals_floor.cpp is compiled straight into the tests executable (see
 // tests/CMakeLists.txt): its symbols carry hidden visibility and so are not
-// reachable through the yaml_c_wrapper shared library.
+// reachable through the PALSParserCpp shared library.
 
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-#include "../src/yaml_c_wrapper.h"
+#include "../src/PALSParserCpp.h"
 
 // ─── file helpers ───────────────────────────────────────────────────────────
 // The tests do not create lattice files. A lattice a test needs only in order to

--- a/tests/test_matching.cpp
+++ b/tests/test_matching.cpp
@@ -175,6 +175,127 @@ TEST_CASE("`>>` filters by BeamLine/Branch, including sub-lines", "[matching]") 
     delete_tree(t);
 }
 
+namespace {
+
+// The example of lattice-elements.md (element name matching): `q1` defined as a
+// facility entry, and a second `q1` written inside the beamline `myline`. Only
+// the first is what `facility>>q1` names.
+const char* FACILITY_YAML =
+    "PALS:\n"
+    "  facility:\n"
+    "    - q1:\n"
+    "        kind: Quadrupole\n"
+    "        length: 0.1\n"
+    "    - unused:\n"
+    "        kind: Sextupole\n"
+    "        length: 0.7\n"
+    "    - myline:\n"
+    "        kind: BeamLine\n"
+    "        line:\n"
+    "          - q1:\n"
+    "              kind: Quadrupole\n"
+    "              length: 0.9\n"
+    "    - mylat:\n"
+    "        kind: Lattice\n"
+    "        branches:\n"
+    "          - mybranch:\n"
+    "              inherit: myline\n";
+
+}  // namespace
+
+TEST_CASE("the branch name `facility` selects the facility node's definitions",
+          "[matching]") {
+    YAMLTreeHandle t = parse_string(FACILITY_YAML);
+
+    // The definition standing outside any beamline, not the `q1` in myline.
+    struct name_matches m = match_names(t, "facility>>q1>length");
+    REQUIRE(m.count == 1);
+    REQUIRE(val_eq(t, m.nodes[0], "0.1"));
+    free_name_matches(m);
+
+    // A beamline qualifier still names the one inside that beamline.
+    m = match_names(t, "myline>>q1>length");
+    REQUIRE(m.count == 1);
+    REQUIRE(val_eq(t, m.nodes[0], "0.9"));
+    free_name_matches(m);
+
+    // A definition no beamline uses is reachable only this way: elements are
+    // otherwise matched where they sit in a `line`, and this one sits in none.
+    m = match_names(t, "facility>>unused>length");
+    REQUIRE(m.count == 1);
+    REQUIRE(val_eq(t, m.nodes[0], "0.7"));
+    free_name_matches(m);
+
+    // The name is still a pattern, and `::` still filters by kind.
+    m = match_names(t, "facility>>.*>length");
+    REQUIRE(m.count == 2);
+    free_name_matches(m);
+
+    m = match_names(t, "facility>>Sextupole::.*>length");
+    REQUIRE(m.count == 1);
+    REQUIRE(val_eq(t, m.nodes[0], "0.7"));
+    free_name_matches(m);
+
+    delete_tree(t);
+}
+
+TEST_CASE("a bare line reference is matched only through its beamline",
+          "[matching]") {
+    // `- q1` names the element without holding any parameter of its own, but it
+    // can be given them, so it is an element of myline like any other. Named
+    // without saying which line it sits in, though, `q1` is the definition it
+    // points at -- otherwise a set before expansion could not target the
+    // definition alone (lattice-construction.md, s:expand.lat).
+    YAMLTreeHandle t = parse_string(
+        "PALS:\n"
+        "  facility:\n"
+        "    - q1:\n"
+        "        kind: Quadrupole\n"
+        "        length: 0.1\n"
+        "    - myline:\n"
+        "        kind: BeamLine\n"
+        "        line:\n"
+        "          - q1\n");
+
+    struct name_matches m = match_names(t, "myline>>q1");
+    REQUIRE(m.count == 1);
+    REQUIRE(val_eq(t, m.nodes[0], "q1"));  // still the bare reference scalar
+    free_name_matches(m);
+
+    // Unqualified, the reference is passed over, and nothing else here sits in
+    // a line -- the definition is reached by naming the facility node instead.
+    m = match_names(t, "q1>length");
+    REQUIRE(m.count == 0);
+    free_name_matches(m);
+
+    m = match_names(t, "facility>>q1>length");
+    REQUIRE(m.count == 1);
+    REQUIRE(val_eq(t, m.nodes[0], "0.1"));
+    free_name_matches(m);
+
+    delete_tree(t);
+}
+
+TEST_CASE("`facility` is a keyword where a branch name goes, not a pattern",
+          "[matching]") {
+    YAMLTreeHandle t = parse_string(FACILITY_YAML);
+
+    // A branch pattern wide enough to spell `facility` still means branches
+    // only: it reaches the `q1` in myline and nothing in the facility list.
+    struct name_matches m = match_names(t, ".*>>q1>length");
+    REQUIRE(m.count == 1);
+    REQUIRE(val_eq(t, m.nodes[0], "0.9"));
+    free_name_matches(m);
+
+    // A lattice qualifier cannot apply: a definition belongs to no lattice
+    // until a lattice is expanded around it.
+    m = match_names(t, "mylat>>>facility>>q1>length");
+    REQUIRE(m.count == 0);
+    free_name_matches(m);
+
+    delete_tree(t);
+}
+
 TEST_CASE("`>>>` selects among lattices with the same element name",
           "[matching]") {
     YAMLTreeHandle t = parse_string(MATCH_YAML);

--- a/tests/test_sets.cpp
+++ b/tests/test_sets.cpp
@@ -174,6 +174,168 @@ TEST_CASE("a set only reaches elements defined before it",
     free_all(lat);
 }
 
+namespace {
+
+// The example of lattice-elements.md (element name matching), as a whole file:
+// `q1` defined as a facility entry, a second `q1` written inside `myline`, and a
+// branch inheriting myline so expansion makes a third. `body` is the facility
+// entries that follow, which is where each test puts its sets.
+std::string facility_qualifier_file(const std::string& body) {
+    return "PALS:\n"
+           "  facility:\n"
+           "    - q1:\n"
+           "        kind: Quadrupole\n"
+           "        length: 0.1\n"
+           "    - myline:\n"
+           "        kind: BeamLine\n"
+           "        line:\n" +
+           std::string(BEGIN_ENTRY) +
+           "          - q1:\n"
+           "              kind: Quadrupole\n"
+           "              length: 0.9\n"
+           "    - mylat:\n"
+           "        kind: Lattice\n"
+           "        branches:\n"
+           "          - mybranch:\n"
+           "              inherit: myline\n"
+           "    - use: \"mylat\"\n" +
+           body;
+}
+
+}  // namespace
+
+TEST_CASE("a set on a bare line reference gives it values of its own",
+          "[expr][lattices][set]") {
+    // `- q1` and `- q1: {length: 0.6}` are the same line entry, the second with
+    // room for values the definition does not give it. A set naming the first
+    // through its beamline writes it, so the two files expand alike.
+    const char* DEF_AND_LINE =
+        "PALS:\n"
+        "  facility:\n"
+        "    - q1:\n"
+        "        kind: Quadrupole\n"
+        "        length: 0.1\n"
+        "    - myline:\n"
+        "        kind: BeamLine\n"
+        "        line:\n";
+    const char* TAIL =
+        "    - mylat:\n"
+        "        kind: Lattice\n"
+        "        branches:\n"
+        "          - mybranch:\n"
+        "              inherit: myline\n"
+        "    - use: \"mylat\"\n";
+
+    const std::string with_set = DEF_AND_LINE + std::string(BEGIN_ENTRY) +
+                                 "          - q1\n" + TAIL +
+                                 "    - sets:\n"
+                                 "        - myline>>q1>length: 0.6\n";
+    const std::string written_out = DEF_AND_LINE + std::string(BEGIN_ENTRY) +
+                                    "          - q1:\n"
+                                    "              length: 0.6\n" +
+                                    TAIL;
+
+    struct lattices a = expand_PALS_string(with_set.c_str(), nullptr);
+    struct lattices b = expand_PALS_string(written_out.c_str(), nullptr);
+    REQUIRE(joined(a) == "");
+    REQUIRE(joined(b) == "");
+
+    REQUIRE(close(one_param(a.full_expanded, "q1", nullptr, "length"), 0.6));
+    REQUIRE(close(one_param(b.full_expanded, "q1", nullptr, "length"), 0.6));
+
+    // The definition the reference points at is not what was named, so it keeps
+    // the length it was given.
+    struct param_value v =
+        get_lattice_parameter_value(a.full_expanded, a.adjunct,
+                                    "facility>>q1>length");
+    REQUIRE(v.kind == PARAM_VALUE_NUMBER);
+    REQUIRE(close(v.number, 0.1));
+
+    free_all(a);
+    free_all(b);
+}
+
+TEST_CASE("an unqualified set targets the definition, not the references to it",
+          "[expr][lattices][set]") {
+    // s:expand.lat: without expand_lattice a set "targets the single q1
+    // definition", and every use of it follows along. If the bare `- q1` in the
+    // line were written too, its 0.6 would override the definition's 0.7 in the
+    // expanded lattice.
+    const std::string doc =
+        "PALS:\n"
+        "  facility:\n"
+        "    - q1:\n"
+        "        kind: Quadrupole\n"
+        "        length: 0.1\n"
+        "    - myline:\n"
+        "        kind: BeamLine\n"
+        "        line:\n" +
+        std::string(BEGIN_ENTRY) +
+        "          - q1\n"
+        "    - mylat:\n"
+        "        kind: Lattice\n"
+        "        branches:\n"
+        "          - mybranch:\n"
+        "              inherit: myline\n"
+        "    - use: \"mylat\"\n"
+        "    - sets:\n"
+        "        - q1>length: 0.7\n";
+
+    struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
+    REQUIRE(joined(lat) == "");
+    REQUIRE(close(one_param(lat.full_expanded, "q1", nullptr, "length"), 0.7));
+
+    free_all(lat);
+}
+
+TEST_CASE("a set qualified with `facility>>` writes only the definition",
+          "[expr][lattices][set]") {
+    // lattice-elements.md: `facility>>q1` names the definition of q1 outside of
+    // myline and mybranch. Before expansion it is the one thing a set can name
+    // that the plain `q1` -- which reaches the copy inside myline -- does not.
+    const std::string doc =
+        facility_qualifier_file("    - sets:\n"
+                                "        - facility>>q1>length: 0.4\n");
+
+    struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
+    REQUIRE(joined(lat) == "");
+
+    struct param_value v =
+        get_lattice_parameter_value(lat.full_expanded, lat.adjunct,
+                                    "facility>>q1>length");
+    REQUIRE(v.kind == PARAM_VALUE_NUMBER);
+    REQUIRE(close(v.number, 0.4));
+
+    // The q1 inside myline, and so the copy expansion made from it, is untouched.
+    REQUIRE(close(one_param(lat.full_expanded, "q1", nullptr, "length"), 0.9));
+
+    free_all(lat);
+}
+
+TEST_CASE("a `facility>>` set after expand_lattice still writes the definition",
+          "[expr][lattices][set]") {
+    // A post-expansion set otherwise acts on the expanded lattice, and the
+    // definitions sit outside it -- naming them is what the qualifier is for.
+    const std::string doc =
+        facility_qualifier_file("    - expand_lattice\n"
+                                "    - sets:\n"
+                                "        - facility>>q1>length: 0.4\n"
+                                "        - mybranch>>q1>length: 0.5\n");
+
+    struct lattices lat = expand_PALS_string(doc.c_str(), nullptr);
+    REQUIRE(joined(lat) == "");
+
+    struct param_value v =
+        get_lattice_parameter_value(lat.full_expanded, lat.adjunct,
+                                    "facility>>q1>length");
+    REQUIRE(v.kind == PARAM_VALUE_NUMBER);
+    REQUIRE(close(v.number, 0.4));
+
+    REQUIRE(close(one_param(lat.full_expanded, "q1", nullptr, "length"), 0.5));
+
+    free_all(lat);
+}
+
 TEST_CASE("a set creates a parameter that defaults to zero",
           "[expr][lattices][set]") {
     // s:lattice.expand: an unwritten parameter of a known element reads as zero,


### PR DESCRIPTION
## Rename

The repo is now `PALSParserCpp`, so nothing keeps the old name:

- CMake project and shared-library target are both `PALSParserCpp` — the artifact is `libPALSParserCpp.dylib`
- `src/yaml_c_wrapper.{h,cpp}` → `src/PALSParserCpp.{h,cpp}`, include guard `PALS_PARSER_CPP_H`
- All `#include`s, the Doxyfile `INPUT` and `PROJECT_NAME`, the Sphinx/Breathe project keys, and the doc prose and URLs follow

Nobody depends on the library yet, so no compatibility alias is left behind. A case-insensitive sweep for the old names comes back empty.

## `facility` as a reserved branch name

`facility>>` selects the element definitions the `facility` list holds directly rather than the elements of any branch. It is matched as a literal word, not a pattern, so a branch pattern wide enough to cover it (`.*`) still means branches only. It reaches neither definitions written inline inside a beamline — those belong to that beamline — nor anything at all when a `{lattice}` qualifier is also given, since a definition belongs to no lattice.

Because that qualifier would otherwise be ambiguous, an element, BeamLine or Lattice named `facility` is now reported as a problem. One problem however many constructs are misnamed: the name, the reason and the fix are identical for all of them, so the count is what the message carries.

## Settable bare line references

A line entry written as a bare reference (`- q1`) is now matchable, through a `{branch}` qualifier only — unqualified, `q1` is still the definition it points at, and a pre-expansion `set` targets that single definition with every reference following along.

A `set` naming a bare reference rewrites the entry into its longhand form (`- q1: {...}`) to hold the value rather than refusing the write; `- q1` and `- q1:` are the same entry, the second just has room for values of its own.

## Testing

Clean configure and build from scratch; `ctest` passes 265/265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)