### PR TITLE
Point at PALSParserJ, the Julia package's new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To see the console output, in the build directory, run
 
 ## Extensions
 
-The [PALSJulia.jl](https://github.com/pals-project/PALSJulia.jl) package is an extension of `PALSParserCpp` to:
+The [PALSParserJ.jl](https://github.com/pals-project/PALSParserJ.jl) package is an extension of `PALSParserCpp` to:
 
 - Provide a Julia interface for `PALSParserCpp` C++ functions.
 - Provide a translator from `PALS` files to [`Bmad`](https://github.com/bmad-sim/bmad-ecosystem) lattice files.

--- a/docs/src/guide/usage.md
+++ b/docs/src/guide/usage.md
@@ -224,7 +224,7 @@ The `examples/` directory contains runnable programs:
 
 ## Extensions
 
-[PALSJulia](https://github.com/pals-project/PALSJulia) extends PALSParserCpp with a
+[PALSParserJ](https://github.com/pals-project/PALSParserJ.jl) extends PALSParserCpp with a
 Julia interface to the C API and translators from PALS to
 [Bmad](https://github.com/bmad-sim/bmad-ecosystem) and
 [SciBmad](https://github.com/bmad-sim/SciBmad.jl) lattice files.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@ YAML lattice files with [rapidyaml](https://github.com/biojppm/rapidyaml),
 expands a lattice according to the PALS specification, evaluates the
 mathematical expressions in the expanded lattice, and exposes everything through
 a C API (`PALSParserCpp.h`) that other languages — such as
-[PALSJulia](https://github.com/pals-project/PALSJulia) — wrap.
+[PALSParserJ](https://github.com/pals-project/PALSParserJ.jl) — wrap.
 
 ```{toctree}
 :hidden:


### PR DESCRIPTION
The Julia package was renamed from PALSJulia to PALSParserJ (repository `PALSParserJ.jl`), so the three links naming it here are stale.

The bare `github.com/pals-project/PALSJulia` URL two of them used never existed — the repository has been `.jl`-suffixed all along — so they now point at `PALSParserJ.jl`.

Companion to pals-project/PALSParserJ.jl#73.

🤖 Generated with [Claude Code](https://claude.com/claude-code)